### PR TITLE
feat: 항목 카드에서 링크 바로 열기

### DIFF
--- a/components/Items/ItemCard.tsx
+++ b/components/Items/ItemCard.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useState, useRef, useEffect } from 'react'
 import Link from 'next/link'
 import type { TripItem, Category } from '@/types'
 import StatusBadge from '@/components/UI/StatusBadge'
@@ -10,6 +13,72 @@ const categoryColors: Record<Category, string> = {
   관광: '#6EE7B7',
   쇼핑: '#C4B5FD',
   기타: '#FCD34D',
+}
+
+function LinkButton({ links }: { links: TripItem['links'] }) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [open])
+
+  if (links.length === 0) return null
+
+  if (links.length === 1) {
+    return (
+      <a
+        href={links[0].url}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={e => e.stopPropagation()}
+        className="flex-shrink-0 p-1 text-gray-400 hover:text-blue-500 transition-colors"
+        title={links[0].label || '링크 열기'}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+          <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+          <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+        </svg>
+      </a>
+    )
+  }
+
+  return (
+    <div ref={ref} className="relative flex-shrink-0">
+      <button
+        onClick={e => { e.preventDefault(); e.stopPropagation(); setOpen(v => !v) }}
+        className="p-1 text-gray-400 hover:text-blue-500 transition-colors flex items-center gap-0.5"
+        title="링크 목록"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+          <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+          <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+        </svg>
+        <span className="text-xs">{links.length}</span>
+      </button>
+      {open && (
+        <div className="absolute right-0 top-7 z-10 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-36">
+          {links.map((link, i) => (
+            <a
+              key={i}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={e => { e.stopPropagation(); setOpen(false) }}
+              className="block px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50 truncate max-w-48"
+            >
+              {link.label || link.url}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  )
 }
 
 export default function ItemCard({ item }: { item: TripItem }) {
@@ -27,6 +96,7 @@ export default function ItemCard({ item }: { item: TripItem }) {
           <div className="flex items-center gap-1 flex-shrink-0 flex-wrap justify-end">
             <StatusBadge status={item.status} />
             {item.priority && <PriorityBadge priority={item.priority} />}
+            <LinkButton links={item.links} />
           </div>
         </div>
 


### PR DESCRIPTION
## 변경 이유
링크 확인을 위해 편집 페이지에 진입해야 하는 불편함 해소.

## 변경 범위
- `components/Items/ItemCard.tsx`: `'use client'` 전환, `LinkButton` 컴포넌트 추가
  - 링크 1개: 외부 링크 아이콘 클릭 시 새 탭으로 바로 열기
  - 링크 2개 이상: 아이콘+개수 버튼 클릭 시 드롭다운으로 목록 표시

## 검증
- `npm run build` 통과

## 남은 작업 / 리스크
없음

Closes #15