### PR TITLE
feat: 지도 타일 간소화 (CartoDB Positron 적용)

### DIFF
--- a/components/Map/ResearchMap.tsx
+++ b/components/Map/ResearchMap.tsx
@@ -46,8 +46,8 @@ export default function ResearchMap({ items }: { items: TripItem[] }) {
       className="touch-none"
     >
       <TileLayer
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+        url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
       />
       {mapItems.map(item => (
         <Marker

--- a/components/Map/ScheduleMap.tsx
+++ b/components/Map/ScheduleMap.tsx
@@ -85,8 +85,8 @@ export default function ScheduleMap({ items }: { items: TripItem[] }) {
         className="touch-none"
       >
         <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+          url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
         />
 
         {dayItems.map((item, idx) => (


### PR DESCRIPTION
## 변경 이유
기본 OpenStreetMap 타일은 색상이 복잡하고 레이블이 많아 커스텀 마커가 배경에 묻혀 보였습니다.

## 변경 범위
- `components/Map/ResearchMap.tsx` — TileLayer를 CartoDB Positron으로 교체
- `components/Map/ScheduleMap.tsx` — TileLayer를 CartoDB Positron으로 교체
- attribution에 CARTO 출처 추가

CartoDB Positron은 흰 배경에 회색 도로와 최소한의 레이블을 제공하는 무료 타일입니다.

## 검증
- `npm run build` 통과

## 남은 작업 / 리스크
없음

Closes #36