### PR TITLE
feat: 폼 유효성 검사 UX 개선 — 인라인 에러 표시

### DIFF
--- a/app/api/items/[id]/route.ts
+++ b/app/api/items/[id]/route.ts
@@ -26,7 +26,7 @@ function validatePartial(body: Record<string, unknown>): string | null {
   ) {
     return '유효하지 않은 reservation_status입니다.'
   }
-  if (body.budget !== undefined && (typeof body.budget !== 'number' || body.budget < 0)) {
+  if (body.budget !== undefined && body.budget !== null && (typeof body.budget !== 'number' || body.budget < 0)) {
     return 'budget은 0 이상의 숫자여야 합니다.'
   }
   if (

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -27,7 +27,7 @@ function validateItem(body: Record<string, unknown>): string | null {
   ) {
     return '유효하지 않은 reservation_status입니다.'
   }
-  if (body.budget !== undefined && (typeof body.budget !== 'number' || body.budget < 0)) {
+  if (body.budget !== undefined && body.budget !== null && (typeof body.budget !== 'number' || body.budget < 0)) {
     return 'budget은 0 이상의 숫자여야 합니다.'
   }
   if (body.date !== undefined && !/^\d{4}-\d{2}-\d{2}$/.test(body.date as string)) {

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -14,10 +14,10 @@ function validateItem(body: Record<string, unknown>): string | null {
   if (!body.name || typeof body.name !== 'string' || !body.name.trim()) {
     return 'name은 필수입니다.'
   }
-  if (!CATEGORY_OPTIONS.includes(body.category as Category)) {
+  if (body.category !== undefined && !CATEGORY_OPTIONS.includes(body.category as Category)) {
     return '유효하지 않은 category입니다.'
   }
-  if (!TRIP_PRIORITY_OPTIONS.includes(body.trip_priority as TripPriority)) {
+  if (body.trip_priority !== undefined && !TRIP_PRIORITY_OPTIONS.includes(body.trip_priority as TripPriority)) {
     return '유효하지 않은 trip_priority입니다.'
   }
   if (
@@ -103,8 +103,8 @@ export async function POST(request: NextRequest) {
   const item: TripItem = {
     id: uuidv4(),
     name: (body.name as string).trim(),
-    category: body.category as Category,
-    trip_priority: body.trip_priority as TripPriority,
+    category: (body.category as Category | undefined) ?? '기타',
+    trip_priority: (body.trip_priority as TripPriority | undefined) ?? '검토 필요',
     reservation_status: (body.reservation_status as ReservationStatus | null | undefined) ?? null,
     links: (body.links as Link[]) ?? [],
     created_at: now,

--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -57,11 +57,13 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
     time_end: initialData?.time_end ?? '',
     links: initialData?.links ?? [],
   })
+  const [nameError, setNameError] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
   const [geocoding, setGeocoding] = useState(false)
   const [geocodeError, setGeocodeError] = useState('')
   const memoRef = useRef<HTMLTextAreaElement>(null)
+  const nameRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     const el = memoRef.current
@@ -71,6 +73,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
   }, [form.memo])
 
   function setField<K extends keyof FormData>(key: K, value: FormData[K]) {
+    if (key === 'name') setNameError('')
     setForm(prev => ({ ...prev, [key]: value }))
   }
 
@@ -108,6 +111,12 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    if (!form.name.trim()) {
+      setNameError('이름을 입력해야 저장할 수 있어요')
+      nameRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      nameRef.current?.focus()
+      return
+    }
     setLoading(true)
     setError('')
 
@@ -186,12 +195,20 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
 
         <div>
           <label className={labelClass}>이름 *</label>
-          <input type="text" value={form.name} onChange={e => setField('name', e.target.value)} className={inputClass} placeholder="장소 또는 활동 이름" required />
+          <input
+            ref={nameRef}
+            type="text"
+            value={form.name}
+            onChange={e => setField('name', e.target.value)}
+            className={`${inputClass}${nameError ? ' border-red-400 focus:ring-red-200' : ''}`}
+            placeholder="장소 또는 활동 이름"
+          />
+          {nameError && <p className="text-xs text-red-500 mt-1">{nameError}</p>}
         </div>
 
-        <SelectField label={`${ITEM_FIELD_LABELS.category} *`} value={form.category} onChange={value => setField('category', value as Category)} options={CATEGORY_OPTIONS.map(value => ({ value, label: value }))} />
-        <SelectField label={`${ITEM_FIELD_LABELS.trip_priority} *`} value={form.trip_priority} onChange={value => setField('trip_priority', value as TripPriority)} options={TRIP_PRIORITY_OPTIONS.map(value => ({ value, label: `${value} - ${TRIP_PRIORITY_META[value].description}` }))} />
-        <SelectField label={`${ITEM_FIELD_LABELS.reservation_status} *`} value={form.reservation_status} onChange={value => setField('reservation_status', value as ReservationStatus)} options={RESERVATION_STATUS_OPTIONS.map(value => ({ value, label: `${value} - ${RESERVATION_STATUS_META[value].description}` }))} />
+        <SelectField label={ITEM_FIELD_LABELS.category} value={form.category} onChange={value => setField('category', value as Category)} options={CATEGORY_OPTIONS.map(value => ({ value, label: value }))} />
+        <SelectField label={ITEM_FIELD_LABELS.trip_priority} value={form.trip_priority} onChange={value => setField('trip_priority', value as TripPriority)} options={TRIP_PRIORITY_OPTIONS.map(value => ({ value, label: `${value} - ${TRIP_PRIORITY_META[value].description}` }))} />
+        <SelectField label={ITEM_FIELD_LABELS.reservation_status} value={form.reservation_status} onChange={value => setField('reservation_status', value as ReservationStatus)} options={RESERVATION_STATUS_OPTIONS.map(value => ({ value, label: `${value} - ${RESERVATION_STATUS_META[value].description}` }))} />
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div className="space-y-3">

--- a/components/Panel/PanelItemForm.tsx
+++ b/components/Panel/PanelItemForm.tsx
@@ -56,9 +56,11 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
     time_end: item.time_end ?? '',
     links: item.links ?? [],
   })
+  const [nameError, setNameError] = useState('')
   const [geocoding, setGeocoding] = useState(false)
   const [geocodeError, setGeocodeError] = useState('')
   const memoRef = useRef<HTMLTextAreaElement>(null)
+  const nameRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     const el = memoRef.current
@@ -88,6 +90,7 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
   }, [form, item, onDirtyChange])
 
   function setField<K extends keyof FormData>(key: K, value: FormData[K]) {
+    if (key === 'name') setNameError('')
     setForm(prev => ({ ...prev, [key]: value }))
   }
 
@@ -113,6 +116,12 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    if (!form.name.trim()) {
+      setNameError('이름을 입력해야 저장할 수 있어요')
+      nameRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      nameRef.current?.focus()
+      return
+    }
     const trimmedAddress = form.address.trim()
     const changes: Record<string, unknown> = {
       name: form.name,
@@ -153,12 +162,21 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
       <div className="flex-1 overflow-y-auto min-h-0 px-5 py-4 space-y-6">
         <section className="space-y-4">
           <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">기본 정보</h3>
-          <Field label="이름 *">
-            <input type="text" value={form.name} onChange={e => setField('name', e.target.value)} className={inputClass} placeholder="장소 또는 활동 이름" required />
-          </Field>
-          <SelectField label={`${ITEM_FIELD_LABELS.category} *`} value={form.category} onChange={value => setField('category', value as Category)} options={CATEGORY_OPTIONS.map(value => ({ value, label: value }))} />
-          <SelectField label={`${ITEM_FIELD_LABELS.trip_priority} *`} value={form.trip_priority} onChange={value => setField('trip_priority', value as TripPriority)} options={TRIP_PRIORITY_OPTIONS.map(value => ({ value, label: `${value} - ${TRIP_PRIORITY_META[value].description}` }))} />
-          <SelectField label={`${ITEM_FIELD_LABELS.reservation_status} *`} value={form.reservation_status} onChange={value => setField('reservation_status', value as ReservationStatus)} options={RESERVATION_STATUS_OPTIONS.map(value => ({ value, label: `${value} - ${RESERVATION_STATUS_META[value].description}` }))} />
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">이름 *</label>
+            <input
+              ref={nameRef}
+              type="text"
+              value={form.name}
+              onChange={e => setField('name', e.target.value)}
+              className={`${inputClass}${nameError ? ' border-red-400 focus:ring-red-200' : ''}`}
+              placeholder="장소 또는 활동 이름"
+            />
+            {nameError && <p className="text-xs text-red-500 mt-1">{nameError}</p>}
+          </div>
+          <SelectField label={ITEM_FIELD_LABELS.category} value={form.category} onChange={value => setField('category', value as Category)} options={CATEGORY_OPTIONS.map(value => ({ value, label: value }))} />
+          <SelectField label={ITEM_FIELD_LABELS.trip_priority} value={form.trip_priority} onChange={value => setField('trip_priority', value as TripPriority)} options={TRIP_PRIORITY_OPTIONS.map(value => ({ value, label: `${value} - ${TRIP_PRIORITY_META[value].description}` }))} />
+          <SelectField label={ITEM_FIELD_LABELS.reservation_status} value={form.reservation_status} onChange={value => setField('reservation_status', value as ReservationStatus)} options={RESERVATION_STATUS_OPTIONS.map(value => ({ value, label: `${value} - ${RESERVATION_STATUS_META[value].description}` }))} />
         </section>
 
         <section className="space-y-3">
@@ -251,7 +269,10 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
         </section>
       </div>
 
-      <div className="flex-shrink-0 px-5 py-3 border-t border-gray-100">
+      <div className="flex-shrink-0 px-5 py-3 border-t border-gray-100 space-y-2">
+        {nameError && (
+          <p className="text-xs text-red-500">{nameError}</p>
+        )}
         <div className="flex gap-3">
           <button type="button" onClick={onCancel} className="px-4 py-2.5 rounded-lg text-sm font-medium text-gray-600 border border-gray-200 hover:bg-gray-50 transition-colors">
             취소

--- a/supabase/migration_add_column_defaults.sql
+++ b/supabase/migration_add_column_defaults.sql
@@ -1,0 +1,8 @@
+-- category, status(=trip_priority) 컬럼에 DEFAULT 추가
+-- Supabase SQL Editor에서 실행하세요.
+
+alter table public.items
+  alter column category set default '기타';
+
+alter table public.items
+  alter column status set default '검토 필요';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3,8 +3,8 @@
 create table public.items (
   id          text        primary key,
   name        text        not null,
-  category    text        not null,
-  status      text        not null,
+  category    text        not null default '기타',
+  status      text        not null default '검토 필요',
   reservation_status text,
   priority    text,
   address     text,


### PR DESCRIPTION
## 변경 사항

### 클라이언트 폼 UX
- \`name\` 하나만 필수 필드로 지정 (기존: name + category + trip_priority + reservation_status)
- \`category\`, \`trip_priority\`, \`reservation_status\`는 기본값으로 자동 처리되므로 필수 표시(\`*\`) 제거
- 저장 시 name이 비어있으면 서버 요청 없이 즉시 클라이언트에서 검증 실패 처리
- 에러 발생 시 동작:
  - name 입력창 하단에 인라인 에러 메시지 표시
  - 입력창 테두리를 빨간색으로 강조
  - 해당 필드로 자동 스크롤 및 포커스 이동
- name을 입력하기 시작하면 에러 즉시 해제
- \`PanelItemForm\`(사이드 패널)도 동일한 방식으로 통일 — 패널 하단 footer에도 에러 메시지 표시

### API 서버
- \`POST /api/items\`: \`category\`/\`trip_priority\` 미전송 시 기본값(\`'기타'\`, \`'검토 필요'\`)으로 폴백 — 기존에는 두 필드가 없으면 400 에러
- \`validateItem\` / \`validatePartial\`: \`category\`/\`trip_priority\`는 값이 있을 때만 유효성 검사하도록 변경

### 버그 수정
- 사이드 패널에서 예산을 비우고 저장하면 실패하던 문제 수정
  - \`PanelItemForm\`은 예산 삭제 시 \`budget: null\`을 전송하는데, \`validatePartial\`이 \`null\`을 \`undefined\`와 구분하지 않아 \`typeof null !== 'number'\` 조건에 걸려 400 에러 발생
  - \`date\`/\`time_start\` 등 다른 nullable 필드처럼 \`budget !== null\` 조건 추가

### DB
- \`supabase/schema.sql\`: \`category\`, \`status\` 컬럼에 \`DEFAULT\` 값 추가
- \`supabase/migration_add_column_defaults.sql\`: 기존 DB에 적용할 \`ALTER TABLE\` 구문 추가

## 영향 범위

- \`components/Items/ItemForm.tsx\` — 신규 생성/편집 페이지 폼
- \`components/Panel/PanelItemForm.tsx\` — 리서치/스케줄 화면 사이드 패널 폼
- \`app/api/items/route.ts\` — POST 검증 및 기본값 처리
- \`app/api/items/[id]/route.ts\` — PUT 검증 (budget null 허용)
- \`supabase/schema.sql\`, \`supabase/migration_add_column_defaults.sql\`