### PR TITLE
fix: 여행 날짜 2025년 6월 → 2026년 7월로 수정

### DIFF
--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -49,7 +49,7 @@ export default function LoginForm() {
             </svg>
           </div>
           <h1 className="text-2xl font-bold text-gray-900">NYC Trip Planner</h1>
-          <p className="text-sm text-gray-400 mt-1">2025년 6월 뉴욕 여행</p>
+          <p className="text-sm text-gray-400 mt-1">2026년 7월 뉴욕 여행</p>
         </div>
 
         <form

--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -102,7 +102,7 @@ export default function Navigation() {
       <aside className="hidden md:flex md:flex-col md:fixed md:left-0 md:top-0 md:h-full md:w-44 bg-white border-r border-gray-100 p-4 z-50">
         <div className="mb-6 px-3">
           <p className="text-sm font-bold text-gray-900">NYC Trip</p>
-          <p className="text-xs text-gray-400 mt-0.5">2025년 6월</p>
+          <p className="text-xs text-gray-400 mt-0.5">2026년 7월</p>
         </div>
         <div className="flex-1 space-y-0.5">
           {navItems.map(({ href, label, icon }) => (


### PR DESCRIPTION
## Summary
- 네비게이션 사이드바, 로그인 화면에 하드코딩된 여행 날짜를 올바른 날짜로 수정
- `components/Layout/Navigation.tsx`: `2025년 6월` → `2026년 7월`
- `app/login/LoginForm.tsx`: `2025년 6월 뉴욕 여행` → `2026년 7월 뉴욕 여행`