### PR TITLE
security: RLS 활성화 및 service role key로 전환

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,4 @@ JWT_SECRET=change_me_to_a_long_random_string
 
 # Supabase (https://supabase.com → Project Settings → API)
 SUPABASE_URL=https://your-project-id.supabase.co
-SUPABASE_PUBLISHABLE_KEY=your-publishable-key
+SUPABASE_SERVICE_KEY=your-service-role-key

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ AUTH_PASSWORD=your_password
 # JWT 서명 키 (충분히 긴 랜덤 문자열 사용)
 JWT_SECRET=change_me_to_a_long_random_string
 
-# Supabase (https://supabase.com → Project Settings → API)
+# Supabase (https://supabase.com → )
+# - Supabase - Project Settings - General settings -> Project ID
 SUPABASE_URL=https://your-project-id.supabase.co
+# - Supabase - Project Settings → API -> Service Role Key(Secret keys)
 SUPABASE_SERVICE_KEY=your-service-role-key

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# supabase
+supabase/.temp/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -9,9 +9,9 @@ import {
 
 function getSupabaseClient() {
   const url = process.env.SUPABASE_URL
-  const key = process.env.SUPABASE_PUBLISHABLE_KEY
+  const key = process.env.SUPABASE_SERVICE_KEY
   if (!url || !key) {
-    throw new Error('SUPABASE_URL and SUPABASE_PUBLISHABLE_KEY must be set')
+    throw new Error('SUPABASE_URL and SUPABASE_SERVICE_KEY must be set')
   }
   return createClient(url, key)
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -24,5 +24,6 @@ create table public.items (
   updated_at       text        not null
 );
 
--- Row Level Security 비활성화 (서버사이드에서만 접근)
-alter table public.items disable row level security;
+-- Row Level Security 활성화 (서버사이드에서 service role key로만 접근)
+-- service role key는 RLS를 우회하므로 별도 정책 없이도 서버에서 정상 동작
+alter table public.items enable row level security;


### PR DESCRIPTION
## Summary

- `public.items` 테이블 RLS 활성화 — anon key로 Supabase에 직접 접근 차단
- 서버 Supabase 클라이언트를 `SUPABASE_PUBLISHABLE_KEY` → `SUPABASE_SERVICE_KEY`로 전환
- service role key는 RLS를 우회하므로 기존 API routes 동작에 영향 없음

## 배포 전 필수 작업

- [x] `.env.local`에 `SUPABASE_SERVICE_KEY` 추가
- [x] Vercel 환경변수에 `SUPABASE_SERVICE_KEY` 추가
- [x] Supabase SQL Editor에서 실행: `alter table public.items enable row level security;`