### PR TITLE
Fix gmaps import and hydration mismatch

### DIFF
--- a/lib/hooks/useItems.ts
+++ b/lib/hooks/useItems.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import useSWR from 'swr'
 import { useToast } from '@/components/UI/Toast'
 import type { TripItem, Status } from '@/types'
@@ -13,18 +14,27 @@ const fetcher = (url: string) =>
 export type SyncStatus = 'fresh' | 'stale' | 'offline' | 'error'
 
 export function useItems() {
+  const [hasMounted, setHasMounted] = useState(false)
+
+  useEffect(() => {
+    setHasMounted(true)
+  }, [])
+
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ items: TripItem[] }>(
-    '/api/items',
+    hasMounted ? '/api/items' : null,
     fetcher
   )
   const { showToast } = useToast()
 
   const items = data?.items ?? []
+  const ready = hasMounted
+  const loading = !ready || isLoading
 
   const syncStatus: SyncStatus = (() => {
+    if (!ready) return 'fresh'
     if (typeof navigator !== 'undefined' && !navigator.onLine) return 'offline'
     if (error) return 'error'
-    if (isValidating && !isLoading) return 'stale'
+    if (isValidating && !loading) return 'stale'
     return 'fresh'
   })()
 
@@ -118,7 +128,7 @@ export function useItems() {
 
   return {
     items,
-    isLoading,
+    isLoading: loading,
     isValidating,
     syncStatus,
     error: error ?? null,

--- a/services/gmaps/fetcher.ts
+++ b/services/gmaps/fetcher.ts
@@ -66,6 +66,33 @@ export async function fetchListPage(listId: string): Promise<string> {
       )
     }
 
+    const entityListPath = extractEntityListPath(html)
+    if (!entityListPath) {
+      return html
+    }
+
+    const entityListUrl = new URL(entityListPath, 'https://www.google.com').toString()
+
+    const payloadResponse = await fetch(entityListUrl, {
+      method: 'GET',
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept-Language': 'ko-KR,ko;q=0.9,en;q=0.8',
+        Accept: '*/*',
+      },
+      signal: controller.signal,
+    })
+
+    if (!payloadResponse.ok) {
+      return html
+    }
+
+    const payload = await payloadResponse.text()
+    if (payload.trim()) {
+      return payload
+    }
+
     return html
   } catch (err) {
     if (err instanceof GmapsFetcherError) throw err
@@ -79,4 +106,11 @@ export async function fetchListPage(listId: string): Promise<string> {
   } finally {
     clearTimeout(timeout)
   }
+}
+
+function extractEntityListPath(html: string): string | null {
+  const match = html.match(/<link href="([^"]*\/maps\/preview\/entitylist\/getlist[^"]*)" as="fetch"/i)
+  if (!match) return null
+
+  return match[1].replace(/&amp;/g, '&')
 }

--- a/services/gmaps/parser.ts
+++ b/services/gmaps/parser.ts
@@ -113,6 +113,54 @@ interface RawPlace {
   types: string[]
 }
 
+function parseEntityListPayload(payload: unknown): RawPlace[] {
+  if (!Array.isArray(payload) || payload.length === 0) return []
+
+  const root = payload.find(node => Array.isArray(node) && node.length >= 9) as unknown[] | undefined
+  if (!root) return []
+
+  const entries = root[8]
+  if (!Array.isArray(entries)) return []
+
+  const places: RawPlace[] = []
+
+  for (const entry of entries) {
+    if (!Array.isArray(entry)) continue
+
+    const details = entry[1]
+    const name = entry[2]
+
+    if (!Array.isArray(details) || typeof name !== 'string' || !name.trim()) {
+      continue
+    }
+
+    const address =
+      typeof details[4] === 'string'
+        ? details[4]
+        : typeof details[2] === 'string'
+          ? details[2]
+          : null
+
+    const coords = Array.isArray(details[5]) ? extractCoordinateArray(details[5]) : null
+
+    const idArray = Array.isArray(details[6])
+      ? details[6].filter((value): value is string => typeof value === 'string')
+      : []
+    const pathId = typeof details[7] === 'string' ? details[7] : null
+
+    places.push({
+      name: name.trim(),
+      address,
+      lat: coords?.lat ?? null,
+      lng: coords?.lng ?? null,
+      placeId: pathId ?? (idArray.length > 0 ? idArray.join(':') : null),
+      types: [],
+    })
+  }
+
+  return places.filter(place => place.lat !== null && place.lng !== null)
+}
+
 /**
  * 파싱된 JSON 데이터에서 장소 목록을 추출한다.
  */
@@ -214,6 +262,24 @@ function extractPlacesFromData(data: unknown): RawPlace[] {
  * @throws GmapsParserError
  */
 export function parseListPage(html: string): GooglePlace[] {
+  if (html.trim().startsWith(")]}'")) {
+    try {
+      const entityListPlaces = parseEntityListPayload(stripXssiPrefix(html))
+      if (entityListPlaces.length > 0) {
+        return entityListPlaces.map(p => ({
+          name: p.name,
+          address: p.address,
+          lat: p.lat,
+          lng: p.lng,
+          googlePlaceId: p.placeId,
+          googleCategory: p.types[0] ?? null,
+        }))
+      }
+    } catch {
+      // Fall through to legacy HTML parser when the payload format does not match.
+    }
+  }
+
   const jsonCandidates = extractJsonFromHtml(html)
 
   if (jsonCandidates.length === 0) {

--- a/services/gmaps/resolver.ts
+++ b/services/gmaps/resolver.ts
@@ -17,30 +17,102 @@ export class GmapsResolverError extends Error {
  * HTTP redirect를 따라가며 최종 URL을 얻는다.
  */
 async function resolveShortUrl(shortUrl: string): Promise<string> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 5000)
+  const maxRedirects = 5
+  const timeoutMs = 5000
 
   try {
-    const response = await fetch(shortUrl, {
-      method: 'GET',
-      redirect: 'follow',
-      headers: {
-        'User-Agent':
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-      },
-      signal: controller.signal,
-    })
+    let finalUrl = await followRedirect(shortUrl, maxRedirects, timeoutMs)
 
-    const finalUrl = response.url
+    if (finalUrl === shortUrl) {
+      const curlResolvedUrl = await resolveShortUrlWithCurl(shortUrl, timeoutMs)
+      if (curlResolvedUrl) {
+        finalUrl = curlResolvedUrl
+      }
+    }
+
     return finalUrl
   } catch (err) {
     if ((err as Error).name === 'AbortError') {
       throw new GmapsResolverError('요청 시간이 초과되었습니다.', 'NETWORK_ERROR')
     }
     throw new GmapsResolverError('URL을 불러오는 중 오류가 발생했습니다.', 'NETWORK_ERROR')
-  } finally {
-    clearTimeout(timeout)
   }
+}
+
+async function resolveShortUrlWithCurl(shortUrl: string, timeoutMs: number): Promise<string | null> {
+  try {
+    const { execFile } = await import('node:child_process')
+
+    const effectiveUrl = await new Promise<string>((resolve, reject) => {
+      execFile(
+        'curl',
+        ['-Ls', '--max-time', String(Math.ceil(timeoutMs / 1000)), '-o', '/dev/null', '-w', '%{url_effective}', shortUrl],
+        (error, stdout) => {
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve(stdout.trim())
+        }
+      )
+    })
+
+    return effectiveUrl || null
+  } catch {
+    return null
+  }
+}
+
+function followRedirect(url: string, redirectsLeft: number, timeoutMs: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url)
+    // Use Node's builtin HTTP client directly. In this route, fetch() receives a
+    // durable deep-link HTML page instead of the 302 Location we need.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const http = require('node:http') as typeof import('node:http')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const https = require('node:https') as typeof import('node:https')
+    const client = parsed.protocol === 'https:' ? https : http
+    const request = client.request(
+      url,
+      {
+        method: 'GET',
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        },
+      },
+      response => {
+        response.resume()
+
+        const location = response.headers.location
+        const isRedirect =
+          response.statusCode !== undefined &&
+          response.statusCode >= 300 &&
+          response.statusCode < 400
+
+        if (isRedirect && location) {
+          if (redirectsLeft <= 0) {
+            reject(new Error('Too many redirects'))
+            return
+          }
+
+          const nextUrl = new URL(location, parsed).toString()
+          followRedirect(nextUrl, redirectsLeft - 1, timeoutMs).then(resolve).catch(reject)
+          return
+        }
+
+        resolve(url)
+      }
+    )
+
+    request.setTimeout(timeoutMs, () => {
+      request.destroy(new Error('AbortError'))
+    })
+
+    request.on('error', reject)
+    request.end()
+  })
 }
 
 /**
@@ -48,12 +120,21 @@ async function resolveShortUrl(shortUrl: string): Promise<string> {
  * 지원 형식:
  *   - /maps/placelists/list/[listId]
  *   - /maps/placelists/list/[listId]/...
+ *   - /maps/@/data=!...[!2s[listId]]...
  */
 export function extractListId(url: string): string | null {
   try {
     const parsed = new URL(url)
-    const match = parsed.pathname.match(/\/maps\/placelists\/list\/([^/?#]+)/)
-    if (match) return match[1]
+
+    const placelistMatch = parsed.pathname.match(/\/maps\/placelists\/list\/([^/?#]+)/)
+    if (placelistMatch) return placelistMatch[1]
+
+    // Newer shared list redirects often encode the list id in the path data payload:
+    // /maps/@/data=!3m1!...!2sLIST_ID!3e3
+    const dataPayload = `${parsed.pathname}${parsed.search}${parsed.hash}`
+    const dataMatch = dataPayload.match(/![12]s([^!/?#&]+)/)
+    if (dataMatch) return dataMatch[1]
+
     return null
   } catch {
     return null


### PR DESCRIPTION
## What changed

- Updated Google Maps list import to handle current short-link and payload formats.

- Fixed hydration mismatch on pages using useItems() by aligning the initial SSR and client render state.

## Why

Google changed its shared list URL and payload behavior, which broke imports. Separately, SWR was starting in a way that could produce different server and client initial markup.

## Validation
- npm run build










