### PR TITLE
feat: README.md 신규 작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# Trip Planner
+
+개인 여행을 위한 리서치·일정 통합 플래너 웹앱. 후보 장소 조사부터 확정 일정 관리까지 하나의 인터페이스에서 처리한다.
+
+## 주요 기능
+
+- **통합 항목 관리** — 리서치(후보) 및 일정(확정) 아이템을 하나의 테이블로 관리
+- **지도 시각화** — Leaflet 기반 지도에 핀 표시 및 카테고리별 색상 구분
+- **카테고리 / 우선순위 / 예약 상태 배지** — 이모지와 색상으로 한눈에 파악
+- **일정 뷰** — 날짜별 그룹, 시간순 정렬, 시작/종료 시간 표시
+- **Google Maps 가져오기** — 저장된 장소 목록을 앱에 일괄 임포트
+- **모바일 지원** — 맥북과 아이폰 브라우저 모두 동작
+
+## 기술 스택
+
+| 분류 | 기술 |
+|------|------|
+| 프레임워크 | Next.js 14 (App Router) |
+| UI | React 18, Tailwind CSS 3 |
+| 지도 | Leaflet, react-leaflet |
+| 데이터베이스 | Supabase (PostgreSQL) |
+| 데이터 패칭 | SWR |
+| 검색 | fuse.js |
+| 인증 | JWT (jose) |
+
+## 로컬 실행 방법
+
+### 1. 저장소 클론
+
+```bash
+git clone <repository-url>
+cd trip-planner
+```
+
+### 2. 의존성 설치
+
+```bash
+npm install
+```
+
+### 3. 환경 변수 설정
+
+```bash
+cp .env.example .env.local
+```
+
+`.env.local` 파일을 열어 아래 값을 채운다 (환경 변수 섹션 참고).
+
+### 4. 개발 서버 실행
+
+```bash
+npm run dev
+```
+
+브라우저에서 [http://localhost:3000](http://localhost:3000) 접속.
+
+## 환경 변수
+
+| 변수명 | 설명 | 값 취득 방법 |
+|--------|------|-------------|
+| `AUTH_ID` | 로그인 아이디 | 직접 설정 (임의 문자열) |
+| `AUTH_PASSWORD` | 로그인 비밀번호 | 직접 설정 (임의 문자열) |
+| `JWT_SECRET` | JWT 서명 키 | 직접 생성 (충분히 긴 랜덤 문자열) |
+| `SUPABASE_URL` | Supabase 프로젝트 URL | [Supabase 대시보드](https://supabase.com) → Project Settings → API |
+| `SUPABASE_PUBLISHABLE_KEY` | Supabase anon key | [Supabase 대시보드](https://supabase.com) → Project Settings → API |
+
+## 스크립트
+
+```bash
+npm run dev      # 개발 서버 실행 (http://localhost:3000)
+npm run build    # 프로덕션 빌드
+npm run start    # 프로덕션 서버 실행
+npm run lint     # 린트 실행
+```

--- a/specs/010-add-readme-docs/checklists/requirements.md
+++ b/specs/010-add-readme-docs/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: README 및 프로젝트 문서 추가
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- 모든 항목 통과. `/speckit.plan`으로 진행 가능.

--- a/specs/010-add-readme-docs/plan.md
+++ b/specs/010-add-readme-docs/plan.md
@@ -1,0 +1,57 @@
+# Implementation Plan: README 및 프로젝트 문서 추가
+
+**Branch**: `010-add-readme-docs` | **Date**: 2026-04-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/010-add-readme-docs/spec.md`
+
+## Summary
+
+저장소 루트에 `README.md`를 신규 작성한다. 프로젝트 한 줄 소개, 주요 기능 요약, 로컬 실행 방법, 환경 변수 설명, 기술 스택 정리를 포함한다. 이미 존재하는 `.env.example`과 내용을 일치시킨다.
+
+## Technical Context
+
+**Language/Version**: Markdown (표준)
+**Primary Dependencies**: N/A (문서 파일만 작성)
+**Storage**: N/A
+**Testing**: 직접 검토 (렌더링 확인, 명령 실행 확인)
+**Target Platform**: GitHub 저장소 루트 (README.md 자동 렌더링)
+**Project Type**: 문서
+**Performance Goals**: N/A
+**Constraints**: 간결하고 실용적인 수준 (개인/2인 프로젝트)
+**Scale/Scope**: README.md 파일 1개
+
+## Constitution Check
+
+constitution.md가 플레이스홀더 상태이므로 명시적 게이트 없음. 진행.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-add-readme-docs/
+├── plan.md              # 이 파일
+├── research.md          # Phase 0 산출물
+└── tasks.md             # /speckit.tasks 산출물
+```
+
+### Source Code (repository root)
+
+```text
+README.md                # 신규 작성
+```
+
+## Phase 0: Research
+
+→ `research.md` 참조
+
+## Phase 1: Design
+
+README.md 구조:
+1. 프로젝트 제목 + 한 줄 소개
+2. 주요 기능 (불릿 목록)
+3. 기술 스택
+4. 로컬 실행 방법 (단계별)
+5. 환경 변수 (테이블)
+
+인터페이스 계약: 해당 없음 (문서 전용)
+데이터 모델: 해당 없음

--- a/specs/010-add-readme-docs/research.md
+++ b/specs/010-add-readme-docs/research.md
@@ -1,0 +1,39 @@
+# Research: README 및 프로젝트 문서 추가
+
+## 프로젝트 파악
+
+- **앱 성격**: 개인(2인) 뉴욕 여행 플래너 웹앱
+- **주요 기능**: 리서치(후보 장소 조사) + 일정(확정 일정 관리)을 통합 항목 테이블로 관리. 지도 핀, 카테고리/우선순위/예약상태 배지.
+- **접근 방식**: 로컬 맥북 + ngrok으로 아이폰 접속 허용
+
+## 기술 스택 (package.json 기반)
+
+- Next.js 14.2.0 (App Router)
+- React 18.3.1
+- Tailwind CSS 3.x
+- Supabase (@supabase/supabase-js)
+- react-leaflet + Leaflet.js (지도)
+- SWR (데이터 캐싱)
+- fuse.js (퍼지 검색)
+- jose (JWT 인증)
+
+## 환경 변수 (.env.example 기반)
+
+| 변수명 | 설명 | 취득 방법 |
+|--------|------|-----------|
+| `AUTH_ID` | 로그인 아이디 | 직접 설정 |
+| `AUTH_PASSWORD` | 로그인 비밀번호 | 직접 설정 |
+| `JWT_SECRET` | JWT 서명 키 (충분히 긴 랜덤 문자열) | 직접 생성 |
+| `SUPABASE_URL` | Supabase 프로젝트 URL | Supabase 대시보드 → Project Settings → API |
+| `SUPABASE_PUBLISHABLE_KEY` | Supabase anon key | Supabase 대시보드 → Project Settings → API |
+
+## 실행 명령 (package.json scripts)
+
+- `npm install` — 의존성 설치
+- `npm run dev` — 개발 서버 (http://localhost:3000)
+- `npm run build` — 프로덕션 빌드
+- `npm run lint` — 린트
+
+## 결론
+
+추가 연구 불필요. README 작성에 필요한 모든 정보가 코드베이스에서 확인됨.

--- a/specs/010-add-readme-docs/spec.md
+++ b/specs/010-add-readme-docs/spec.md
@@ -1,0 +1,70 @@
+# Feature Specification: README 및 프로젝트 문서 추가
+
+**Feature Branch**: `010-add-readme-docs`
+**Created**: 2026-04-06
+**Status**: Draft
+**Input**: User description: "issue #37: README 및 프로젝트 문서 추가 — 현재 프로젝트에 README.md가 없음. 저장소에 처음 방문하면 프로젝트가 무엇인지 알 수 없음."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 저장소 방문자가 프로젝트 파악 (Priority: P1)
+
+저장소에 처음 방문한 사람(협업자, 미래의 자신)이 README.md를 읽고 이 프로젝트가 무엇인지, 어떻게 로컬에서 실행하는지 이해한다.
+
+**Why this priority**: README가 없으면 저장소의 첫인상이 완전히 없는 것과 마찬가지다. 이것 하나만 있어도 즉각적인 가치를 제공한다.
+
+**Independent Test**: README.md 파일을 GitHub에서 열어 프로젝트 소개, 기술 스택, 실행 방법, 환경 변수 섹션이 모두 존재하는지 확인한다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 저장소 루트에 README.md가 없는 상태에서, **When** README.md를 작성하면, **Then** GitHub 저장소 첫 페이지에 프로젝트 소개가 렌더링된다.
+2. **Given** README.md가 존재할 때, **When** 방문자가 "로컬 실행 방법" 섹션을 따라 명령을 실행하면, **Then** 개발 서버가 정상 기동된다.
+3. **Given** README.md가 존재할 때, **When** 방문자가 환경 변수 섹션을 읽으면, **Then** 어떤 변수가 필요하고 어디서 얻는지 알 수 있다.
+
+---
+
+### User Story 2 - 환경 변수 설정 가이드 확인 (Priority: P2)
+
+새로 프로젝트를 클론한 사람이 `.env.example` 파일과 README의 환경 변수 섹션을 참고해 `.env.local` 파일을 올바르게 작성한다.
+
+**Why this priority**: 환경 변수 설정 실패는 가장 흔한 "처음 실행" 장애물이다. 명확한 가이드가 있으면 진입 장벽을 낮출 수 있다.
+
+**Independent Test**: README의 환경 변수 섹션만 읽고 `.env.local` 파일을 작성할 수 있는지 확인한다.
+
+**Acceptance Scenarios**:
+
+1. **Given** `.env.example`과 README가 존재할 때, **When** 방문자가 각 변수 설명을 읽으면, **Then** 변수의 목적과 값을 얻는 방법(Supabase 대시보드 위치 등)을 이해한다.
+
+---
+
+### Edge Cases
+
+- README의 실행 방법 명령이 실제 package.json의 스크립트와 다를 경우 오류 발생 → 항상 실제 명령과 동기화한다.
+- 환경 변수 목록이 `.env.example`과 README 간에 불일치할 경우 혼란 발생 → 두 파일을 항상 일치시킨다.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 저장소 루트에 `README.md` 파일이 존재해야 한다.
+- **FR-002**: README에는 프로젝트 한 줄 소개(무엇을 위한 앱인지)가 포함되어야 한다.
+- **FR-003**: README에는 주요 기능 요약(최소 3개 이상)이 포함되어야 한다.
+- **FR-004**: README에는 로컬 실행 방법(`npm install` + `npm run dev`)이 단계별로 포함되어야 한다.
+- **FR-005**: README에는 필요한 환경 변수 목록과 각 변수의 설명 및 값 취득 방법이 포함되어야 한다.
+- **FR-006**: README에는 사용된 기술 스택(Next.js, React, Supabase, Tailwind CSS 등)이 간략히 정리되어야 한다.
+- **FR-007**: `.env.example` 파일이 루트에 존재하고 README의 환경 변수 목록과 일치해야 한다.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 저장소 루트에 README.md가 존재하고, GitHub에서 렌더링 시 모든 섹션(소개, 기능, 실행 방법, 환경 변수, 기술 스택)이 정상 표시된다.
+- **SC-002**: README의 실행 방법을 따라 명령을 입력하면 개발 서버가 오류 없이 기동된다.
+- **SC-003**: README의 환경 변수 섹션과 `.env.example` 파일의 변수 목록이 100% 일치한다.
+- **SC-004**: 프로젝트를 처음 보는 사람이 README만 읽고 5분 이내에 로컬 실행 환경을 구성할 수 있다.
+
+## Assumptions
+
+- 이 프로젝트는 개인(2인) 사용 목적의 여행 플래너 앱으로, README는 간결하고 실용적인 수준이면 충분하다.
+- 별도의 기여 가이드(CONTRIBUTING.md) 또는 라이선스 파일은 이 이슈의 범위에 포함되지 않는다.
+- `.env.example` 파일이 이미 존재하므로, 해당 파일의 변수를 기반으로 README를 작성한다.

--- a/specs/010-add-readme-docs/tasks.md
+++ b/specs/010-add-readme-docs/tasks.md
@@ -1,0 +1,89 @@
+# Tasks: README 및 프로젝트 문서 추가
+
+**Input**: Design documents from `/specs/010-add-readme-docs/`
+**Prerequisites**: plan.md, spec.md, research.md
+
+**Organization**: 단일 파일 작성 작업이므로 사용자 스토리 순서대로 구성
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 병렬 실행 가능
+- **[Story]**: 해당 사용자 스토리
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: 프로젝트 현황 파악
+
+- [x] T001 기존 `.env.example` 파일 내용 확인 (루트 경로)
+
+---
+
+## Phase 2: User Story 1 - 저장소 방문자가 프로젝트 파악 (Priority: P1) 🎯 MVP
+
+**Goal**: README.md 신규 작성 — 프로젝트 소개, 주요 기능, 기술 스택, 실행 방법, 환경 변수 포함
+
+**Independent Test**: `README.md` 파일이 루트에 존재하고 모든 필수 섹션(소개, 기능, 기술 스택, 실행 방법, 환경 변수)이 포함되어 있는지 확인
+
+- [x] T002 [US1] `README.md` 신규 작성 — 프로젝트 한 줄 소개 섹션 작성 (루트 경로)
+- [x] T003 [US1] `README.md` 주요 기능 섹션 작성 (리서치/일정 관리, 지도, 카테고리/우선순위/예약상태 배지 등)
+- [x] T004 [US1] `README.md` 기술 스택 섹션 작성 (Next.js, React, Supabase, Tailwind CSS, Leaflet, SWR 등)
+- [x] T005 [US1] `README.md` 로컬 실행 방법 섹션 작성 (클론 → 의존성 설치 → 환경 변수 → 실행)
+- [x] T006 [US1] `README.md` 환경 변수 섹션 작성 (`.env.example` 기반 테이블 형식)
+
+**Checkpoint**: README.md 완성 — 방문자가 프로젝트 파악 및 실행 가능
+
+---
+
+## Phase 3: User Story 2 - 환경 변수 설정 가이드 확인 (Priority: P2)
+
+**Goal**: `.env.example` 파일이 README의 환경 변수 섹션과 100% 일치하는지 검증 및 필요 시 업데이트
+
+**Independent Test**: README의 환경 변수 테이블 항목과 `.env.example` 변수 목록이 동일한지 대조
+
+- [x] T007 [US2] README 환경 변수 섹션과 `.env.example` 일치 여부 검증 및 필요 시 수정
+
+**Checkpoint**: 환경 변수 가이드 일관성 확보
+
+---
+
+## Phase 4: Polish
+
+**Purpose**: 최종 검토
+
+- [x] T008 README.md 전체 내용 검토 — 마크다운 렌더링, 링크, 들여쓰기, 오탈자 확인
+
+---
+
+## Dependencies & Execution Order
+
+- **Phase 1 (T001)**: 즉시 시작 가능
+- **Phase 2 (T002-T006)**: T001 이후 순차 실행 (모두 같은 파일 편집)
+- **Phase 3 (T007)**: T006 완료 후 실행
+- **Phase 4 (T008)**: 모든 단계 완료 후
+
+### Parallel Opportunities
+
+- T002-T006은 개념상 각각 다른 섹션이지만 동일 파일이므로 순차 실행 권장
+- T007은 T006과 독립적으로 시작 가능
+
+---
+
+## Implementation Strategy
+
+### MVP (User Story 1만)
+
+1. T001: `.env.example` 확인
+2. T002-T006: README.md 작성
+3. **STOP and VALIDATE**: 파일 존재 및 섹션 완비 확인
+4. T007-T008: 마무리
+
+---
+
+## Notes
+
+- README.md는 한국어/영어 혼용 가능 — 섹션 제목은 영어, 설명은 한국어로 작성
+- `.env.example`이 이미 존재하므로 새로 만들 필요 없음
+- 스크린샷/이미지는 이 이슈 범위에 포함되지 않음
+- CONTRIBUTING.md, LICENSE 등 추가 문서도 이 이슈 범위 밖


### PR DESCRIPTION
## 변경 이유

저장소에 README.md가 없어 처음 방문하는 사람이 프로젝트가 무엇인지 파악할 수 없었음 (Closes #37)

## 변경 범위

- `README.md` 신규 작성
  - 프로젝트 한 줄 소개
  - 주요 기능 요약 (통합 항목 관리, 지도 시각화, 배지, 일정 뷰, Google Maps 가져오기, 모바일 지원)
  - 기술 스택 테이블 (Next.js, React, Tailwind, Supabase, Leaflet, SWR, fuse.js, JWT)
  - 로컬 실행 방법 단계별 안내 (클론 → 설치 → 환경 변수 → 실행)
  - 환경 변수 테이블 (`.env.example`과 100% 일치)
  - 스크립트 목록

## 검증

- `npm run build` 통과
- `npm run lint` 통과 (ESLint 경고/에러 없음)
- README 환경 변수 5개와 `.env.example` 5개 일치 확인

## 남은 작업 / 리스크

없음