### PR TITLE
feat: 상세보기/편집 UX 분리

### DIFF
--- a/app/items/[id]/edit/page.tsx
+++ b/app/items/[id]/edit/page.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { readItems } from '@/lib/data'
+import Navigation from '@/components/Layout/Navigation'
+import ItemForm from '@/components/Items/ItemForm'
+
+export default async function EditItemPage({ params }: { params: { id: string } }) {
+  const items = await readItems()
+  const item = items.find(i => i.id === params.id)
+
+  if (!item) notFound()
+
+  return (
+    <div className="md:pl-44">
+      <div className="max-w-lg mx-auto px-4 py-6">
+        <div className="flex items-center gap-3 mb-6">
+          <Link href={`/items/${item.id}`} className="text-sm text-gray-400 hover:text-gray-600 transition-colors">
+            ← 상세보기
+          </Link>
+          <h1 className="text-xl font-bold text-gray-900">항목 수정</h1>
+        </div>
+        <ItemForm mode="edit" initialData={item} itemId={item.id} />
+      </div>
+      <Navigation />
+    </div>
+  )
+}

--- a/app/items/[id]/page.tsx
+++ b/app/items/[id]/page.tsx
@@ -1,9 +1,11 @@
+import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { readItems } from '@/lib/data'
 import Navigation from '@/components/Layout/Navigation'
-import ItemForm from '@/components/Items/ItemForm'
+import StatusBadge from '@/components/UI/StatusBadge'
+import PriorityBadge from '@/components/UI/PriorityBadge'
 
-export default async function EditItemPage({ params }: { params: { id: string } }) {
+export default async function ItemDetailPage({ params }: { params: { id: string } }) {
   const items = await readItems()
   const item = items.find(i => i.id === params.id)
 
@@ -11,11 +13,108 @@ export default async function EditItemPage({ params }: { params: { id: string } 
 
   return (
     <div className="md:pl-44">
-      <div className="max-w-lg mx-auto px-4 py-6">
-        <h1 className="text-xl font-bold text-gray-900 mb-6">항목 수정</h1>
-        <ItemForm mode="edit" initialData={item} itemId={item.id} />
+      <div className="max-w-lg mx-auto px-4 py-6 pb-28 md:pb-6">
+        {/* 헤더 */}
+        <div className="flex items-center justify-between mb-6">
+          <Link href="/research" className="text-sm text-gray-400 hover:text-gray-600 transition-colors">
+            ← 목록
+          </Link>
+          <Link
+            href={`/items/${item.id}/edit`}
+            className="px-3 py-1.5 text-sm font-medium bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
+          >
+            편집
+          </Link>
+        </div>
+
+        {/* 이름 + 배지 */}
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">{item.name}</h1>
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-xs font-medium text-gray-500 bg-gray-100 rounded-full px-2.5 py-1">
+              {item.category}
+            </span>
+            <StatusBadge status={item.status} />
+            {item.priority && <PriorityBadge priority={item.priority} />}
+          </div>
+        </div>
+
+        <div className="space-y-5">
+          {/* 일정 & 예산 */}
+          {(item.date || item.time_start || item.budget !== undefined) && (
+            <section className="bg-gray-50 rounded-xl p-4 space-y-1.5">
+              {item.date && (
+                <Row label="날짜" value={item.date} />
+              )}
+              {item.time_start && (
+                <Row label="시작 시간" value={item.time_start} />
+              )}
+              {item.budget !== undefined && (
+                <Row label="예산" value={`$${item.budget.toLocaleString()}`} />
+              )}
+            </section>
+          )}
+
+          {/* 위치 */}
+          {item.address && (
+            <section>
+              <SectionTitle>위치</SectionTitle>
+              <p className="text-sm text-gray-700">{item.address}</p>
+              {item.lat !== undefined && item.lng !== undefined && (
+                <p className="text-xs text-gray-400 mt-1">{item.lat}, {item.lng}</p>
+              )}
+            </section>
+          )}
+
+          {/* 링크 */}
+          {item.links.length > 0 && (
+            <section>
+              <SectionTitle>링크</SectionTitle>
+              <div className="space-y-1.5">
+                {item.links.map((link, i) => (
+                  <a
+                    key={i}
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 transition-colors"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                      <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+                      <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+                    </svg>
+                    {link.label || link.url}
+                  </a>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* 메모 */}
+          {item.memo && (
+            <section>
+              <SectionTitle>메모</SectionTitle>
+              <p className="text-sm text-gray-700 whitespace-pre-wrap">{item.memo}</p>
+            </section>
+          )}
+        </div>
       </div>
       <Navigation />
+    </div>
+  )
+}
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">{children}</h2>
+  )
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-xs text-gray-500">{label}</span>
+      <span className="text-sm font-medium text-gray-900">{value}</span>
     </div>
   )
 }

--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -128,7 +128,11 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
     })
 
     if (res.ok) {
-      router.push('/research')
+      if (mode === 'edit' && itemId) {
+        router.push(`/items/${itemId}`)
+      } else {
+        router.push('/research')
+      }
       router.refresh()
     } else {
       const data = await res.json()


### PR DESCRIPTION
## 변경 이유
카드 클릭 시 바로 편집 폼으로 진입하는 불편함 개선. 상세 내용 확인을 위해 편집 뷰에 진입할 필요 없음.

## 변경 범위
- `app/items/[id]/page.tsx`: 읽기전용 상세보기로 변환 (이름, 카테고리, 상태/우선순위 배지, 일정, 위치, 링크, 메모 표시)
- `app/items/[id]/edit/page.tsx`: 기존 편집 폼 (← 상세보기 뒤로가기 링크 추가)
- `components/Items/ItemForm.tsx`: 수정 저장 성공 후 `/research` 대신 상세보기(`/items/[id]`)로 리다이렉트

## 검증
- `npm run build` 통과

## 남은 작업 / 리스크
- PC 2열 레이아웃은 미구현 (현재 모바일/PC 동일하게 단일 컬럼)

Closes #7