### PR TITLE
feat: Prettier 설정 추가 및 코드 포맷 정규화

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "arrowParens": "avoid"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/app/items/[id]/edit/page.tsx
+++ b/app/items/[id]/edit/page.tsx
@@ -14,7 +14,10 @@ export default async function EditItemPage({ params }: { params: { id: string } 
     <div className="md:pl-44">
       <div className="max-w-lg mx-auto px-4 py-6">
         <div className="flex items-center gap-3 mb-6">
-          <Link href={`/items/${item.id}`} className="text-sm text-gray-400 hover:text-gray-600 transition-colors">
+          <Link
+            href={`/items/${item.id}`}
+            className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+          >
             ← 상세보기
           </Link>
           <h1 className="text-xl font-bold text-gray-900">항목 수정</h1>

--- a/app/items/[id]/page.tsx
+++ b/app/items/[id]/page.tsx
@@ -16,7 +16,10 @@ export default async function ItemDetailPage({ params }: { params: { id: string 
       <div className="max-w-lg mx-auto px-4 py-6 pb-28 md:pb-6">
         {/* 헤더 */}
         <div className="flex items-center justify-between mb-6">
-          <Link href="/research" className="text-sm text-gray-400 hover:text-gray-600 transition-colors">
+          <Link
+            href="/research"
+            className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+          >
             ← 목록
           </Link>
           <Link
@@ -43,12 +46,8 @@ export default async function ItemDetailPage({ params }: { params: { id: string 
           {/* 일정 & 예산 */}
           {(item.date || item.time_start || item.budget !== undefined) && (
             <section className="bg-gray-50 rounded-xl p-4 space-y-1.5">
-              {item.date && (
-                <Row label="날짜" value={item.date} />
-              )}
-              {item.time_start && (
-                <Row label="시작 시간" value={item.time_start} />
-              )}
+              {item.date && <Row label="날짜" value={item.date} />}
+              {item.time_start && <Row label="시작 시간" value={item.time_start} />}
               {item.budget !== undefined && (
                 <Row label="예산" value={`$${item.budget.toLocaleString()}`} />
               )}
@@ -61,7 +60,9 @@ export default async function ItemDetailPage({ params }: { params: { id: string 
               <SectionTitle>위치</SectionTitle>
               <p className="text-sm text-gray-700">{item.address}</p>
               {item.lat !== undefined && item.lng !== undefined && (
-                <p className="text-xs text-gray-400 mt-1">{item.lat}, {item.lng}</p>
+                <p className="text-xs text-gray-400 mt-1">
+                  {item.lat}, {item.lng}
+                </p>
               )}
             </section>
           )}
@@ -79,7 +80,12 @@ export default async function ItemDetailPage({ params }: { params: { id: string 
                     rel="noopener noreferrer"
                     className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 transition-colors"
                   >
-                    <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="w-3.5 h-3.5 flex-shrink-0"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
                       <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
                       <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
                     </svg>
@@ -106,7 +112,9 @@ export default async function ItemDetailPage({ params }: { params: { id: string 
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
   return (
-    <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">{children}</h2>
+    <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+      {children}
+    </h2>
   )
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,16 +7,10 @@ export const metadata: Metadata = {
   description: '뉴욕 여행 플래너',
 }
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko">
-      <body className="bg-gray-50 text-gray-900">
-        {children}
-      </body>
+      <body className="bg-gray-50 text-gray-900">{children}</body>
     </html>
   )
 }

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -35,8 +35,17 @@ export default function LoginForm() {
       <div className="w-full max-w-sm">
         <div className="text-center mb-8">
           <div className="w-12 h-12 bg-gray-900 rounded-2xl flex items-center justify-center mx-auto mb-4">
-            <svg xmlns="http://www.w3.org/2000/svg" className="w-6 h-6 text-white" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="w-6 h-6 text-white"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
+                clipRule="evenodd"
+              />
             </svg>
           </div>
           <h1 className="text-2xl font-bold text-gray-900">NYC Trip Planner</h1>

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -1,58 +1,58 @@
-'use client';
+'use client'
 
-import { useEffect, useState, useMemo } from 'react';
-import dynamic from 'next/dynamic';
-import Navigation from '@/components/Layout/Navigation';
-import ItemCard from '@/components/Items/ItemCard';
-import type { TripItem } from '@/types';
+import { useEffect, useState, useMemo } from 'react'
+import dynamic from 'next/dynamic'
+import Navigation from '@/components/Layout/Navigation'
+import ItemCard from '@/components/Items/ItemCard'
+import type { TripItem } from '@/types'
 
-const ScheduleMap = dynamic(() => import('@/components/Map/ScheduleMap'), { ssr: false });
+const ScheduleMap = dynamic(() => import('@/components/Map/ScheduleMap'), { ssr: false })
 
 export default function SchedulePage() {
-  const [items, setItems] = useState<TripItem[]>([]);
-  const [tab, setTab] = useState<'list' | 'map'>('list');
-  const [loading, setLoading] = useState(true);
+  const [items, setItems] = useState<TripItem[]>([])
+  const [tab, setTab] = useState<'list' | 'map'>('list')
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     fetch('/api/items')
-      .then((r) => r.json())
-      .then((data) => {
-        setItems(data.items ?? []);
-        setLoading(false);
-      });
-  }, []);
+      .then(r => r.json())
+      .then(data => {
+        setItems(data.items ?? [])
+        setLoading(false)
+      })
+  }, [])
 
-  const confirmedItems = useMemo(() => items.filter((item) => item.status === '확정'), [items]);
+  const confirmedItems = useMemo(() => items.filter(item => item.status === '확정'), [items])
 
   const scheduleItems = useMemo(() => {
     return confirmedItems
-      .filter((item) => item.date)
+      .filter(item => item.date)
       .sort((a, b) => {
-        if (a.date! < b.date!) return -1;
-        if (a.date! > b.date!) return 1;
-        if (!a.time_start && !b.time_start) return 0;
-        if (!a.time_start) return 1;
-        if (!b.time_start) return -1;
-        return a.time_start.localeCompare(b.time_start);
-      });
-  }, [confirmedItems]);
+        if (a.date! < b.date!) return -1
+        if (a.date! > b.date!) return 1
+        if (!a.time_start && !b.time_start) return 0
+        if (!a.time_start) return 1
+        if (!b.time_start) return -1
+        return a.time_start.localeCompare(b.time_start)
+      })
+  }, [confirmedItems])
 
-  const undatedItems = useMemo(() => confirmedItems.filter((item) => !item.date), [confirmedItems]);
+  const undatedItems = useMemo(() => confirmedItems.filter(item => !item.date), [confirmedItems])
 
   const grouped = useMemo(() => {
-    const groups: Record<string, TripItem[]> = {};
+    const groups: Record<string, TripItem[]> = {}
     for (const item of scheduleItems) {
-      const date = item.date!;
-      if (!groups[date]) groups[date] = [];
-      groups[date].push(item);
+      const date = item.date!
+      if (!groups[date]) groups[date] = []
+      groups[date].push(item)
     }
-    return groups;
-  }, [scheduleItems]);
+    return groups
+  }, [scheduleItems])
 
   const totalBudget = useMemo(
     () => confirmedItems.reduce((sum, item) => sum + (item.budget ?? 0), 0),
-    [confirmedItems],
-  );
+    [confirmedItems]
+  )
 
   return (
     <div className="md:pl-44">
@@ -69,7 +69,9 @@ export default function SchedulePage() {
             {confirmedItems.length === 0 ? (
               <div className="text-center text-gray-400 py-16">
                 <p className="text-sm">확정 일정이 없습니다.</p>
-                <p className="text-xs mt-1">항목 상태를 &quot;확정&quot;으로 변경하고 날짜를 입력하세요.</p>
+                <p className="text-xs mt-1">
+                  항목 상태를 &quot;확정&quot;으로 변경하고 날짜를 입력하세요.
+                </p>
               </div>
             ) : (
               <>
@@ -77,41 +79,54 @@ export default function SchedulePage() {
                 {totalBudget > 0 && (
                   <div className="flex items-center justify-between px-1 py-2 border-b border-gray-100">
                     <span className="text-xs text-gray-400">확정 항목 예산 합계</span>
-                    <span className="text-sm font-semibold text-gray-900">${totalBudget.toLocaleString()}</span>
+                    <span className="text-sm font-semibold text-gray-900">
+                      ${totalBudget.toLocaleString()}
+                    </span>
                   </div>
                 )}
 
                 {/* 날짜별 일정 */}
                 {Object.entries(grouped).map(([date, dateItems]) => {
-                  const dayBudget = dateItems.reduce((sum, item) => sum + (item.budget ?? 0), 0);
+                  const dayBudget = dateItems.reduce((sum, item) => sum + (item.budget ?? 0), 0)
                   return (
                     <div key={date}>
                       <div className="flex items-center justify-between mb-2">
-                        <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">{date}</h2>
-                        {dayBudget > 0 && <span className="text-xs text-gray-400">${dayBudget.toLocaleString()}</span>}
+                        <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                          {date}
+                        </h2>
+                        {dayBudget > 0 && (
+                          <span className="text-xs text-gray-400">
+                            ${dayBudget.toLocaleString()}
+                          </span>
+                        )}
                       </div>
                       <div className="space-y-2">
-                        {dateItems.map((item) => (
+                        {dateItems.map(item => (
                           <ItemCard key={item.id} item={item} />
                         ))}
                       </div>
                     </div>
-                  );
+                  )
                 })}
 
                 {/* 날짜 미정 섹션 */}
                 {undatedItems.length > 0 && (
                   <div>
                     <div className="flex items-center justify-between mb-2">
-                      <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">미정</h2>
+                      <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                        미정
+                      </h2>
                       {undatedItems.reduce((sum, i) => sum + (i.budget ?? 0), 0) > 0 && (
                         <span className="text-xs text-gray-400">
-                          ${undatedItems.reduce((sum, i) => sum + (i.budget ?? 0), 0).toLocaleString()}
+                          $
+                          {undatedItems
+                            .reduce((sum, i) => sum + (i.budget ?? 0), 0)
+                            .toLocaleString()}
                         </span>
                       )}
                     </div>
                     <div className="space-y-3">
-                      {undatedItems.map((item) => (
+                      {undatedItems.map(item => (
                         <ItemCard key={item.id} item={item} />
                       ))}
                     </div>
@@ -128,13 +143,19 @@ export default function SchedulePage() {
       </div>
       <Navigation />
     </div>
-  );
+  )
 }
 
-function TabSwitcher({ tab, onChange }: { tab: 'list' | 'map'; onChange: (t: 'list' | 'map') => void }) {
+function TabSwitcher({
+  tab,
+  onChange,
+}: {
+  tab: 'list' | 'map'
+  onChange: (t: 'list' | 'map') => void
+}) {
   return (
     <div className="flex rounded-lg border border-gray-200 overflow-hidden">
-      {(['list', 'map'] as const).map((t) => (
+      {(['list', 'map'] as const).map(t => (
         <button
           key={t}
           onClick={() => onChange(t)}
@@ -146,5 +167,5 @@ function TabSwitcher({ tab, onChange }: { tab: 'list' | 'map'; onChange: (t: 'li
         </button>
       ))}
     </div>
-  );
+  )
 }

--- a/components/Items/ItemCard.tsx
+++ b/components/Items/ItemCard.tsx
@@ -43,7 +43,12 @@ function LinkButton({ links }: { links: TripItem['links'] }) {
         className="flex-shrink-0 p-1 text-gray-400 hover:text-blue-500 transition-colors"
         title={links[0].label || '링크 열기'}
       >
-        <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="w-3.5 h-3.5"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
           <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
           <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
         </svg>
@@ -54,11 +59,20 @@ function LinkButton({ links }: { links: TripItem['links'] }) {
   return (
     <div ref={ref} className="relative flex-shrink-0">
       <button
-        onClick={e => { e.preventDefault(); e.stopPropagation(); setOpen(v => !v) }}
+        onClick={e => {
+          e.preventDefault()
+          e.stopPropagation()
+          setOpen(v => !v)
+        }}
         className="p-1 text-gray-400 hover:text-blue-500 transition-colors flex items-center gap-0.5"
         title="링크 목록"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="w-3.5 h-3.5"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
           <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
           <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
         </svg>
@@ -72,7 +86,10 @@ function LinkButton({ links }: { links: TripItem['links'] }) {
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"
-              onClick={e => { e.stopPropagation(); setOpen(false) }}
+              onClick={e => {
+                e.stopPropagation()
+                setOpen(false)
+              }}
               className="block px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50 truncate max-w-48"
             >
               {link.label || link.url}
@@ -116,7 +133,10 @@ export default function ItemCard({ item }: { item: TripItem }) {
             <LinkButton links={item.links} />
             {item.is_franchise && item.branches && item.branches.length > 0 && (
               <button
-                onClick={e => { e.preventDefault(); setBranchesOpen(v => !v) }}
+                onClick={e => {
+                  e.preventDefault()
+                  setBranchesOpen(v => !v)
+                }}
                 className="p-1 text-gray-400 hover:text-gray-600 transition-colors"
                 title="지점 목록"
               >
@@ -126,7 +146,11 @@ export default function ItemCard({ item }: { item: TripItem }) {
                   viewBox="0 0 20 20"
                   fill="currentColor"
                 >
-                  <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+                  <path
+                    fillRule="evenodd"
+                    d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                    clipRule="evenodd"
+                  />
                 </svg>
               </button>
             )}
@@ -137,8 +161,17 @@ export default function ItemCard({ item }: { item: TripItem }) {
           <div className="mt-2.5 flex items-center gap-2 text-xs text-gray-400 pl-[22px]">
             {item.date && (
               <span className="flex items-center gap-1">
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clipRule="evenodd" />
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="w-3 h-3"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
+                    clipRule="evenodd"
+                  />
                 </svg>
                 {item.date}
               </span>
@@ -154,14 +187,21 @@ export default function ItemCard({ item }: { item: TripItem }) {
           <div className="mt-3 pl-[22px] space-y-1.5 border-t border-gray-100 pt-3">
             {item.branches.map(branch => (
               <div key={branch.id} className="flex items-start gap-1.5">
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5 text-gray-300 flex-shrink-0 mt-0.5" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="w-3.5 h-3.5 text-gray-300 flex-shrink-0 mt-0.5"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
+                    clipRule="evenodd"
+                  />
                 </svg>
                 <div>
                   <span className="text-xs font-medium text-gray-700">{branch.name}</span>
-                  {branch.address && (
-                    <p className="text-xs text-gray-400">{branch.address}</p>
-                  )}
+                  {branch.address && <p className="text-xs text-gray-400">{branch.address}</p>}
                 </div>
               </div>
             ))}

--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -4,7 +4,17 @@ import { useState, useRef, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import type { TripItem, Category, Status, Priority, Link as TripLink } from '@/types'
 
-const CATEGORIES: Category[] = ['교통', '숙소', '식당', '카페', '관광', '공연', '스포츠', '쇼핑', '기타']
+const CATEGORIES: Category[] = [
+  '교통',
+  '숙소',
+  '식당',
+  '카페',
+  '관광',
+  '공연',
+  '스포츠',
+  '쇼핑',
+  '기타',
+]
 
 const STATUS_OPTIONS: { value: Status; label: string }[] = [
   { value: '검토중', label: '검토중 — 아직 결정 안 됨' },
@@ -107,7 +117,10 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
   }
 
   function removeLink(i: number) {
-    setField('links', form.links.filter((_, idx) => idx !== i))
+    setField(
+      'links',
+      form.links.filter((_, idx) => idx !== i)
+    )
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -176,9 +189,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
     <form onSubmit={handleSubmit} className="space-y-8 pb-28 md:pb-8">
       {/* 기본 정보 */}
       <section className="space-y-4">
-        <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
-          기본 정보
-        </h2>
+        <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">기본 정보</h2>
 
         <div>
           <label className={labelClass}>이름 *</label>
@@ -286,9 +297,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
             className={inputClass}
             placeholder="주소 입력 후 포커스를 벗어나면 좌표 자동 입력"
           />
-          {geocoding && (
-            <p className="text-xs text-gray-400 mt-1">좌표 검색 중...</p>
-          )}
+          {geocoding && <p className="text-xs text-gray-400 mt-1">좌표 검색 중...</p>}
           {!geocoding && geocodeError && (
             <p className="text-xs text-amber-500 mt-1">{geocodeError}</p>
           )}

--- a/components/Items/ItemList.tsx
+++ b/components/Items/ItemList.tsx
@@ -1,20 +1,30 @@
-'use client';
+'use client'
 
-import { useState, useMemo } from 'react';
-import type { TripItem, Category, Status, Priority } from '@/types';
-import ItemCard from './ItemCard';
+import { useState, useMemo } from 'react'
+import type { TripItem, Category, Status, Priority } from '@/types'
+import ItemCard from './ItemCard'
 
-const CATEGORIES: Category[] = ['교통', '숙소', '식당', '카페', '관광', '공연', '스포츠', '쇼핑', '기타'];
-const STATUSES: Status[] = ['검토중', '보류', '대기중', '확정', '탈락'];
-const PRIORITIES: Priority[] = ['반드시', '들를만해', '시간 남으면'];
+const CATEGORIES: Category[] = [
+  '교통',
+  '숙소',
+  '식당',
+  '카페',
+  '관광',
+  '공연',
+  '스포츠',
+  '쇼핑',
+  '기타',
+]
+const STATUSES: Status[] = ['검토중', '보류', '대기중', '확정', '탈락']
+const PRIORITIES: Priority[] = ['반드시', '들를만해', '시간 남으면']
 
-type SortKey = 'name' | 'date' | 'budget' | 'priority';
-type SortDir = 'asc' | 'desc';
+type SortKey = 'name' | 'date' | 'budget' | 'priority'
+type SortDir = 'asc' | 'desc'
 
-const PRIORITY_ORDER: Record<string, number> = { 반드시: 0, 들를만해: 1, '시간 남으면': 2 };
+const PRIORITY_ORDER: Record<string, number> = { 반드시: 0, 들를만해: 1, '시간 남으면': 2 }
 
 function toggle<T>(arr: T[], val: T): T[] {
-  return arr.includes(val) ? arr.filter((x) => x !== val) : [...arr, val];
+  return arr.includes(val) ? arr.filter(x => x !== val) : [...arr, val]
 }
 
 function Chip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
@@ -29,69 +39,69 @@ function Chip({ label, active, onClick }: { label: string; active: boolean; onCl
     >
       {label}
     </button>
-  );
+  )
 }
 
 export default function ItemList({ items }: { items: TripItem[] }) {
-  const [selCats, setSelCats] = useState<Category[]>([]);
-  const [selStatuses, setSelStatuses] = useState<Status[]>([]);
-  const [selPriorities, setSelPriorities] = useState<Priority[]>([]);
-  const [showEliminated, setShowEliminated] = useState(false);
-  const [query, setQuery] = useState('');
-  const [sortKey, setSortKey] = useState<SortKey>('name');
-  const [sortDir, setSortDir] = useState<SortDir>('asc');
+  const [selCats, setSelCats] = useState<Category[]>([])
+  const [selStatuses, setSelStatuses] = useState<Status[]>([])
+  const [selPriorities, setSelPriorities] = useState<Priority[]>([])
+  const [showEliminated, setShowEliminated] = useState(false)
+  const [query, setQuery] = useState('')
+  const [sortKey, setSortKey] = useState<SortKey>('name')
+  const [sortDir, setSortDir] = useState<SortDir>('asc')
 
-  const eliminatedCount = useMemo(() => items.filter((i) => i.status === '탈락').length, [items]);
+  const eliminatedCount = useMemo(() => items.filter(i => i.status === '탈락').length, [items])
 
   function handleSortChange(key: SortKey) {
     if (sortKey === key) {
-      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'))
     } else {
-      setSortKey(key);
-      setSortDir('asc');
+      setSortKey(key)
+      setSortDir('asc')
     }
   }
 
   const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    const result = items.filter((item) => {
-      if (!showEliminated && item.status === '탈락') return false;
-      if (selCats.length && !selCats.includes(item.category)) return false;
-      if (selStatuses.length && !selStatuses.includes(item.status)) return false;
+    const q = query.trim().toLowerCase()
+    const result = items.filter(item => {
+      if (!showEliminated && item.status === '탈락') return false
+      if (selCats.length && !selCats.includes(item.category)) return false
+      if (selStatuses.length && !selStatuses.includes(item.status)) return false
       if (selPriorities.length) {
-        if (!item.priority || !selPriorities.includes(item.priority)) return false;
+        if (!item.priority || !selPriorities.includes(item.priority)) return false
       }
-      if (q && !item.name.toLowerCase().includes(q)) return false;
-      return true;
-    });
+      if (q && !item.name.toLowerCase().includes(q)) return false
+      return true
+    })
 
     result.sort((a, b) => {
-      let cmp = 0;
+      let cmp = 0
       if (sortKey === 'name') {
-        cmp = a.name.localeCompare(b.name, 'ko');
+        cmp = a.name.localeCompare(b.name, 'ko')
       } else if (sortKey === 'date') {
-        const da = a.date ?? '';
-        const db = b.date ?? '';
-        cmp = da < db ? -1 : da > db ? 1 : 0;
+        const da = a.date ?? ''
+        const db = b.date ?? ''
+        cmp = da < db ? -1 : da > db ? 1 : 0
       } else if (sortKey === 'budget') {
-        cmp = (a.budget ?? 0) - (b.budget ?? 0);
+        cmp = (a.budget ?? 0) - (b.budget ?? 0)
       } else if (sortKey === 'priority') {
-        const pa = a.priority ? PRIORITY_ORDER[a.priority] : 99;
-        const pb = b.priority ? PRIORITY_ORDER[b.priority] : 99;
-        cmp = pa - pb;
+        const pa = a.priority ? PRIORITY_ORDER[a.priority] : 99
+        const pb = b.priority ? PRIORITY_ORDER[b.priority] : 99
+        cmp = pa - pb
       }
-      return sortDir === 'asc' ? cmp : -cmp;
-    });
+      return sortDir === 'asc' ? cmp : -cmp
+    })
 
-    return result;
-  }, [items, selCats, selStatuses, selPriorities, showEliminated, query, sortKey, sortDir]);
+    return result
+  }, [items, selCats, selStatuses, selPriorities, showEliminated, query, sortKey, sortDir])
 
   const SORT_OPTIONS: { key: SortKey; label: string }[] = [
     { key: 'name', label: '이름' },
     { key: 'date', label: '날짜' },
     { key: 'budget', label: '예산' },
     { key: 'priority', label: '우선순위' },
-  ];
+  ]
 
   return (
     <div className="space-y-4">
@@ -99,7 +109,7 @@ export default function ItemList({ items }: { items: TripItem[] }) {
       <input
         type="text"
         value={query}
-        onChange={(e) => setQuery(e.target.value)}
+        onChange={e => setQuery(e.target.value)}
         placeholder="이름으로 검색..."
         className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 bg-white"
       />
@@ -107,12 +117,17 @@ export default function ItemList({ items }: { items: TripItem[] }) {
       {/* Filters */}
       <div className="space-y-2">
         <div className="flex flex-wrap gap-1.5">
-          {CATEGORIES.map((c) => (
-            <Chip key={c} label={c} active={selCats.includes(c)} onClick={() => setSelCats(toggle(selCats, c))} />
+          {CATEGORIES.map(c => (
+            <Chip
+              key={c}
+              label={c}
+              active={selCats.includes(c)}
+              onClick={() => setSelCats(toggle(selCats, c))}
+            />
           ))}
         </div>
         <div className="flex flex-wrap gap-1.5">
-          {STATUSES.map((s) => (
+          {STATUSES.map(s => (
             <Chip
               key={s}
               label={s}
@@ -122,7 +137,7 @@ export default function ItemList({ items }: { items: TripItem[] }) {
           ))}
         </div>
         <div className="flex flex-wrap gap-1.5">
-          {PRIORITIES.map((p) => (
+          {PRIORITIES.map(p => (
             <Chip
               key={p}
               label={p}
@@ -156,7 +171,7 @@ export default function ItemList({ items }: { items: TripItem[] }) {
         <p className="text-xs text-gray-400">{filtered.length}개 항목</p>
         {eliminatedCount > 0 && (
           <button
-            onClick={() => setShowEliminated((v) => !v)}
+            onClick={() => setShowEliminated(v => !v)}
             className="text-xs text-gray-400 hover:text-gray-600 underline underline-offset-2 transition-colors"
           >
             {showEliminated ? `탈락 항목 숨기기` : `탈락 항목 보기 (${eliminatedCount})`}
@@ -165,11 +180,13 @@ export default function ItemList({ items }: { items: TripItem[] }) {
       </div>
 
       <div className="space-y-2">
-        {filtered.map((item) => (
+        {filtered.map(item => (
           <ItemCard key={item.id} item={item} />
         ))}
-        {filtered.length === 0 && <p className="text-center text-gray-400 py-12 text-sm">항목이 없습니다.</p>}
+        {filtered.length === 0 && (
+          <p className="text-center text-gray-400 py-12 text-sm">항목이 없습니다.</p>
+        )}
       </div>
     </div>
-  );
+  )
 }

--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -8,9 +8,18 @@ const navItems = [
     href: '/research',
     label: '리서치',
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="w-5 h-5"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+      >
         <path d="M9 9a2 2 0 114 0 2 2 0 01-4 0z" />
-        <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a4 4 0 00-3.446 6.032l-2.261 2.26a1 1 0 101.414 1.415l2.261-2.261A4 4 0 1011 5z" clipRule="evenodd" />
+        <path
+          fillRule="evenodd"
+          d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a4 4 0 00-3.446 6.032l-2.261 2.26a1 1 0 101.414 1.415l2.261-2.261A4 4 0 1011 5z"
+          clipRule="evenodd"
+        />
       </svg>
     ),
   },
@@ -18,8 +27,17 @@ const navItems = [
     href: '/schedule',
     label: '일정',
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-        <path fillRule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clipRule="evenodd" />
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="w-5 h-5"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+      >
+        <path
+          fillRule="evenodd"
+          d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
+          clipRule="evenodd"
+        />
       </svg>
     ),
   },
@@ -27,8 +45,17 @@ const navItems = [
     href: '/items/new',
     label: '추가',
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-        <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="w-5 h-5"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+      >
+        <path
+          fillRule="evenodd"
+          d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
+          clipRule="evenodd"
+        />
       </svg>
     ),
   },
@@ -97,8 +124,17 @@ export default function Navigation() {
           onClick={handleLogout}
           className="flex items-center gap-2 px-3 py-2 text-sm text-gray-400 hover:text-gray-600 text-left rounded-lg hover:bg-gray-50 transition-colors"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M3 3a1 1 0 00-1 1v12a1 1 0 102 0V4a1 1 0 00-1-1zm10.293 9.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L14.586 9H7a1 1 0 100 2h7.586l-1.293 1.293z" clipRule="evenodd" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="w-4 h-4"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fillRule="evenodd"
+              d="M3 3a1 1 0 00-1 1v12a1 1 0 102 0V4a1 1 0 00-1-1zm10.293 9.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L14.586 9H7a1 1 0 100 2h7.586l-1.293 1.293z"
+              clipRule="evenodd"
+            />
           </svg>
           로그아웃
         </button>

--- a/components/Map/ScheduleMap.tsx
+++ b/components/Map/ScheduleMap.tsx
@@ -29,9 +29,7 @@ function createNumberIcon(num: number) {
 
 export default function ScheduleMap({ items }: { items: TripItem[] }) {
   const confirmedDates = useMemo(() => {
-    const dates = items
-      .filter(i => i.status === '확정' && i.date)
-      .map(i => i.date!)
+    const dates = items.filter(i => i.status === '확정' && i.date).map(i => i.date!)
     return Array.from(new Set(dates)).sort()
   }, [items])
 
@@ -92,19 +90,13 @@ export default function ScheduleMap({ items }: { items: TripItem[] }) {
         />
 
         {dayItems.map((item, idx) => (
-          <Marker
-            key={item.id}
-            position={[item.lat!, item.lng!]}
-            icon={createNumberIcon(idx + 1)}
-          >
+          <Marker key={item.id} position={[item.lat!, item.lng!]} icon={createNumberIcon(idx + 1)}>
             <Popup>
               <div className="space-y-1 min-w-[140px]">
                 <p className="font-semibold text-gray-900 text-sm">
                   {idx + 1}. {item.name}
                 </p>
-                {item.time_start && (
-                  <p className="text-xs text-gray-500">{item.time_start}</p>
-                )}
+                {item.time_start && <p className="text-xs text-gray-500">{item.time_start}</p>}
                 {item.budget !== undefined && (
                   <p className="text-xs text-gray-500">${item.budget}</p>
                 )}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,9 +1,7 @@
 import { SignJWT, jwtVerify } from 'jose'
 
 function getSecret() {
-  return new TextEncoder().encode(
-    process.env.JWT_SECRET || 'dev-secret-change-me-in-production'
-  )
+  return new TextEncoder().encode(process.env.JWT_SECRET || 'dev-secret-change-me-in-production')
 }
 
 export async function createToken(payload: Record<string, unknown>): Promise<string> {

--- a/lib/geocode.ts
+++ b/lib/geocode.ts
@@ -1,6 +1,4 @@
-export async function geocodeAddress(
-  q: string
-): Promise<{ lat: number; lng: number } | null> {
+export async function geocodeAddress(q: string): Promise<{ lat: number; lng: number } | null> {
   const url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(q)}&format=json&limit=1`
 
   const res = await fetch(url, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint": "^8",
         "eslint-config-next": "^14.2.0",
         "postcss": "^8",
+        "prettier": "^3.8.1",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
       }
@@ -4739,6 +4740,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -9,25 +9,26 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "jose": "^5.2.4",
+    "leaflet": "^1.9.4",
     "next": "^14.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-leaflet": "^4.2.1",
-    "leaflet": "^1.9.4",
-    "jose": "^5.2.4",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@types/leaflet": "^1.9.8",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "@types/leaflet": "^1.9.8",
     "@types/uuid": "^9.0.8",
-    "postcss": "^8",
-    "tailwindcss": "^3.4.1",
     "autoprefixer": "^10.0.1",
     "eslint": "^8",
-    "eslint-config-next": "^14.2.0"
+    "eslint-config-next": "^14.2.0",
+    "postcss": "^8",
+    "prettier": "^3.8.1",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5"
   }
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,37 +1,46 @@
-export type Category = '교통' | '숙소' | '식당' | '카페' | '관광' | '공연' | '스포츠' | '쇼핑' | '기타';
-export type Status   = '검토중' | '보류' | '대기중' | '확정' | '탈락';
-export type Priority = '반드시' | '들를만해' | '시간 남으면';
+export type Category =
+  | '교통'
+  | '숙소'
+  | '식당'
+  | '카페'
+  | '관광'
+  | '공연'
+  | '스포츠'
+  | '쇼핑'
+  | '기타'
+export type Status = '검토중' | '보류' | '대기중' | '확정' | '탈락'
+export type Priority = '반드시' | '들를만해' | '시간 남으면'
 
 export interface Link {
-  label: string;
-  url:   string;
+  label: string
+  url: string
 }
 
 export interface Branch {
-  id:       string;
-  name:     string;
-  address?: string;
-  lat?:     number;
-  lng?:     number;
+  id: string
+  name: string
+  address?: string
+  lat?: number
+  lng?: number
 }
 
 export interface TripItem {
-  id:           string;
-  name:         string;
-  category:     Category;
-  status:       Status;
-  priority?:    Priority;
-  address?:     string;
-  lat?:         number;
-  lng?:         number;
-  links:        Link[];
-  budget?:      number;
-  memo?:        string;
-  date?:        string;
-  time_start?:  string;
-  time_end?:    string;
-  is_franchise?: boolean;
-  branches?:    Branch[];
-  created_at:   string;
-  updated_at:   string;
+  id: string
+  name: string
+  category: Category
+  status: Status
+  priority?: Priority
+  address?: string
+  lat?: number
+  lng?: number
+  links: Link[]
+  budget?: number
+  memo?: string
+  date?: string
+  time_start?: string
+  time_end?: string
+  is_franchise?: boolean
+  branches?: Branch[]
+  created_at: string
+  updated_at: string
 }


### PR DESCRIPTION
## Summary

- `.prettierrc` 추가: 프로젝트 포맷 규칙 고정 (semi: false, singleQuote: true, arrowParens: avoid 등)
- `.vscode/settings.json` 추가: VS Code에서 저장 시 Prettier 자동 적용
- `prettier` devDependency 추가 (v3.8.1)
- 기존 소스 코드 14개 파일을 Prettier 규칙에 맞게 정규화

## 적용된 Prettier 설정

| 옵션 | 값 |
|---|---|
| `semi` | `false` |
| `singleQuote` | `true` |
| `tabWidth` | `2` |
| `trailingComma` | `es5` |
| `printWidth` | `100` |
| `arrowParens` | `avoid` |

## 해결하는 문제

Claude Code가 수정한 코드를 VS Code에서 저장하면 포맷이 바뀌는 문제를 해결한다.
공유 설정 파일이 없어 두 도구가 각자 다른 기준으로 포맷하던 것을 `.prettierrc`로 통일한다.

## VS Code 사용 전제 조건

[Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) 익스텐션이 설치되어 있어야 한다.