### PR TITLE
feat: 디자인 전면 개선

### DIFF
--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -31,53 +31,60 @@ export default function LoginForm() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-gray-50 to-stone-100 flex items-center justify-center p-4">
       <div className="w-full max-w-sm">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2 text-center">
-          NYC Trip Planner
-        </h1>
-        <p className="text-sm text-gray-400 text-center mb-8">2025년 6월 뉴욕 여행</p>
+        <div className="text-center mb-8">
+          <div className="w-12 h-12 bg-gray-900 rounded-2xl flex items-center justify-center mx-auto mb-4">
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-6 h-6 text-white" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
+            </svg>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">NYC Trip Planner</h1>
+          <p className="text-sm text-gray-400 mt-1">2025년 6월 뉴욕 여행</p>
+        </div>
 
         <form
           onSubmit={handleSubmit}
-          className="bg-white rounded-xl border border-gray-200 p-6 space-y-4"
+          className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 space-y-4"
         >
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1.5">
               아이디
             </label>
             <input
               type="text"
               value={id}
               onChange={e => setId(e.target.value)}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-gray-900 text-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+              className="w-full border border-gray-200 rounded-xl px-3.5 py-2.5 text-gray-900 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent transition-shadow"
               autoComplete="username"
               required
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1.5">
               비밀번호
             </label>
             <input
               type="password"
               value={password}
               onChange={e => setPassword(e.target.value)}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-gray-900 text-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+              className="w-full border border-gray-200 rounded-xl px-3.5 py-2.5 text-gray-900 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent transition-shadow"
               autoComplete="current-password"
               required
             />
           </div>
 
           {error && (
-            <p className="text-red-500 text-sm">{error}</p>
+            <div className="bg-rose-50 border border-rose-200 rounded-lg px-3 py-2">
+              <p className="text-rose-600 text-sm">{error}</p>
+            </div>
           )}
 
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-gray-900 text-white rounded-lg px-4 py-2.5 text-sm font-medium disabled:opacity-50 hover:bg-gray-800 transition-colors"
+            className="w-full bg-gray-900 text-white rounded-xl px-4 py-2.5 text-sm font-semibold disabled:opacity-50 hover:bg-gray-800 active:bg-gray-950 transition-colors mt-2"
           >
             {loading ? '로그인 중...' : '로그인'}
           </button>

--- a/components/Items/ItemCard.tsx
+++ b/components/Items/ItemCard.tsx
@@ -2,11 +2,11 @@
 
 import { useState, useRef, useEffect } from 'react'
 import Link from 'next/link'
-import type { TripItem, Category } from '@/types'
+import type { TripItem } from '@/types'
 import StatusBadge from '@/components/UI/StatusBadge'
 import PriorityBadge from '@/components/UI/PriorityBadge'
 
-const categoryColors: Record<Category, string> = {
+const categoryColors: Record<string, string> = {
   교통: '#94A3B8',
   숙소: '#7DD3FC',
   식당: '#FB923C',
@@ -43,7 +43,7 @@ function LinkButton({ links }: { links: TripItem['links'] }) {
         className="flex-shrink-0 p-1 text-gray-400 hover:text-blue-500 transition-colors"
         title={links[0].label || '링크 열기'}
       >
-        <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+        <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
           <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
           <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
         </svg>
@@ -58,14 +58,14 @@ function LinkButton({ links }: { links: TripItem['links'] }) {
         className="p-1 text-gray-400 hover:text-blue-500 transition-colors flex items-center gap-0.5"
         title="링크 목록"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+        <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
           <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
           <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
         </svg>
         <span className="text-xs">{links.length}</span>
       </button>
       {open && (
-        <div className="absolute right-0 top-7 z-10 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-36">
+        <div className="absolute right-0 top-7 z-10 bg-white border border-gray-200 rounded-xl shadow-lg py-1 min-w-36">
           {links.map((link, i) => (
             <a
               key={i}
@@ -87,14 +87,19 @@ function LinkButton({ links }: { links: TripItem['links'] }) {
 export default function ItemCard({ item }: { item: TripItem }) {
   return (
     <Link href={`/items/${item.id}`}>
-      <div className="bg-white rounded-xl border border-gray-200 p-4 hover:border-gray-300 transition-colors cursor-pointer">
+      <div className="bg-white rounded-2xl border border-gray-100 p-4 hover:border-gray-200 hover:shadow-sm transition-all cursor-pointer">
         <div className="flex items-start justify-between gap-2">
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex items-center gap-2.5 min-w-0">
             <span
-              className="w-2.5 h-2.5 rounded-full flex-shrink-0"
-              style={{ backgroundColor: categoryColors[item.category] }}
+              className="w-3 h-3 rounded-full flex-shrink-0 ring-2 ring-white shadow-sm"
+              style={{ backgroundColor: categoryColors[item.category] ?? '#D1D5DB' }}
             />
-            <span className="font-medium text-gray-900 truncate text-sm">{item.name}</span>
+            <div className="min-w-0">
+              <span className="font-semibold text-gray-900 truncate text-sm block">{item.name}</span>
+              {item.address && (
+                <span className="text-xs text-gray-400 truncate block">{item.address}</span>
+              )}
+            </div>
           </div>
           <div className="flex items-center gap-1 flex-shrink-0 flex-wrap justify-end">
             <StatusBadge status={item.status} />
@@ -104,10 +109,19 @@ export default function ItemCard({ item }: { item: TripItem }) {
         </div>
 
         {(item.date || item.time_start || item.budget !== undefined) && (
-          <div className="mt-2 flex items-center gap-2 text-xs text-gray-400 pl-[18px]">
-            {item.date && <span>{item.date}</span>}
+          <div className="mt-2.5 flex items-center gap-2 text-xs text-gray-400 pl-[22px]">
+            {item.date && (
+              <span className="flex items-center gap-1">
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clipRule="evenodd" />
+                </svg>
+                {item.date}
+              </span>
+            )}
             {item.time_start && <span>{item.time_start}</span>}
-            {item.budget !== undefined && <span>${item.budget}</span>}
+            {item.budget !== undefined && (
+              <span className="font-medium text-gray-500">${item.budget.toLocaleString()}</span>
+            )}
           </div>
         )}
       </div>

--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -3,6 +3,37 @@
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 
+const navItems = [
+  {
+    href: '/research',
+    label: '리서치',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M9 9a2 2 0 114 0 2 2 0 01-4 0z" />
+        <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a4 4 0 00-3.446 6.032l-2.261 2.26a1 1 0 101.414 1.415l2.261-2.261A4 4 0 1011 5z" clipRule="evenodd" />
+      </svg>
+    ),
+  },
+  {
+    href: '/schedule',
+    label: '일정',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+        <path fillRule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clipRule="evenodd" />
+      </svg>
+    ),
+  },
+  {
+    href: '/items/new',
+    label: '추가',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+        <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
+      </svg>
+    ),
+  },
+]
+
 export default function Navigation() {
   const pathname = usePathname()
   const router = useRouter()
@@ -12,30 +43,28 @@ export default function Navigation() {
     router.push('/login')
   }
 
-  const navLinks = [
-    { href: '/research', label: '리서치' },
-    { href: '/schedule', label: '일정' },
-    { href: '/items/new', label: '+ 추가' },
-  ]
+  function isActive(href: string) {
+    if (href === '/items/new') return false
+    return pathname.startsWith(href)
+  }
 
   return (
     <>
       {/* Mobile: bottom fixed nav */}
       <nav
-        className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 z-50"
+        className="md:hidden fixed bottom-0 left-0 right-0 bg-white/90 backdrop-blur-sm border-t border-gray-100 z-50"
         style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
       >
         <div className="flex">
-          {navLinks.map(({ href, label }) => (
+          {navItems.map(({ href, label, icon }) => (
             <Link
               key={href}
               href={href}
-              className={`flex-1 py-3 text-center text-sm font-medium transition-colors ${
-                pathname.startsWith(href) && href !== '/items/new'
-                  ? 'text-gray-900'
-                  : 'text-gray-400'
+              className={`flex-1 flex flex-col items-center gap-0.5 py-2.5 text-xs font-medium transition-colors ${
+                isActive(href) ? 'text-gray-900' : 'text-gray-400'
               }`}
             >
+              {icon}
               {label}
             </Link>
           ))}
@@ -43,29 +72,34 @@ export default function Navigation() {
       </nav>
 
       {/* Desktop: left sidebar */}
-      <aside className="hidden md:flex md:flex-col md:fixed md:left-0 md:top-0 md:h-full md:w-44 bg-white border-r border-gray-200 p-4 z-50">
-        <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-4 px-3">
-          NYC Trip
-        </p>
+      <aside className="hidden md:flex md:flex-col md:fixed md:left-0 md:top-0 md:h-full md:w-44 bg-white border-r border-gray-100 p-4 z-50">
+        <div className="mb-6 px-3">
+          <p className="text-sm font-bold text-gray-900">NYC Trip</p>
+          <p className="text-xs text-gray-400 mt-0.5">2025년 6월</p>
+        </div>
         <div className="flex-1 space-y-0.5">
-          {navLinks.map(({ href, label }) => (
+          {navItems.map(({ href, label, icon }) => (
             <Link
               key={href}
               href={href}
-              className={`block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                pathname.startsWith(href) && href !== '/items/new'
-                  ? 'bg-gray-100 text-gray-900'
+              className={`flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                isActive(href)
+                  ? 'bg-gray-900 text-white'
                   : 'text-gray-500 hover:bg-gray-50 hover:text-gray-700'
               }`}
             >
+              {icon}
               {label}
             </Link>
           ))}
         </div>
         <button
           onClick={handleLogout}
-          className="px-3 py-2 text-sm text-gray-400 hover:text-gray-600 text-left rounded-lg hover:bg-gray-50 transition-colors"
+          className="flex items-center gap-2 px-3 py-2 text-sm text-gray-400 hover:text-gray-600 text-left rounded-lg hover:bg-gray-50 transition-colors"
         >
+          <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M3 3a1 1 0 00-1 1v12a1 1 0 102 0V4a1 1 0 00-1-1zm10.293 9.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L14.586 9H7a1 1 0 100 2h7.586l-1.293 1.293z" clipRule="evenodd" />
+          </svg>
           로그아웃
         </button>
       </aside>

--- a/components/Map/ResearchMap.tsx
+++ b/components/Map/ResearchMap.tsx
@@ -2,11 +2,11 @@
 
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
 import L from 'leaflet'
-import type { TripItem, Category } from '@/types'
+import type { TripItem } from '@/types'
 import StatusBadge from '@/components/UI/StatusBadge'
 import PriorityBadge from '@/components/UI/PriorityBadge'
 
-const categoryColors: Record<Category, string> = {
+const categoryColors: Record<string, string> = {
   교통: '#94A3B8',
   숙소: '#7DD3FC',
   식당: '#FB923C',

--- a/components/UI/PriorityBadge.tsx
+++ b/components/UI/PriorityBadge.tsx
@@ -1,16 +1,23 @@
 import type { Priority } from '@/types'
 
 const styles: Record<Priority, string> = {
-  반드시: 'bg-rose-100 text-rose-700',
-  들를만해: 'bg-orange-100 text-orange-700',
-  '시간 남으면': 'bg-gray-100 text-gray-500',
+  반드시: 'bg-rose-50 text-rose-600 ring-1 ring-rose-200',
+  들를만해: 'bg-orange-50 text-orange-600 ring-1 ring-orange-200',
+  '시간 남으면': 'bg-gray-50 text-gray-400 ring-1 ring-gray-200',
+}
+
+const dots: Record<Priority, string> = {
+  반드시: 'bg-rose-500',
+  들를만해: 'bg-orange-400',
+  '시간 남으면': 'bg-gray-300',
 }
 
 export default function PriorityBadge({ priority }: { priority: Priority }) {
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${styles[priority]}`}
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${styles[priority]}`}
     >
+      <span className={`w-1.5 h-1.5 rounded-full ${dots[priority]}`} />
       {priority}
     </span>
   )

--- a/components/UI/StatusBadge.tsx
+++ b/components/UI/StatusBadge.tsx
@@ -1,11 +1,11 @@
 import type { Status } from '@/types'
 
 const styles: Record<Status, string> = {
-  검토중: 'bg-blue-100 text-blue-700',
-  보류: 'bg-gray-100 text-gray-600',
-  대기중: 'bg-yellow-100 text-yellow-700',
-  확정: 'bg-emerald-100 text-emerald-700',
-  탈락: 'bg-red-100 text-red-400',
+  검토중: 'bg-sky-50 text-sky-700 ring-1 ring-sky-200',
+  보류: 'bg-gray-50 text-gray-500 ring-1 ring-gray-200',
+  대기중: 'bg-amber-50 text-amber-700 ring-1 ring-amber-200',
+  확정: 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200',
+  탈락: 'bg-rose-50 text-rose-500 ring-1 ring-rose-200',
 }
 
 export default function StatusBadge({ status }: { status: Status }) {


### PR DESCRIPTION
## 변경 이유
전반적인 비주얼 품질 향상 및 가독성 개선.

## 변경 범위
- **Navigation**: 각 탭에 SVG 아이콘 추가, 모바일 아이콘+텍스트 세로 배치, 데스크탑 활성 항목 `bg-gray-900 text-white`로 강화, backdrop-blur 적용
- **StatusBadge**: `ring-1` 테두리로 배지 경계 정교화, 색상 팔레트 미세 조정
- **PriorityBadge**: `ring-1` 테두리 추가, 우선순위별 색상 점(dot) 추가
- **ItemCard**: `rounded-2xl` 카드, 주소 서브텍스트 표시, 날짜 캘린더 아이콘, `hover:shadow-sm`, 링크 바로 열기 버튼 포함
- **ResearchMap**: 새 카테고리 색상 포함 (공연/스포츠/카페)
- **LoginForm**: 그라데이션 배경, 핀 아이콘 헤더, `rounded-2xl` + `shadow-sm` 카드, 에러 박스 스타일링

## 검증
- `npm run build` 통과

## 남은 작업 / 리스크
없음

Closes #8