### PR TITLE
fix: 모바일 항목 추가 폼에서 저장 버튼이 하단 네비에 가려지는 문제 수정

### DIFF
--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -180,7 +180,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
   const labelClass = 'block text-sm font-medium text-gray-700 mb-1'
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-8 pb-28 md:pb-8">
+    <form onSubmit={handleSubmit} className="space-y-8 pb-36 md:pb-8">
       <section className="space-y-4">
         <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">기본 정보</h2>
 
@@ -292,7 +292,10 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
 
       {error && <p className="text-sm text-red-500">{error}</p>}
 
-      <div className="fixed bottom-0 left-0 right-0 md:static bg-white/95 backdrop-blur border-t md:border-t-0 px-4 py-3 md:px-0 md:py-0">
+      <div
+        className="fixed left-0 right-0 md:static bg-white/95 backdrop-blur border-t md:border-t-0 px-4 py-3 md:px-0 md:py-0 z-40"
+        style={{ bottom: 'calc(3.5rem + env(safe-area-inset-bottom))' }}
+      >
         <div className="max-w-lg mx-auto md:max-w-none flex gap-3">
           {mode === 'edit' && (
             <button type="button" onClick={handleDelete} disabled={loading} className="px-4 py-2.5 rounded-lg text-sm font-medium text-red-500 border border-red-200 hover:bg-red-50 transition-colors">


### PR DESCRIPTION
## 변경 이유
모바일에서 항목 추가(/items/new) 페이지 진입 시 저장 버튼 바(`fixed bottom-0`)가 하단 네비게이션(`fixed bottom-0 z-50`)과 같은 위치에 렌더링되어, z-index가 높은 네비게이션에 의해 저장 버튼이 완전히 가려지는 문제가 있었습니다.

## 변경 범위
- `components/Items/ItemForm.tsx`
  - 저장 버튼 바 위치를 `bottom-0`에서 `calc(3.5rem + env(safe-area-inset-bottom))`으로 변경하여 네비게이션 높이(~56px) + safe-area만큼 위에 표시되도록 수정
  - 폼 하단 패딩을 `pb-28` → `pb-36`으로 확장하여 버튼 바 + 네비 두 레이어 + safe-area를 모두 수용

## 검증
- `npm run build` 통과
- 모바일 레이아웃: 저장 버튼 바가 네비게이션 위에 표시됨
- 데스크탑: `md:static` 으로 고정 포지셔닝이 해제되어 기존과 동일하게 동작

## 남은 작업 / 리스크
없음