### PR TITLE
feat: 카테고리/우선순위/예약상태 뱃지에 이모지 및 의미 색상 적용

### DIFF
--- a/components/Items/ItemCard.tsx
+++ b/components/Items/ItemCard.tsx
@@ -99,10 +99,9 @@ export default function ItemCard({ item, onSelect, isActive = false }: ItemCardP
     >
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2.5 min-w-0">
-          <span
-            className="w-3 h-3 rounded-full flex-shrink-0 ring-2 ring-white shadow-sm"
-            style={{ backgroundColor: CATEGORY_META[item.category]?.dot ?? '#D1D5DB' }}
-          />
+          <span className="flex-shrink-0 text-base leading-none">
+            {CATEGORY_META[item.category]?.emoji ?? '📌'}
+          </span>
           <div className="min-w-0">
             <div className="flex items-center gap-1.5">
               <span className="font-semibold text-gray-900 truncate text-sm">{item.name}</span>

--- a/components/Map/ResearchMap.tsx
+++ b/components/Map/ResearchMap.tsx
@@ -5,18 +5,24 @@ import L from 'leaflet'
 import type { TripItem } from '@/types'
 import { CATEGORY_META } from '@/lib/itemOptions'
 
-function createDotIcon(color: string) {
+function createEmojiChipIcon(emoji: string) {
   return L.divIcon({
     html: `<div style="
-      width:18px;height:18px;
-      border-radius:50%;
-      background:${color};
-      border:2.5px solid white;
-      box-shadow:0 1px 4px rgba(0,0,0,0.25);
-    "></div>`,
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      padding:2px 6px;
+      background:white;
+      border:1.5px solid #e2e8f0;
+      border-radius:9999px;
+      box-shadow:0 1px 4px rgba(0,0,0,0.15);
+      font-size:14px;
+      line-height:1;
+      white-space:nowrap;
+    ">${emoji}</div>`,
     className: '',
-    iconSize: [18, 18],
-    iconAnchor: [9, 9],
+    iconSize: [28, 24],
+    iconAnchor: [14, 12],
   })
 }
 
@@ -45,7 +51,7 @@ export default function ResearchMap({ items, onSelectItem }: ResearchMapProps) {
         <Marker
           key={item.id}
           position={[item.lat!, item.lng!]}
-          icon={createDotIcon(CATEGORY_META[item.category]?.dot ?? '#D1D5DB')}
+          icon={createEmojiChipIcon(CATEGORY_META[item.category]?.emoji ?? '📌')}
           eventHandlers={
             onSelectItem
               ? {

--- a/components/UI/ItemMetadataChips.tsx
+++ b/components/UI/ItemMetadataChips.tsx
@@ -1,5 +1,6 @@
 import type { TripItem } from '@/types'
 import {
+  CATEGORY_META,
   CHIP_TONE,
   ITEM_FIELD_LABELS,
   PLACEHOLDER_LABELS,
@@ -18,9 +19,10 @@ function PlaceholderChip({ label }: { label: string }) {
 
 function CategoryChip({ category }: { category: TripItem['category'] | undefined }) {
   if (!category) return <PlaceholderChip label={PLACEHOLDER_LABELS.category} />
+  const emoji = CATEGORY_META[category]?.emoji
   return (
-    <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${CHIP_TONE}`}>
-      {category}
+    <span className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium ${CHIP_TONE}`}>
+      {emoji} {category}
     </span>
   )
 }

--- a/components/UI/ReservationStatusBadge.tsx
+++ b/components/UI/ReservationStatusBadge.tsx
@@ -1,5 +1,5 @@
 import type { ReservationStatus } from '@/types'
-import { CHIP_TONE, normalizeReservationStatus } from '@/lib/itemOptions'
+import { RESERVATION_STATUS_META, normalizeReservationStatus } from '@/lib/itemOptions'
 
 export default function ReservationStatusBadge({
   reservationStatus,
@@ -7,11 +7,13 @@ export default function ReservationStatusBadge({
   reservationStatus: ReservationStatus
 }) {
   const normalized = normalizeReservationStatus(reservationStatus) ?? '확인 필요'
+  const meta = RESERVATION_STATUS_META[normalized]
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${CHIP_TONE}`}
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border"
+      style={meta.style}
     >
-      {normalized}
+      {meta.emoji} {normalized}
     </span>
   )
 }

--- a/components/UI/TripPriorityBadge.tsx
+++ b/components/UI/TripPriorityBadge.tsx
@@ -1,12 +1,14 @@
 import type { TripPriority } from '@/types'
-import { CHIP_TONE } from '@/lib/itemOptions'
+import { TRIP_PRIORITY_META } from '@/lib/itemOptions'
 
 export default function TripPriorityBadge({ tripPriority }: { tripPriority: TripPriority }) {
+  const meta = TRIP_PRIORITY_META[tripPriority]
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${CHIP_TONE}`}
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border"
+      style={meta.style}
     >
-      {tripPriority}
+      {meta.emoji} {tripPriority}
     </span>
   )
 }

--- a/lib/itemOptions.ts
+++ b/lib/itemOptions.ts
@@ -1,5 +1,13 @@
 import type { Category, ReservationStatus, TripItem, TripPriority } from '@/types'
 
+interface BadgeStyle {
+  background: string
+  color: string
+  borderColor: string
+  fontWeight?: number
+  textDecoration?: string
+}
+
 export const CATEGORY_OPTIONS: Category[] = [
   '교통',
   '숙박',
@@ -48,33 +56,33 @@ export const CHIP_BASE_TONE = 'bg-white border border-gray-200'
 export const CHIP_TONE = `${CHIP_BASE_TONE} text-gray-700`
 export const PLACEHOLDER_TONE = `${CHIP_BASE_TONE} text-gray-400`
 
-export const CATEGORY_META: Record<Category, { dot: string }> = {
-  교통: { dot: '#94A3B8' },
-  숙박: { dot: '#7DD3FC' },
-  명소: { dot: '#6EE7B7' },
-  식당: { dot: '#FB923C' },
-  카페: { dot: '#FDBA74' },
-  쇼핑: { dot: '#C4B5FD' },
-  문화시설: { dot: '#67E8F9' },
-  '공연·스포츠': { dot: '#F9A8D4' },
-  액티비티: { dot: '#86EFAC' },
-  휴양: { dot: '#5EEAD4' },
-  기타: { dot: '#FCD34D' },
+export const CATEGORY_META: Record<Category, { emoji: string }> = {
+  교통: { emoji: '🚌' },
+  숙박: { emoji: '🏨' },
+  명소: { emoji: '🏛️' },
+  식당: { emoji: '🍽️' },
+  카페: { emoji: '☕' },
+  쇼핑: { emoji: '🛍️' },
+  문화시설: { emoji: '🎨' },
+  '공연·스포츠': { emoji: '🎭' },
+  액티비티: { emoji: '🎯' },
+  휴양: { emoji: '🌴' },
+  기타: { emoji: '🔖' },
 }
 
-export const TRIP_PRIORITY_META: Record<TripPriority, { description: string; order: number }> = {
-  '검토 필요': { description: '아직 결정하지 않은 후보', order: 0 },
-  '시간 되면': { description: '여유가 있으면 가볼 곳', order: 1 },
-  '가고 싶음': { description: '꼭 가고 싶은 곳', order: 2 },
-  '확정': { description: '일정에 넣기로 결정', order: 3 },
-  '제외': { description: '이번 여행에서 제외', order: 4 },
+export const TRIP_PRIORITY_META: Record<TripPriority, { description: string; order: number; emoji: string; style: BadgeStyle }> = {
+  '검토 필요': { description: '아직 결정하지 않은 후보', order: 0, emoji: '🤔', style: { background: '#f8fafc', color: '#94a3b8', borderColor: '#e2e8f0' } },
+  '시간 되면': { description: '여유가 있으면 가볼 곳', order: 1, emoji: '⏳', style: { background: '#eff6ff', color: '#3b82f6', borderColor: '#bfdbfe' } },
+  '가고 싶음': { description: '꼭 가고 싶은 곳', order: 2, emoji: '⭐', style: { background: '#f5f3ff', color: '#7c3aed', borderColor: '#ddd6fe' } },
+  '확정': { description: '일정에 넣기로 결정', order: 3, emoji: '✅', style: { background: '#f0fdf4', color: '#16a34a', borderColor: '#bbf7d0', fontWeight: 600 } },
+  '제외': { description: '이번 여행에서 제외', order: 4, emoji: '❌', style: { background: '#f8fafc', color: '#cbd5e1', borderColor: '#e2e8f0', textDecoration: 'line-through' } },
 }
 
-export const RESERVATION_STATUS_META: Record<ReservationStatus, { description: string }> = {
-  '확인 필요': { description: '예약 필요 여부 미확정' },
-  불필요: { description: '예약 없이 진행 가능' },
-  '필요(미예약)': { description: '예약이 필요하지만 아직 안 함' },
-  예약완료: { description: '예약 완료' },
+export const RESERVATION_STATUS_META: Record<ReservationStatus, { description: string; emoji: string; style: BadgeStyle }> = {
+  '확인 필요': { description: '예약 필요 여부 미확정', emoji: '🔍', style: { background: '#fffbeb', color: '#d97706', borderColor: '#fde68a' } },
+  불필요: { description: '예약 없이 진행 가능', emoji: '🆓', style: { background: '#f8fafc', color: '#94a3b8', borderColor: '#e2e8f0' } },
+  '필요(미예약)': { description: '예약이 필요하지만 아직 안 함', emoji: '🔔', style: { background: '#fff7ed', color: '#ea580c', borderColor: '#fed7aa', fontWeight: 600 } },
+  예약완료: { description: '예약 완료', emoji: '✅', style: { background: '#f0fdf4', color: '#16a34a', borderColor: '#bbf7d0' } },
 }
 
 const LEGACY_CATEGORY_MAP: Record<string, Category> = {


### PR DESCRIPTION
## 변경 내용

- `lib/itemOptions.ts` — `CATEGORY_META`에 이모지 추가 (dot 색상 제거), `TRIP_PRIORITY_META` / `RESERVATION_STATUS_META`에 `emoji` + `style` 필드 추가
- `TripPriorityBadge`, `ReservationStatusBadge` — 이모지 prefix 및 값별 의미 색상(background/color/border) 적용
- `ItemMetadataChips` — `CategoryChip`에 이모지 prefix 추가
- `ItemCard` — 카드 헤더의 컬러 dot을 카테고리 이모지로 교체
- `ResearchMap` — 지도 마커를 컬러 dot에서 이모지 칩(흰 배경 pill)으로 교체

## 색상 정책

| 값 | 색상 의미 |
|---|---|
| 검토 필요 🤔 | 회색 (미결정) |
| 시간 되면 ⏳ | 파랑 (낮은 우선순위) |
| 가고 싶음 ⭐ | 보라 (관심) |
| 확정 ✅ | 초록 bold (완료) |
| 제외 ❌ | 회색 취소선 |
| 확인 필요 🔍 | 노랑 (주의) |
| 불필요 🆓 | 회색 (중립) |
| 필요(미예약) 🔔 | 주황 bold (긴박) |
| 예약완료 ✅ | 초록 (완료) |