### PR TITLE
feat: 지도 마커 클릭 시 아이템 패널 열기

### DIFF
--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -63,7 +63,10 @@ export default function ResearchPage() {
         </div>
       ) : (
         <div className="h-[calc(100vh-72px)]">
-          <ResearchMap items={items} />
+          <ResearchMap
+            items={items}
+            onSelectItem={id => setSelectedItemId(prev => (prev === id ? null : id))}
+          />
         </div>
       )}
 

--- a/components/Map/ResearchMap.tsx
+++ b/components/Map/ResearchMap.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
+import { MapContainer, TileLayer, Marker, Tooltip } from 'react-leaflet'
 import L from 'leaflet'
 import type { TripItem } from '@/types'
-import StatusBadge from '@/components/UI/StatusBadge'
-import PriorityBadge from '@/components/UI/PriorityBadge'
 
 const categoryColors: Record<string, string> = {
   교통: '#94A3B8',
@@ -33,7 +31,12 @@ function createDotIcon(color: string) {
   })
 }
 
-export default function ResearchMap({ items }: { items: TripItem[] }) {
+interface ResearchMapProps {
+  items: TripItem[]
+  onSelectItem?: (id: string) => void
+}
+
+export default function ResearchMap({ items, onSelectItem }: ResearchMapProps) {
   const mapItems = items.filter(
     item => item.status !== '탈락' && item.lat !== undefined && item.lng !== undefined
   )
@@ -54,17 +57,17 @@ export default function ResearchMap({ items }: { items: TripItem[] }) {
           key={item.id}
           position={[item.lat!, item.lng!]}
           icon={createDotIcon(categoryColors[item.category])}
+          eventHandlers={
+            onSelectItem
+              ? {
+                  click: () => onSelectItem(item.id),
+                }
+              : undefined
+          }
         >
-          <Popup>
-            <div className="space-y-1 min-w-[140px]">
-              <p className="font-semibold text-gray-900 text-sm">{item.name}</p>
-              <p className="text-xs text-gray-500">{item.category}</p>
-              <div className="flex gap-1 flex-wrap pt-0.5">
-                <StatusBadge status={item.status} />
-                {item.priority && <PriorityBadge priority={item.priority} />}
-              </div>
-            </div>
-          </Popup>
+          <Tooltip direction="top" offset={[0, -12]} opacity={0.9}>
+            <span className="text-xs font-medium">{item.name}</span>
+          </Tooltip>
         </Marker>
       ))}
     </MapContainer>


### PR DESCRIPTION
## 변경 이유
지도 마커 클릭 시 Leaflet 기본 팝업이 뜨고 앱 내 패널과 연동이 안 되어 UX가 어색했습니다.

## 변경 범위
- `components/Map/ResearchMap.tsx`
  - `onSelectItem` 콜백 prop 추가
  - 마커 `eventHandlers.click` → `onSelectItem(item.id)` 호출
  - `Popup` 제거, `Tooltip`(hover 시 이름 표시)으로 교체
  - `StatusBadge`, `PriorityBadge` import 제거
- `app/research/page.tsx`
  - `ResearchMap`에 `onSelectItem` prop 연결 → `ItemPanel` 열기/닫기 토글

## 검증
- `npm run build` 통과

## 남은 작업 / 리스크
없음

Closes #43