### PR TITLE
fix: 지도 위에서 아이템 패널이 가려지는 버그 수정

### DIFF
--- a/components/Panel/ItemPanel.tsx
+++ b/components/Panel/ItemPanel.tsx
@@ -54,9 +54,9 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
 
   return (
     <>
-      {/* 백드롭: z-[55]로 네비게이션(z-50) 위에 씌움 */}
+      {/* 백드롭: Leaflet 최대 z-index(700)보다 높게 설정해 지도 위에 표시 */}
       <div
-        className={`fixed inset-0 bg-black/30 z-[55] transition-opacity duration-300 ${
+        className={`fixed inset-0 bg-black/30 z-[1000] transition-opacity duration-300 ${
           isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
         }`}
         onClick={onClose}
@@ -69,7 +69,7 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
         aria-label="항목 상세 패널"
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
-        className={`fixed z-[60] bg-white shadow-2xl transition-transform duration-300 ease-in-out flex flex-col bottom-0 left-0 right-0 rounded-t-2xl h-[80vh] md:h-screen md:bottom-auto md:right-0 md:top-0 md:left-auto md:w-[520px] md:rounded-none md:rounded-l-2xl ${
+        className={`fixed z-[1010] bg-white shadow-2xl transition-transform duration-300 ease-in-out flex flex-col bottom-0 left-0 right-0 rounded-t-2xl h-[80vh] md:h-screen md:bottom-auto md:right-0 md:top-0 md:left-auto md:w-[520px] md:rounded-none md:rounded-l-2xl ${
           isOpen
             ? 'translate-y-0 md:translate-y-0 md:translate-x-0'
             : 'translate-y-full md:translate-y-0 md:translate-x-full'


### PR DESCRIPTION
## 변경 이유
지도 탭에서 마커 클릭 시 Leaflet 내부 레이어(마커 z-600, 팝업 z-700)가 root stacking context에서 패널의 z-index(60)보다 높아 패널이 지도 뒤에 가려졌습니다.

## 변경 범위
- `components/Panel/ItemPanel.tsx`
  - 백드롭: `z-[55]` → `z-[1000]`
  - 패널: `z-[60]` → `z-[1010]`

Leaflet 최대 z-index(700)보다 충분히 높은 값으로 설정해 지도·마커 레이어 위에 딤 오버레이와 패널이 올바르게 표시됩니다.

## 검증
- `npm run build` 통과

## 남은 작업 / 리스크
없음

Closes #43