### PR TITLE
feat: 지도 탭 PC 전체 너비 레이아웃 적용

### DIFF
--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -37,27 +37,33 @@ export default function ResearchPage() {
 
   return (
     <div className="md:pl-44">
-      <div className="max-w-2xl mx-auto px-4 pt-4 pb-24 md:pb-6">
-        {/* Header */}
+      {/* Header: 항상 제한된 너비 */}
+      <div className="max-w-2xl mx-auto px-4 pt-4">
         <div className="flex items-center justify-between mb-4">
           <h1 className="text-xl font-bold text-gray-900">리서치</h1>
           <TabSwitcher tab={tab} onChange={setTab} />
         </div>
+      </div>
 
-        {loading ? (
+      {/* 콘텐츠: 목록은 제한 너비, 지도는 전체 너비 */}
+      {loading ? (
+        <div className="max-w-2xl mx-auto px-4">
           <p className="text-center text-gray-400 py-16 text-sm">불러오는 중...</p>
-        ) : tab === 'list' ? (
+        </div>
+      ) : tab === 'list' ? (
+        <div className="max-w-2xl mx-auto px-4 pb-24 md:pb-6">
           <ItemList
             items={items}
             selectedItemId={selectedItemId}
             onSelectItem={id => setSelectedItemId(prev => (prev === id ? null : id))}
           />
-        ) : (
-          <div className="h-[calc(100vh-130px)] -mx-4">
-            <ResearchMap items={items} />
-          </div>
-        )}
-      </div>
+        </div>
+      ) : (
+        <div className="h-[calc(100vh-72px)]">
+          <ResearchMap items={items} />
+        </div>
+      )}
+
       <Navigation />
 
       <ItemPanel

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -56,15 +56,21 @@ export default function SchedulePage() {
 
   return (
     <div className="md:pl-44">
-      <div className="max-w-2xl mx-auto px-4 pt-4 pb-24 md:pb-6">
+      {/* Header: 항상 제한된 너비 */}
+      <div className="max-w-2xl mx-auto px-4 pt-4">
         <div className="flex items-center justify-between mb-4">
           <h1 className="text-xl font-bold text-gray-900">일정</h1>
           <TabSwitcher tab={tab} onChange={setTab} />
         </div>
+      </div>
 
-        {loading ? (
+      {/* 콘텐츠: 목록은 제한 너비, 지도는 전체 너비 */}
+      {loading ? (
+        <div className="max-w-2xl mx-auto px-4">
           <p className="text-center text-gray-400 py-16 text-sm">불러오는 중...</p>
-        ) : tab === 'list' ? (
+        </div>
+      ) : tab === 'list' ? (
+        <div className="max-w-2xl mx-auto px-4 pb-24 md:pb-6">
           <div className="space-y-6">
             {confirmedItems.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-16 text-center">
@@ -138,12 +144,12 @@ export default function SchedulePage() {
               </>
             )}
           </div>
-        ) : (
-          <div className="h-[calc(100vh-130px)] -mx-4">
-            <ScheduleMap items={items} />
-          </div>
-        )}
-      </div>
+        </div>
+      ) : (
+        <div className="h-[calc(100vh-72px)]">
+          <ScheduleMap items={items} />
+        </div>
+      )}
       <Navigation />
     </div>
   )


### PR DESCRIPTION
## 변경 이유
지도 탭이 `max-w-2xl` 컨테이너에 제한되어 데스크탑에서 양옆에 빈 공간이 생겼습니다.

## 변경 범위
- `app/research/page.tsx` — 헤더는 제한 너비 유지, 지도는 `h-[calc(100vh-72px)]` 전체 너비로 분리
- `app/schedule/page.tsx` — 동일 패턴 적용

목록 탭은 기존 `max-w-2xl mx-auto` 제한 너비를 유지하고,
지도 탭은 `md:pl-44` 사이드바 이후 전체 너비를 사용합니다.

## 검증
- `npm run build` 통과

## 남은 작업 / 리스크
없음

Closes #35