### PR TITLE
이미 로그인된 경우 /login 리다이렉트 확인 (이슈 종료)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,10 @@
 # trip-planner Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-03-23
+Auto-generated from all feature plans. Last updated: 2026-03-24
 
 ## Active Technologies
+- TypeScript + Node.js 18+ + Next.js 14 (App Router), jose (JWT) (002-login-redirect)
+- N/A (쿠키 기반 인증 토큰) (002-login-redirect)
 
 - TypeScript + Node.js 18+ + Next.js 14+ (App Router), Tailwind CSS, react-leaflet + Leaflet.js, jose (JWT) (001-trip-planner-mvp)
 
@@ -26,6 +28,7 @@ npm run dev    # 로컬 개발 서버 (http://localhost:3000)
 TypeScript + Node.js 18+: Follow standard conventions
 
 ## Recent Changes
+- 002-login-redirect: Added TypeScript + Node.js 18+ + Next.js 14 (App Router), jose (JWT)
 
 - 001-trip-planner-mvp: Added TypeScript + Node.js 18+ + Next.js 14+ (App Router), Tailwind CSS, react-leaflet + Leaflet.js, jose (JWT)
 

--- a/specs/002-login-redirect/checklists/requirements.md
+++ b/specs/002-login-redirect/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: 이미 로그인된 경우 /login 리다이렉트
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- 기존 코드(`app/login/page.tsx`)에 이미 리다이렉트 로직이 구현되어 있음을 확인함
+- 구현 완료 상태이며 이슈 종료 처리 필요

--- a/specs/002-login-redirect/plan.md
+++ b/specs/002-login-redirect/plan.md
@@ -1,0 +1,51 @@
+# Implementation Plan: 이미 로그인된 경우 /login 리다이렉트
+
+**Branch**: `002-login-redirect` | **Date**: 2026-03-24 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/002-login-redirect/spec.md`
+
+## Summary
+
+로그인 상태에서 `/login` 접근 시 `/research`로 자동 리다이렉트하는 기능. 코드 분석 결과, `app/login/page.tsx`에 이미 구현되어 있음을 확인. 별도 구현 없이 이슈 확인 및 종료 처리.
+
+## Technical Context
+
+**Language/Version**: TypeScript + Node.js 18+
+**Primary Dependencies**: Next.js 14 (App Router), jose (JWT)
+**Storage**: N/A (쿠키 기반 인증 토큰)
+**Testing**: 수동 검증 (브라우저에서 직접 확인)
+**Target Platform**: 웹 (Next.js SSR)
+**Project Type**: web-service
+**Performance Goals**: N/A (단순 리다이렉트)
+**Constraints**: 로그인 폼 렌더링 전 서버 사이드에서 리다이렉트 처리
+**Scale/Scope**: 단일 파일 수정 범위
+
+## Constitution Check
+
+constitution.md가 템플릿 상태로 프로젝트 원칙이 정의되지 않음. 일반 웹 개발 관행을 따름.
+
+- 기존 구현 확인: `app/login/page.tsx`에 이미 리다이렉트 코드 존재
+- 보안: 서버 사이드에서 JWT 검증 후 리다이렉트 (적절한 구현)
+- 게이트 위반 없음
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-login-redirect/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 output (speckit.tasks 명령어 생성)
+```
+
+### Source Code (repository root)
+
+```text
+app/
+└── login/
+    └── page.tsx         # 이미 리다이렉트 로직 구현됨 (확인만 필요)
+```
+
+**Structure Decision**: 단일 파일 확인. 데이터 모델 변경 없음, API 계약 없음.

--- a/specs/002-login-redirect/research.md
+++ b/specs/002-login-redirect/research.md
@@ -1,0 +1,35 @@
+# Research: 이미 로그인된 경우 /login 리다이렉트
+
+**Date**: 2026-03-24
+
+## 기존 구현 분석
+
+### 결정: 현재 구현이 요구사항을 만족함
+
+**코드 위치**: `app/login/page.tsx` (서버 컴포넌트)
+
+```typescript
+export default async function LoginPage() {
+  // T034: 이미 로그인된 경우 /research 로 리다이렉트
+  const token = cookies().get('auth')?.value
+  if (token && (await verifyToken(token))) {
+    redirect('/research')
+  }
+
+  return <LoginForm />
+}
+```
+
+**근거**:
+- `cookies()`로 `auth` 쿠키를 서버에서 읽음
+- `verifyToken()`으로 JWT 유효성 검사 (만료/위변조 모두 처리)
+- 유효하면 `redirect('/research')` 호출 - 페이지 렌더링 전에 실행됨
+- 유효하지 않으면 `LoginForm` 렌더링
+
+**대안 검토**:
+- **middleware.ts에서 처리**: 더 일찍 처리되지만 현재 구현도 서버 사이드에서 처리되므로 차이 없음. 미들웨어에 추가하면 복잡도가 늘어남.
+- **클라이언트 사이드 처리**: 로그인 폼이 잠깐 보일 수 있으므로 부적절.
+
+## 결론
+
+별도 구현 불필요. 이슈는 기존에 이미 구현된 상태이며, GitHub 이슈를 닫는 PR만 필요.

--- a/specs/002-login-redirect/spec.md
+++ b/specs/002-login-redirect/spec.md
@@ -1,0 +1,44 @@
+# Feature Specification: 이미 로그인된 경우 /login 리다이렉트
+
+**Feature Branch**: `002-login-redirect`
+**Created**: 2026-03-24
+**Status**: Draft
+**Input**: User description: "이미 로그인된 경우 /login 리다이렉트"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 로그인 상태에서 /login 재접근 (Priority: P1)
+
+이미 로그인된 사용자가 `/login` 경로에 직접 접근하면, 로그인 페이지 대신 메인 앱 화면(`/research`)으로 자동으로 이동된다.
+
+**Why this priority**: 로그인 페이지를 다시 보여주는 것은 사용자 혼란을 야기하며, 이미 인증된 세션이 있는 사용자를 앱의 핵심 기능으로 빠르게 안내해야 한다.
+
+**Independent Test**: 로그인 후 브라우저 주소창에 `/login`을 직접 입력했을 때 `/research`로 이동하는지 확인.
+
+**Acceptance Scenarios**:
+
+1. **Given** 사용자가 유효한 인증 쿠키를 가지고 있을 때, **When** `/login` 경로에 접근하면, **Then** `/research`로 자동 리다이렉트된다.
+2. **Given** 사용자가 로그아웃 상태일 때, **When** `/login` 경로에 접근하면, **Then** 로그인 페이지가 정상적으로 표시된다.
+
+---
+
+### Edge Cases
+
+- 인증 쿠키가 만료된 경우: 로그인 페이지를 정상적으로 표시한다.
+- 인증 쿠키가 위변조된 경우: 로그인 페이지를 정상적으로 표시한다.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 유효한 인증 세션이 있는 사용자가 `/login`에 접근하면 시스템은 `/research`로 자동 리다이렉트해야 한다.
+- **FR-002**: 인증되지 않은 사용자(세션 없음, 만료, 위변조)는 로그인 페이지를 정상적으로 볼 수 있어야 한다.
+- **FR-003**: 리다이렉트는 로그인 폼이 화면에 표시되기 전에 발생해야 한다.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 로그인된 사용자가 `/login`에 접근 시 100% `/research`로 리다이렉트된다.
+- **SC-002**: 미인증 사용자의 `/login` 접근 시 로그인 페이지가 정상 표시된다.
+- **SC-003**: 리다이렉트는 페이지 렌더링 없이 즉시 발생한다 (로그인 폼이 잠시라도 표시되지 않음).

--- a/specs/002-login-redirect/tasks.md
+++ b/specs/002-login-redirect/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: 이미 로그인된 경우 /login 리다이렉트
+
+**Input**: Design documents from `/specs/002-login-redirect/`
+**Prerequisites**: plan.md, spec.md, research.md
+
+**참고**: research.md 분석 결과, `app/login/page.tsx`에 이미 구현 완료되어 있음. 추가 구현 불필요.
+
+## Format: `[ID] [P?] [Story] Description`
+
+---
+
+## Phase 1: 기존 구현 확인
+
+**Purpose**: 이미 구현된 코드가 요구사항을 올바르게 충족하는지 검증
+
+- [x] T001 [US1] `app/login/page.tsx`에서 리다이렉트 로직 동작 확인 - 유효 토큰 시 `/research` 리다이렉트, 미인증 시 로그인 폼 표시
+- [x] T002 [US1] `lib/auth.ts`의 `verifyToken`이 만료/위변조 토큰에 대해 `false` 반환하는지 확인
+
+**Checkpoint**: 기존 구현이 FR-001, FR-002, FR-003을 모두 충족함을 확인
+
+---
+
+## Phase 2: 이슈 종료
+
+**Purpose**: GitHub 이슈 #10 닫기
+
+- [ ] T003 spec, plan, research, tasks 파일을 git에 커밋
+- [ ] T004 PR 생성하여 issue #10 close
+
+---
+
+## Dependencies & Execution Order
+
+- T001, T002: 병렬 실행 가능 (각기 다른 파일 검증)
+- T003: T001, T002 완료 후
+- T004: T003 완료 후
+
+---
+
+## Implementation Strategy
+
+구현 불필요. 기존 코드 확인 후 PR 생성으로 이슈를 닫는다.


### PR DESCRIPTION
## 변경 이유
이슈 #10에서 보고된 기능이 이미 `app/login/page.tsx`에 구현되어 있음을 확인. 이슈를 공식적으로 종료하기 위한 PR.

## 변경 범위
- 소스 코드 변경 없음
- `specs/002-login-redirect/` 디렉터리에 분석 문서(spec, plan, research, tasks) 추가
- `CLAUDE.md` Active Technologies 항목 업데이트

## 검증
- `app/login/page.tsx`: 유효 JWT 쿠키 존재 시 서버 사이드에서 `/research`로 `redirect()` 실행 확인
- `lib/auth.ts`: `verifyToken()`이 만료/위변조 토큰에 대해 `false` 반환 확인
- `npm run build` 성공

## 남은 작업 / 리스크
없음

Closes #10