### PR TITLE
feat: 카테고리 세분화 (공연/스포츠/카페 분리)

### DIFF
--- a/app/api/items/[id]/route.ts
+++ b/app/api/items/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { readItems, writeItems } from '@/lib/data'
 import type { Category, Status, Priority } from '@/types'
 
-const CATEGORIES: Category[] = ['교통', '숙소', '식당', '관광', '쇼핑', '기타']
+const CATEGORIES: Category[] = ['교통', '숙소', '식당', '카페', '관광', '공연', '스포츠', '쇼핑', '기타']
 const STATUSES: Status[] = ['검토중', '보류', '대기중', '확정', '탈락']
 const PRIORITIES: Priority[] = ['반드시', '들를만해', '시간 남으면']
 

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -3,7 +3,7 @@ import { readItems, writeItems } from '@/lib/data'
 import { v4 as uuidv4 } from 'uuid'
 import type { TripItem, Category, Status, Priority, Link } from '@/types'
 
-const CATEGORIES: Category[] = ['교통', '숙소', '식당', '관광', '쇼핑', '기타']
+const CATEGORIES: Category[] = ['교통', '숙소', '식당', '카페', '관광', '공연', '스포츠', '쇼핑', '기타']
 const STATUSES: Status[] = ['검토중', '보류', '대기중', '확정', '탈락']
 const PRIORITIES: Priority[] = ['반드시', '들를만해', '시간 남으면']
 

--- a/components/Items/ItemCard.tsx
+++ b/components/Items/ItemCard.tsx
@@ -7,7 +7,10 @@ const categoryColors: Record<Category, string> = {
   교통: '#94A3B8',
   숙소: '#7DD3FC',
   식당: '#FB923C',
+  카페: '#FDBA74',
   관광: '#6EE7B7',
+  공연: '#F9A8D4',
+  스포츠: '#86EFAC',
   쇼핑: '#C4B5FD',
   기타: '#FCD34D',
 }

--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import type { TripItem, Category, Status, Priority, Link as TripLink } from '@/types'
 
-const CATEGORIES: Category[] = ['교통', '숙소', '식당', '관광', '쇼핑', '기타']
+const CATEGORIES: Category[] = ['교통', '숙소', '식당', '카페', '관광', '공연', '스포츠', '쇼핑', '기타']
 
 const STATUS_OPTIONS: { value: Status; label: string }[] = [
   { value: '검토중', label: '검토중 — 아직 결정 안 됨' },

--- a/components/Items/ItemList.tsx
+++ b/components/Items/ItemList.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from 'react'
 import type { TripItem, Category, Status, Priority } from '@/types'
 import ItemCard from './ItemCard'
 
-const CATEGORIES: Category[] = ['교통', '숙소', '식당', '관광', '쇼핑', '기타']
+const CATEGORIES: Category[] = ['교통', '숙소', '식당', '카페', '관광', '공연', '스포츠', '쇼핑', '기타']
 const STATUSES: Status[] = ['검토중', '보류', '대기중', '확정', '탈락']
 const PRIORITIES: Priority[] = ['반드시', '들를만해', '시간 남으면']
 

--- a/components/Map/ResearchMap.tsx
+++ b/components/Map/ResearchMap.tsx
@@ -10,7 +10,10 @@ const categoryColors: Record<Category, string> = {
   교통: '#94A3B8',
   숙소: '#7DD3FC',
   식당: '#FB923C',
+  카페: '#FDBA74',
   관광: '#6EE7B7',
+  공연: '#F9A8D4',
+  스포츠: '#86EFAC',
   쇼핑: '#C4B5FD',
   기타: '#FCD34D',
 }

--- a/data/items.json
+++ b/data/items.json
@@ -47,7 +47,7 @@
     {
       "id": "a1b2c3d4-0001-4000-8000-100000000001",
       "name": "Marquis Theatre",
-      "category": "관광",
+      "category": "공연",
       "status": "검토중",
       "priority": "들를만해",
       "address": "1535 Broadway, New York, NY 10036",
@@ -61,7 +61,7 @@
     {
       "id": "a1b2c3d4-0002-4000-8000-100000000002",
       "name": "마제스틱 극장 (Majestic Theatre)",
-      "category": "관광",
+      "category": "공연",
       "status": "검토중",
       "priority": "들를만해",
       "address": "245 W 44th St, New York, NY 10036",
@@ -75,7 +75,7 @@
     {
       "id": "a1b2c3d4-0003-4000-8000-100000000003",
       "name": "Broadway Theatre",
-      "category": "관광",
+      "category": "공연",
       "status": "검토중",
       "priority": "들를만해",
       "address": "1681 Broadway, New York, NY 10019",
@@ -89,7 +89,7 @@
     {
       "id": "a1b2c3d4-0004-4000-8000-100000000004",
       "name": "Chicago The Musical (CIBC Theatre)",
-      "category": "관광",
+      "category": "공연",
       "status": "검토중",
       "priority": "들를만해",
       "address": "18 W 45th St, New York, NY 10036",
@@ -103,7 +103,7 @@
     {
       "id": "a1b2c3d4-0005-4000-8000-100000000005",
       "name": "Gershwin Theatre",
-      "category": "관광",
+      "category": "공연",
       "status": "검토중",
       "priority": "들를만해",
       "address": "222 W 51st St, New York, NY 10019",
@@ -117,7 +117,7 @@
     {
       "id": "a1b2c3d4-0006-4000-8000-100000000006",
       "name": "Aladdin the Musical (New Amsterdam Theatre)",
-      "category": "관광",
+      "category": "공연",
       "status": "검토중",
       "priority": "들를만해",
       "address": "214 W 42nd St, New York, NY 10036",
@@ -131,7 +131,7 @@
     {
       "id": "a1b2c3d4-0007-4000-8000-100000000007",
       "name": "더 라이온 킹 (Minskoff Theatre)",
-      "category": "관광",
+      "category": "공연",
       "status": "검토중",
       "priority": "반드시",
       "address": "200 W 45th St, New York, NY 10036",
@@ -257,7 +257,7 @@
     {
       "id": "a1b2c3d4-0016-4000-8000-100000000016",
       "name": "양키 스타디움",
-      "category": "관광",
+      "category": "스포츠",
       "status": "검토중",
       "priority": "시간 남으면",
       "address": "1 E 161st St, Bronx, NY 10451",
@@ -285,7 +285,7 @@
     {
       "id": "a1b2c3d4-0018-4000-8000-100000000018",
       "name": "메츠 플라자 (Citi Field)",
-      "category": "관광",
+      "category": "스포츠",
       "status": "검토중",
       "priority": "시간 남으면",
       "address": "41 Seaver Way, Flushing, NY 11368",
@@ -341,7 +341,7 @@
     {
       "id": "a1b2c3d4-0022-4000-8000-100000000022",
       "name": "질레트 스타디움",
-      "category": "관광",
+      "category": "스포츠",
       "status": "검토중",
       "priority": "시간 남으면",
       "address": "1 Patriot Place, Foxborough, MA 02035",

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,4 +1,4 @@
-export type Category = '교통' | '숙소' | '식당' | '관광' | '쇼핑' | '기타';
+export type Category = '교통' | '숙소' | '식당' | '카페' | '관광' | '공연' | '스포츠' | '쇼핑' | '기타';
 export type Status   = '검토중' | '보류' | '대기중' | '확정' | '탈락';
 export type Priority = '반드시' | '들를만해' | '시간 남으면';
 


### PR DESCRIPTION
## 변경 이유
'관광' 카테고리에 명소, 공연, 스포츠 등 성격이 다른 항목이 혼재하고, 이미 데이터에 '카페'가 사용 중이나 타입에 미정의된 상태 개선.

## 변경 범위
- `types/index.ts`: Category 타입에 카페, 공연, 스포츠 추가 (6 → 9개)
- `data/items.json`: 기존 데이터 마이그레이션
  - 브로드웨이 공연 7개 → '공연'
  - 스포츠 경기장 3개 → '스포츠'
  - 나머지 관광 항목은 유지
- `components/Items/ItemForm.tsx`, `ItemList.tsx`, `ItemCard.tsx`: 새 카테고리 목록 및 색상 추가
- `components/Map/ResearchMap.tsx`: 지도 마커 색상 추가
- `app/api/items/route.ts`, `[id]/route.ts`: 유효성 검사 목록 업데이트

## 검증
- `npm run build` 통과
- 카테고리 분포: 식당 26, 관광 15, 쇼핑 13, 공연 7, 카페 6, 스포츠 3, 교통 2, 숙소 2

## 남은 작업 / 리스크
없음

Closes #5