### PR TITLE
feat: 데이터 로딩 시 스켈레톤 UI 표시

### DIFF
--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import dynamic from 'next/dynamic'
 import Navigation from '@/components/Layout/Navigation'
 import ItemList from '@/components/Items/ItemList'
+import ItemCardSkeleton from '@/components/UI/ItemCardSkeleton'
 import type { TripItem } from '@/types'
 
 const ResearchMap = dynamic(() => import('@/components/Map/ResearchMap'), { ssr: false })
@@ -47,8 +48,10 @@ export default function ResearchPage() {
 
       {/* 콘텐츠: 목록은 제한 너비, 지도는 전체 너비 */}
       {loading ? (
-        <div className="max-w-2xl mx-auto px-4">
-          <p className="text-center text-gray-400 py-16 text-sm">불러오는 중...</p>
+        <div className="max-w-2xl mx-auto px-4 space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <ItemCardSkeleton key={i} />
+          ))}
         </div>
       ) : tab === 'list' ? (
         <div className="max-w-2xl mx-auto px-4 pb-24 md:pb-6">

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo } from 'react'
 import dynamic from 'next/dynamic'
 import Navigation from '@/components/Layout/Navigation'
 import ItemCard from '@/components/Items/ItemCard'
+import ItemCardSkeleton from '@/components/UI/ItemCardSkeleton'
 import type { TripItem } from '@/types'
 
 const ScheduleMap = dynamic(() => import('@/components/Map/ScheduleMap'), { ssr: false })
@@ -66,8 +67,10 @@ export default function SchedulePage() {
 
       {/* 콘텐츠: 목록은 제한 너비, 지도는 전체 너비 */}
       {loading ? (
-        <div className="max-w-2xl mx-auto px-4">
-          <p className="text-center text-gray-400 py-16 text-sm">불러오는 중...</p>
+        <div className="max-w-2xl mx-auto px-4 space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <ItemCardSkeleton key={i} />
+          ))}
         </div>
       ) : tab === 'list' ? (
         <div className="max-w-2xl mx-auto px-4 pb-24 md:pb-6">

--- a/components/UI/ItemCardSkeleton.tsx
+++ b/components/UI/ItemCardSkeleton.tsx
@@ -1,0 +1,18 @@
+export default function ItemCardSkeleton() {
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 p-4 animate-pulse">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2.5 min-w-0 flex-1">
+          <div className="w-3 h-3 rounded-full bg-gray-200 flex-shrink-0" />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <div className="h-3.5 bg-gray-200 rounded w-2/5" />
+            <div className="h-3 bg-gray-100 rounded w-3/5" />
+          </div>
+        </div>
+        <div className="flex items-center gap-1 flex-shrink-0">
+          <div className="h-5 w-12 bg-gray-100 rounded-full" />
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 변경 이유
Supabase에서 데이터를 불러오는 동안 화면이 비어있어 레이아웃이 갑자기 채워지는 현상이 있었습니다.

## 변경 범위
- `components/UI/ItemCardSkeleton.tsx` 신규 생성 — ItemCard 구조를 흉내낸 `animate-pulse` 스켈레톤
- `app/research/page.tsx` — 로딩 중 스켈레톤 5개 표시
- `app/schedule/page.tsx` — 로딩 중 스켈레톤 4개 표시

## 검증
- `npm run build` 통과

## 남은 작업 / 리스크
없음

Closes #40