### PR TITLE
fix: 필터 활성 상태에서 아이템 편집 시 상세 모달이 즉시 닫히는 문제 수정

### DIFF
--- a/components/Items/ItemList.tsx
+++ b/components/Items/ItemList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo, useEffect, useRef } from 'react'
+import { useState, useMemo } from 'react'
 import Link from 'next/link'
 import type { Category, ReservationStatus, TripItem, TripPriority } from '@/types'
 import ItemCard from './ItemCard'
@@ -46,11 +46,6 @@ export default function ItemList({ items, selectedItemId, onSelectItem }: ItemLi
   const [query, setQuery] = useState('')
   const [sortKey, setSortKey] = useState<SortKey>('name')
   const [sortDir, setSortDir] = useState<SortDir>('asc')
-
-  const onSelectItemRef = useRef(onSelectItem)
-  useEffect(() => {
-    onSelectItemRef.current = onSelectItem
-  })
 
   const excludedCount = useMemo(() => items.filter(i => i.trip_priority === '제외').length, [items])
 
@@ -113,12 +108,6 @@ export default function ItemList({ items, selectedItemId, onSelectItem }: ItemLi
 
     return result
   }, [items, query, selCats, selTripPriorities, selReservationStatuses, showExcluded, sortDir, sortKey])
-
-  useEffect(() => {
-    if (selectedItemId && !filtered.some(i => i.id === selectedItemId)) {
-      onSelectItemRef.current(selectedItemId)
-    }
-  }, [filtered, selectedItemId])
 
   const SORT_OPTIONS: { key: SortKey; label: string }[] = [
     { key: 'name', label: '이름' },


### PR DESCRIPTION
## 변경 이유

리서치 목록에서 필터를 적용한 후 아이템 카드를 열어 상세 모달에서 값을 편집하면, 편집 결과가 필터 조건을 벗어나는 순간 모달이 즉시 닫히는 UX 문제가 있었다.

예) "검토 필요" 필터 → 아이템 선택 → 상태를 "가고 싶음"으로 변경 → 모달 닫힘

## 변경 범위

- `components/Items/ItemList.tsx`
  - `selectedItemId`가 `filtered` 배열에 없을 때 `onSelectItem`을 호출해 모달을 닫던 `useEffect` 제거
  - 이 `useEffect`에서만 사용하던 `onSelectItemRef` / 관련 import (`useEffect`, `useRef`) 함께 제거

## 검증

- `npm run build` 성공 (타입 오류 없음)
- 재현 시나리오: 필터 적용 → 아이템 선택 → 모달에서 상태 변경 → 모달이 유지됨을 확인 (카드는 목록에서 사라지나 모달은 그대로)

## 남은 작업 / 리스크

- 이제 사용자가 필터 칩을 직접 변경해도 이미 열린 모달은 닫히지 않는다. 이는 오히려 더 자연스러운 동작으로 판단하며, 별도 이슈가 필요하면 후속 처리한다.