### PR TITLE
fix: 로그인 상태에서 /login 접속 시 /research로 리다이렉트

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,14 +1,5 @@
-import { cookies } from 'next/headers'
-import { redirect } from 'next/navigation'
-import { verifyToken } from '@/lib/auth'
 import LoginForm from './LoginForm'
 
-export default async function LoginPage() {
-  // T034: 이미 로그인된 경우 /research 로 리다이렉트
-  const token = cookies().get('auth')?.value
-  if (token && (await verifyToken(token))) {
-    redirect('/research')
-  }
-
+export default function LoginPage() {
   return <LoginForm />
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,12 +10,21 @@ export async function middleware(request: NextRequest) {
 
   const isProtectedPage = PROTECTED_PAGES.some(p => pathname.startsWith(p))
   const isProtectedApi = PROTECTED_API.some(p => pathname.startsWith(p))
+  const isLoginPage = pathname === '/login'
+
+  const token = request.cookies.get('auth')?.value
+  const isAuthenticated = token ? await verifyToken(token) : false
+
+  if (isLoginPage) {
+    if (isAuthenticated) {
+      return NextResponse.redirect(new URL('/research', request.url))
+    }
+    return NextResponse.next()
+  }
 
   if (!isProtectedPage && !isProtectedApi) return NextResponse.next()
 
-  const token = request.cookies.get('auth')?.value
-
-  if (!token || !(await verifyToken(token))) {
+  if (!isAuthenticated) {
     if (isProtectedApi) {
       return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
     }
@@ -27,6 +36,7 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
+    '/login',
     '/research/:path*',
     '/schedule/:path*',
     '/items/:path*',


### PR DESCRIPTION
## 변경 이유
로그인 상태에서 `/login`에 접속해도 로그인 페이지가 그대로 표시되는 문제 수정.

## 변경 범위
- `middleware.ts`: `/login` 경로를 matcher에 추가하고, 인증된 사용자 접근 시 `/research`로 리다이렉트
- `app/login/page.tsx`: middleware로 이관되어 중복된 리다이렉트 처리 제거

## 검증
- `npm run build` 통과

## 남은 작업 / 리스크
없음

Closes #10