### PR TITLE
fix: 인라인 테이블뷰 드롭다운 선택이 적용되지 않는 버그 수정

### DIFF
--- a/app/api/items/[id]/route.ts
+++ b/app/api/items/[id]/route.ts
@@ -80,12 +80,6 @@ function validatePartial(body: Record<string, unknown>): string | null {
   ) {
     return 'time_end는 HH:MM 형식이어야 합니다.'
   }
-  if (body.time_start !== undefined && body.time_start !== null && !body.date) {
-    return 'time_start를 입력하려면 시작 날짜가 필요합니다.'
-  }
-  if (body.time_end !== undefined && body.time_end !== null && !body.end_date) {
-    return 'time_end를 입력하려면 종료 날짜가 필요합니다.'
-  }
   return null
 }
 
@@ -117,6 +111,13 @@ export async function PUT(request: NextRequest, { params }: RouteContext) {
     id: items[idx].id,
     created_at: items[idx].created_at,
     updated_at: new Date().toISOString(),
+  }
+
+  if (updated.time_start && !updated.date) {
+    return NextResponse.json({ error: 'time_start를 입력하려면 시작 날짜가 필요합니다.' }, { status: 400 })
+  }
+  if (updated.time_end && !updated.end_date) {
+    return NextResponse.json({ error: 'time_end를 입력하려면 종료 날짜가 필요합니다.' }, { status: 400 })
   }
 
   items[idx] = updated

--- a/components/Research/ResearchTable.tsx
+++ b/components/Research/ResearchTable.tsx
@@ -133,7 +133,8 @@ export default function ResearchTable({
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
-      if ((e.target as HTMLElement).closest('[data-research-row]')) return
+      const target = e.target as HTMLElement
+      if (target.closest('[data-portal]') || target.closest('[data-research-row]')) return
       setEditingCell(null)
     }
     document.addEventListener('mousedown', handleClick)

--- a/components/Schedule/ScheduleTable.tsx
+++ b/components/Schedule/ScheduleTable.tsx
@@ -241,7 +241,10 @@ export default function ScheduleTable({
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
-      if ((e.target as HTMLElement).closest('[data-schedule-row]')) return
+      const target = e.target as HTMLElement
+      // data-portal 요소(포털 드롭다운)와 data-schedule-row 내부 클릭은 무시한다.
+      // 포털은 DOM 트리상 data-schedule-row 밖에 있지만 편집 셀을 닫아선 안 된다.
+      if (target.closest('[data-portal]') || target.closest('[data-schedule-row]')) return
       setEditingCell(null)
     }
     document.addEventListener('mousedown', handleClick)

--- a/components/Schedule/cells/CategoryCell.tsx
+++ b/components/Schedule/cells/CategoryCell.tsx
@@ -69,6 +69,7 @@ export default function CategoryCell({
         createPortal(
           <div
             ref={dropdownRef}
+            data-portal="true"
             className="fixed z-[1200] rounded-xl border border-gray-200 bg-white shadow-lg p-2"
             style={{ top: position.top, left: position.left }}
           >

--- a/components/Schedule/cells/PriorityCell.tsx
+++ b/components/Schedule/cells/PriorityCell.tsx
@@ -73,6 +73,7 @@ export default function PriorityCell({
         createPortal(
           <div
             ref={dropdownRef}
+            data-portal="true"
             className="fixed z-[1200] rounded-xl border border-gray-200 bg-white shadow-lg p-1 w-52"
             style={{ top: position.top, left: position.left }}
           >

--- a/components/Schedule/cells/StatusCell.tsx
+++ b/components/Schedule/cells/StatusCell.tsx
@@ -87,6 +87,7 @@ export default function StatusCell({
         createPortal(
           <div
             ref={dropdownRef}
+            data-portal="true"
             className="fixed z-[1200] rounded-xl border border-gray-200 bg-white shadow-lg p-1 w-44"
             style={{ top: position.top, left: position.left }}
           >

--- a/lib/hooks/useItems.ts
+++ b/lib/hooks/useItems.ts
@@ -15,15 +15,7 @@ const fetcher = (url: string) =>
 export type SyncStatus = 'fresh' | 'stale' | 'offline' | 'error'
 
 function applyItemChanges(item: TripItem, changes: Record<string, unknown>): TripItem {
-  const next: Record<string, unknown> = { ...item }
-  Object.entries(changes).forEach(([key, value]) => {
-    if (value === null) {
-      delete next[key]
-      return
-    }
-    next[key] = value
-  })
-  return normalizeTripItem(next as unknown as TripItem).item
+  return normalizeTripItem({ ...item, ...changes } as TripItem).item
 }
 
 export function useItems() {


### PR DESCRIPTION
## 근본 원인

`ScheduleTable` / `ResearchTable`의 document-level `mousedown` 핸들러가 포털 드롭다운 내부 클릭을 **외부 클릭으로 오인**하여 `setEditingCell(null)`을 호출하는 것이 핵심 원인입니다.

포털(`createPortal`)은 `document.body`에 직접 붙기 때문에 `[data-schedule-row]` 밖에 있습니다. React가 해당 상태 업데이트를 `click` 이벤트보다 먼저 커밋하면 포털 DOM이 언마운트되고, 분리된 노드에서 발생하는 `click` 이벤트는 React 이벤트 위임에 도달하지 못해 `onSelect` 콜백이 호출되지 않습니다.

## 변경 사항

### 버그 수정 (주요)
- **`ScheduleTable.tsx`, `ResearchTable.tsx`**: `mousedown` 핸들러가 `[data-portal]` 요소 내부 클릭은 `setEditingCell(null)` 호출을 건너뜀
- **`StatusCell.tsx`, `CategoryCell.tsx`, `PriorityCell.tsx`**: 포털 컨테이너에 `data-portal="true"` 속성 추가

### 관련 잠재 버그 수정
- **`useItems.ts` — `applyItemChanges`**: `null` 값에 대해 key를 삭제하는 대신 스프레드 연산으로 단순화. `normalizeTripItem`이 `undefined` 대신 `null`을 수신해 optimistic update 정확성 개선
- **`app/api/items/[id]/route.ts`**: `time_start` / `time_end` 교차 필드 검증을 `body`가 아닌 **병합된 아이템** 기준으로 이동. 날짜가 이미 있는 아이템에서 시간만 수정할 때 PUT 요청이 잘못 거부되던 버그 수정

## 테스트 포인트

- [ ] 일정 뷰 테이블에서 예약상태 드롭다운 선택 → 값이 저장됨
- [ ] 일정 뷰 테이블에서 카테고리 드롭다운 선택 → 값이 저장됨
- [ ] 전체 뷰 테이블에서 우선순위 드롭다운 선택 → 값이 저장됨
- [ ] 예약상태를 없음으로 변경 → null로 저장됨
- [ ] 날짜가 있는 아이템의 시작 시간 수정 → 정상 저장됨