### PR TITLE
fix: QA 2026-04 Full Pass — 6개 버그 수정 (BUG-001~005, BUG-009)

### DIFF
--- a/.qa/2026-04-full-pass/charter.md
+++ b/.qa/2026-04-full-pass/charter.md
@@ -1,0 +1,297 @@
+# Full QA 캠페인 Charter — trip-planner / 2026-04-full-pass
+
+> 한 번의 캠페인으로 trip-planner의 모든 기능을 훑어 결함을 제거하고, 한 closeout 보고서로 종결한다.
+> AI 4 역할(기능 조사·결함 조사·결함 수정·리포트), 사람은 트리아지 게이트만 책임진다.
+
+## 0. 캠페인 메타
+
+- **프로젝트**: trip-planner (개인용 여행 리서치·일정 통합 플래너)
+- **캠페인 ID**: `2026-04-full-pass`
+- **시작일**: 2026-04-27
+- **목표 종료일**: 2026-05-11 (약 2주)
+- **베이스 브랜치**: `main` (커밋 `774a86e` 기준)
+- **테스트 환경**:
+  - 로컬: `npm run dev` → http://localhost:3000
+  - DB: Supabase (테스트 환경 연동, 실 데이터 — 사용자가 별도 백업 보유)
+  - 데이터 정책: **가급적 데이터를 보존하며 QA**한다. 다만 데이터가 날아가도 캠페인 차단 사유는 아님 (백업으로 복원 가능).
+  - 인증: `AUTH_ID` / `AUTH_PASSWORD` / `JWT_SECRET` (`.env.local`)
+- **타겟 디바이스**:
+  - Desktop: 1440px 이상 (MacBook Safari·Chrome)
+  - Mobile: iPhone Safari (375-430px), 가로/세로
+- **AI 모델 운용**: 각 역할은 별도 세션. Fixer ↔ 2차 점검은 컨텍스트가 다른 세션이어야 한다. 모델은 역할·작업 난이도에 따라 자동 선택 — §9 가이드.
+
+## 1. 스코프
+
+### 인 스코프 (모두 검증)
+
+| 영역 | 표면 | 비고 |
+|---|---|---|
+| **인증** | 로그인 폼, JWT 미들웨어, 만료/리다이렉트 | `app/login`, `middleware.ts`, `app/api/auth` |
+| **항목 관리** | CRUD, 카테고리/우선순위/예약 상태 배지, 메모 | `app/items`, `components/Items/*`, `app/api/items` |
+| **리서치 뷰** | 후보 항목 리스트 + 지도, 핀 클릭 ↔ 리스트 동기 | `app/research`, `components/Research`, `components/Map/ResearchMap.tsx` |
+| **일정 뷰** | 날짜별 그룹·시간순 정렬, 시작/종료 시간, 인라인 편집, 모바일 카드 | `app/schedule`, `components/Schedule/*` |
+| **지도** | Leaflet 핀, 카테고리 색상, 줌·팬, 모바일 제스처 | `components/Map/*` |
+| **검색·필터** | 이름/주소/메모 검색(fuse.js), 모바일 바텀시트 필터, 정렬 | 014/079/013 스펙 영역 |
+| **Google Maps Import** | 저장 장소 일괄 임포트, `google_place_id` 중복 검사 | `app/gmaps-import`, `app/api/gmaps`, `app/api/geocode` |
+| **네비게이션** | 탭 구조, 기기별 뷰 전환, URL 보존 | 014 스펙 |
+| **데이터 캐싱** | SWR 캐시·재검증, localStorage 캐시 | 005 스펙 |
+| **체인 그룹핑** | 같은 그룹 항목 묶음 표시 | 011 스펙 |
+
+### 아웃 스코프
+
+- 다중 사용자/다중 여행 지원 (메모리 노트: 2026-07 이후 별도 트랙)
+- 새 기능 추가, 디자인 리뉴얼
+- Supabase 스키마 마이그레이션 (단, 결함 수정에 필수 시 별도 PR로 분리)
+- 대용량(1000+ 항목) 부하 테스트 — 본 캠페인은 100 항목 규모까지만 검증
+- E2E 자동화 도입 — closeout의 "다음 트랙 입력"으로 시드만 남김
+
+## 2. 검증 차원 (Discovery 매트릭스 축)
+
+각 `F-XXX` × 차원 셀에서 최소 1회 결함 시도.
+
+1. **기능 정확성** — 명세대로 동작하는가
+2. **반응형/뷰포트** — 데스크톱 ↔ 모바일 (375 / 768 / 1440px), 가로 회전
+3. **상태/엣지** — 빈 상태, 단일 항목, 대량(50+), 잘못된 입력, 좌표 미존재
+4. **데이터 정합성** — 새로고침 후 일치, SWR 재검증, 동시 편집, 캐시 stale
+5. **인증·권한** — 비로그인 접근, JWT 만료, 라우트 가드
+6. **네트워크 실패** — Supabase 오프라인, 5xx, 느린 응답
+7. **상호작용** — 키보드 탐색, 포커스 트랩, 터치 제스처, 드래그
+8. **i18n/문구** — 한국어 라벨 일관성, 시간대(KST), 날짜 포맷
+9. **접근성** — 라벨, role, 색 대비 (스폿 체크 — 깊게 X)
+10. **성능 체감** — 초기 로드, 지도 렌더, 대량 항목 스크롤 (계측 도구 X, 체감만)
+
+## 3. 종료 조건
+
+### 단계별 게이트
+
+- **AI ① 기능 조사 종료** — `features.md`에 화면 트리의 80% 이상 등재 + 마지막 1세션 동안 신규 기능 0건.
+- **AI ② 결함 조사 종료** — (기능 × 차원) 매트릭스의 80% 이상 셀에 1회 이상 시도 기록 + 마지막 1세션 동안 새 critical 0건 + 새 major ≤2건.
+- **사람 트리아지 종료** — 모든 BUG-ID에 라벨 부여, cluster 확정, fix-now 캡 준수.
+- **AI ③ 결함 수정 종료** — fix-now 100% PR 작성·머지·verification(2회 fail은 reopen 후 재트리아지로 반환).
+- **AI ④ 리포트 종료** — `closeout.md` 5섹션 완성, `improvements.md`/`known-issues.md` 정리.
+
+### Fix-now 라벨링 — 캠페인 핵심 가치: "제품 사용 체감 개선"
+
+수치 캡 대신 **체감 영향**으로 트리아지한다. 각 BUG에 아래 3축을 1-3 점수로 매겨 합산.
+
+| 축 | 1점 | 2점 | 3점 |
+|---|---|---|---|
+| **마주칠 빈도** | 특정 조건에서 가끔 | 자주 쓰는 화면에서 종종 | 핵심 플로우에서 매번 |
+| **마주쳤을 때 짜증** | 알아채기 힘듦 / 작은 위화감 | 흐름이 끊김 / 다시 입력 | 데이터 손실 / 오해 / 막힘 |
+| **우회 난이도** | 무의식적으로 우회 가능 | 의식해야 우회 가능 | 우회 방법 없음 |
+
+- **합 7-9** → `fix-now` (체감을 분명히 흐리는 결함)
+- **합 5-6** → `fix-now` 후보, cluster에 묶이면 같이 처리. 단독이면 `accept` 가능.
+- **합 3-4** → `accept` (known-issue로 기록) 또는 `out-of-scope`.
+
+수치는 트리아지 단계 가이드일 뿐 절대 캡은 아님 — 사용자 체감을 흐리는 결함은 수가 많아도 처리한다. 반대로 점수가 높아도 캠페인 스코프 밖이면 `out-of-scope`.
+
+## 4. 디렉터리 / 산출물
+
+```
+.qa/2026-04-full-pass/
+├── charter.md           # ← 이 파일
+├── features.md          # AI ①
+├── discovery.md         # AI ② (append-only)
+├── triage.md            # 사람 게이트
+├── fixes/               # AI ③
+│   ├── BUG-XXX.md
+│   └── cluster-Cn.md
+├── known-issues.md      # accept 라벨 모음
+├── improvements.md      # 캠페인 외부로 분리한 구조 개선 후보
+└── closeout.md          # AI ④
+```
+
+## 5. 4 역할 실행 가이드
+
+### 역할 ① 기능 조사 (Feature Investigator)
+
+**세션 부팅 프롬프트 (요약)**:
+> 너는 trip-planner를 처음 보는 사용자다. 결함 평가는 하지 말고 동작하는 기능의 지도를 그려라. `npm run dev` 후 `/login`부터 시작해 모든 라우트(`/research`, `/items`, `/schedule`, `/gmaps-import`, `/map`)와 컴포넌트 진입점을 클릭해 본다. 각 발견 단위를 `features.md`에 템플릿대로 추가한다. 코드 읽기는 동작이 모호할 때만 보조로 쓴다.
+
+**권한**: 읽기 전용. 수정 권한 없음. 테스트 데이터 추가는 가능(후처리에서 정리).
+
+**출발 시드 (라우트)**:
+- `/login`
+- `/research` (리서치 항목 + 지도)
+- `/items` (테이블, 인라인 편집, 검색·필터·정렬)
+- `/schedule` (날짜 그룹, 모바일 카드, 인라인 편집)
+- `/map` (전체 지도)
+- `/gmaps-import` (장소 임포트)
+
+**검증 디바이스**: 데스크톱 1440px + 모바일 에뮬 375px 두 모드 모두 훑기.
+
+**종료 신호**: charter §3 게이트 도달 → assistant가 "Phase 1 done"을 본문에 명시하고 PR 없이 종료.
+
+### 역할 ② 결함 조사 (Defect Investigator)
+
+**세션 부팅 프롬프트 (요약)**:
+> 입력은 `features.md`. 각 F-XXX × charter §2의 검증 차원 셀에서 최소 1회 결함을 시도한다. 발견 시 `discovery.md`에 append-only로 기록(스키마는 charter §6). 회의적으로 본다 — `confidence`를 정직하게 매기고, 같은 root cause로 묶일 후보는 `cluster_hint`에 적는다. 수정은 절대 하지 않는다.
+
+**권한**: 읽기 전용 (코드, 앱 동작, 네트워크 패널). DB 직접 수정 금지.
+
+**중점 시나리오 (charter §2를 trip-planner 맥락으로 구체화)**:
+- **인증**: 비로그인 직접 URL 진입, JWT 만료 후 SWR 재검증, 잘못된 비밀번호 N회.
+- **데이터 정합성**: 데스크톱·모바일 두 탭 동시 편집, SWR `mutate` 누락, localStorage stale 후 새로고침.
+- **모바일**: 바텀시트 ↔ 드롭다운 전환, 카드 인라인 편집 후 키보드 닫힘 동작, 가로 회전, 안전영역(notch).
+- **지도**: 좌표 누락 항목, 동일 좌표 핀 겹침, 지도 ↔ 리스트 선택 동기, 카테고리 색상.
+- **임포트**: 동일 `google_place_id` 재임포트, 좌표 없는 입력, 지오코딩 실패.
+- **테이블**: 정렬·필터·검색 조합, 인라인 편집 중 다른 행 클릭, 빈 결과 상태.
+- **체인 그룹핑**: 그룹 해체·재형성, 그룹 내 일부만 시간 변경.
+
+### 사람 게이트: 트리아지
+
+- 입력: `discovery.md` (AI는 `label_candidate`와 한 줄 근거를 미리 제출).
+- 출력: `triage.md` (라벨·cluster·root cause 가설·fix 우선순위).
+- 사람 책임: 라벨 확정, cluster 머지, 캡 적용, PR 머지 승인.
+
+### 역할 ③ 결함 수정 (Defect Fixer)
+
+**세션 부팅 프롬프트 (요약)**:
+> 입력은 `triage.md`. 각 fix-now 또는 cluster마다 `fixes/<id>.md` 노트를 먼저 작성(root cause·strategy·regression test·collateral). PR은 strategy에 따라 분리(direct / tidy_then_fix / structural). 같은 cluster 다중 BUG는 1 PR + 본문에 BUG-ID 전부 링크. PR 본문 5필수 줄 누락 금지. 머지 전 별도 컨텍스트 AI에 4질문 점검을 받아 결과를 노트에 첨부.
+
+**권한**: 소스 수정, 회귀 테스트 추가, 마이그레이션 SQL(필요 시 supabase/), PR 생성. **머지는 사람이 한다.**
+
+**trip-planner 특화 가드레일**:
+- **Tidy 범위 제한**: cluster가 만지는 영역만. 예) `components/Schedule/cells/*`만 정리. `components/Items/*`로 번지면 `improvements.md`로 분리.
+- **회귀 테스트 부재**: 현재 자동화 스위트가 없으므로, 회귀는 (a) 재현 시나리오를 `fixes/<id>.md`에 절차로 적고 (b) 가능하면 단위/통합 테스트의 첫 케이스를 추가한다 — 그 자체가 closeout의 "자동화 시드".
+- **Supabase 스키마 변경**: 동작 변경 PR과 분리. 구조 PR은 변경 전후 동일 reproduction이 깨지지 않음을 입증.
+- **모바일 회귀**: 모든 fix는 데스크톱 + 모바일 에뮬 둘 다에서 통과해야 verification `pass`.
+- **차단 사유 외 hotfix 금지**: 수정 중 신규 발견 → `discovery.md`에 append.
+
+**머지 직전 2차 점검 4질문** (별도 세션에 PR diff + BUG 노트 + fix 노트 전달):
+1. root cause가 증상이 아닌 원인 수준인가?
+2. 회귀 시나리오/테스트가 BUG를 실제로 재현하는가?
+3. Strategy가 적절한가? (`direct`로 충분한데 부풀거나, 반대로 `direct`로 덮어 root cause가 남지 않았는가?)
+4. 구조 변경 PR이 동작 변경을 포함하지 않았는가?
+
+**검증 절차** (각 머지 fix별):
+- BUG의 reproduction 그대로 재실행 → `pass`/`fail`/`blocked` 기록.
+- cluster의 인접 화면 1-2개 sanity check (예: schedule cluster면 research 뷰도 확인).
+- 핵심 happy path 1회 통주행: 로그인 → 항목 추가 → 일정 배치 → 지도 확인 → 검색.
+- `fail` 1회 → `BUG-<ID>-r2`로 reopen, 1회 재진입. 2회 fail → 트리아지 반환.
+
+### 역할 ④ 리포트 작성 (Reporter)
+
+**세션 부팅 프롬프트 (요약)**:
+> 인풋은 `features.md`, `discovery.md`, `triage.md`, `fixes/*`, 머지된 PR 목록, verification 결과. `closeout.md`를 charter §6의 5섹션 스키마로 작성한다. 숫자(발견·머지·테스트·잔여)는 산출물에서 직접 카운트. cluster별 strategy 분포(direct/tidy/structural 비율)와 root cause 패턴은 closeout의 핵심 가치이므로 빠뜨리지 말 것. before/after는 charter의 핵심 happy path 통주행 결과를 기준으로.
+
+**권한**: 읽기 전용 + `closeout.md`/`known-issues.md`/`improvements.md` 작성.
+
+## 6. 산출물 스키마 (4 역할 공통 템플릿)
+
+### `features.md` 항목
+
+```yaml
+id: F-001
+name: 로그인
+area: 인증
+user_flow: /login → 자격증명 입력 → /research 리다이렉트
+inputs: AUTH_ID, AUTH_PASSWORD
+states: 빈 폼, 검증 중, 실패, 성공
+permissions: 비로그인 진입 가능
+dependencies: app/api/auth, JWT_SECRET, middleware.ts
+observed_behavior: 성공 시 토큰 쿠키, /research로 이동
+spec_reference: specs/001-trip-planner-mvp/spec.md
+uncertainty: 만료 시 리다이렉트 시점이 SWR 재검증과 충돌하는지 미확인
+```
+
+### `discovery.md` 항목
+
+```yaml
+id: BUG-001
+feature_ref: F-007
+title: 일정 카드 인라인 편집 중 다른 카드 탭하면 변경값이 사라짐
+area: schedule / mobile
+severity: major
+confidence: confirmed
+reproduction:
+  - /schedule (모바일 375px)
+  - 카드 A 시간 셀 탭 → 편집 모드 진입
+  - 편집값 입력 (저장 안 함)
+  - 카드 B의 임의 영역 탭
+  - 카드 A로 돌아옴
+expected: A의 편집값이 저장되어 있거나 명시적 confirm 다이얼로그
+actual: A의 변경값이 사라지고 원래 값 표시
+reproduction_rate: 5/5
+environment: iPhone 14 Safari emul, 375x812, main@774a86e
+evidence: screenshots/BUG-001/*.png
+cluster_hint: 인라인 편집 dirty state 미보존 (C? — 테이블뷰 #83 fix와 같은 root cause 가능)
+assumption: 편집 자동저장이 명시 스펙은 아니나 #83에서 동일 의도로 수정됨
+label_candidate: fix-now (major + 빈도 높음)
+```
+
+### `triage.md` 항목
+
+```yaml
+id: BUG-001
+label: fix-now
+cluster: C1
+cluster_root_cause: 인라인 편집 컴포넌트가 blur/외부 클릭 이벤트를 onSave로 연결하지 않고 onCancel로 처리
+priority: P1
+notes: BUG-004, BUG-009도 같은 cluster — 한 번에 처리
+```
+
+### `fixes/<id>.md` 항목
+
+```yaml
+summary: 인라인 편집 dirty state를 외부 클릭 시 자동 저장
+root_cause: useInlineEdit 훅의 onClickOutside가 항상 cancel을 호출 — schedule cell과 table row의 #83 fix와 동일 패턴이지만 모바일 카드는 누락
+fix_strategy: tidy_then_fix
+change_scope:
+  - tidy: components/common/useInlineEdit.ts (훅 추출)
+  - fix: components/Schedule/cells/*, components/Items/* (훅 사용)
+regression_test:
+  - 시나리오: BUG-001/BUG-004/BUG-009 reproduction 그대로
+  - 자동화 시드: __tests__/useInlineEdit.test.ts (신규)
+collateral_impact: 테이블 뷰(#83)에 동일 훅 적용 — 동작 동일 확인
+prs:
+  - tidy: #PR-A
+  - fix: #PR-B
+verification:
+  - BUG-001: pass (모바일·데스크톱)
+  - BUG-004: pass
+  - BUG-009: pass
+  - happy path: pass
+ai_review:
+  reviewer_session: opus-4-7-fresh-context
+  q1: pass — root cause는 onClickOutside 핸들러 수준
+  q2: pass — 단위 테스트가 BUG-001 시나리오 재현
+  q3: pass — direct는 부족, structural은 과대, tidy_then_fix가 적절
+  q4: pass — tidy PR diff에 동작 변경 없음 (기존 테스트 통과)
+```
+
+## 7. 위험 / 가정
+
+- **테스트 환경 + 백업 보유**: 데이터가 날아가도 캠페인 차단 사유는 아님. 단 가급적 보존 — 결함 조사·수정 시 "복구 불가능한 대량 삭제"는 사람 확인 후 수행.
+- **자동화 부재**: 회귀 테스트는 수동 시나리오 + 신규 단위 테스트로만 보장. closeout에서 자동화 시드를 명시.
+- **모바일 실기기 검증 한계**: 주로 에뮬레이터(Chrome DevTools / Safari Responsive Design) 사용. 체감 영향 7점 이상 결함은 실기기 1회 확인 권장.
+- **AI ② 거짓 양성**: confidence가 hypothesis인 항목은 사람 트리아지에서 1차 필터링.
+- **2차 점검 AI 동질성**: Fixer와 Reviewer가 같은 모델/프롬프트라면 review distance가 약함 → 다른 세션 + 다른 컨텍스트(diff·노트만 전달, charter 미전달). 가능하면 모델군도 다르게(§9).
+
+## 8. AI 모델 자동 선택 가이드
+
+각 세션을 부팅할 때 아래 표를 따른다. 작업이 시작된 뒤 난이도가 달라지면 모델을 바꾼다.
+
+| 역할 / 작업 | 권장 모델 | 이유 |
+|---|---|---|
+| **AI ① 기능 조사** | Sonnet (latest) | 광범위 탐색·도구 호출 다수, 추론 깊이보다 커버리지·속도가 중요. |
+| **AI ② 결함 조사 (1차 패스)** | Sonnet (latest) | 매트릭스 셀을 빠르게 훑으며 가설을 쌓는 단계. |
+| **AI ② 결함 조사 (어려운 셀 / 정합성·인증·캐시)** | Opus | SWR·JWT·동시 편집처럼 상태 추론이 깊어야 하는 셀은 Opus로 승격. |
+| **AI ③ 결함 수정 — direct strategy** | Sonnet (latest) | 단일 컴포넌트 수정 + 회귀 시나리오 작성 수준. |
+| **AI ③ 결함 수정 — tidy_then_fix / structural** | Opus | 추출·재배치·root cause 분리 판단이 필요한 케이스. |
+| **2차 점검 (4질문)** | Opus, **다른 세션** | review distance가 핵심 — Fixer가 Sonnet이었으면 점검은 반드시 Opus. Fixer가 Opus였으면 점검은 다른 컨텍스트의 Opus 또는 Sonnet. |
+| **AI ④ 리포트** | Sonnet (latest) | 산출물 종합·카운트·요약은 Sonnet으로 충분. |
+
+**휴리스틱**:
+- "이 결함이 왜 일어났는지 한 줄 root cause를 못 쓰겠다" → Opus로 승격.
+- "코드 한 곳만 바꾸면 끝" → Sonnet 유지.
+- 토큰·속도 비용은 캠페인 가치 대비 미미하므로 의심되면 Opus.
+
+## 9. 다음 트랙으로 흘려보낼 자산
+
+- **자동화 시드**: `fixes/*/regression_test.자동화 시드` 항목을 모아 별도 트랙에 PR 큐로 전환.
+- **회귀 영역 우선순위**: cluster별 root cause 패턴 → 가장 큰 cluster가 만진 모듈을 모니터링 1순위.
+- **모니터링 시드**: `known-issues.md`의 사용자 가시 known-issue → 향후 알림/Sentry 시드.
+- **`improvements.md`**: 캠페인이 손대지 않은 구조 개선 후보 → 다음 캠페인 입력 또는 별도 리팩토링 트랙.
+- **`features.md`**: 살아있는 제품 명세의 1차 시드 → README/CLAUDE.md 보강 입력.

--- a/.qa/2026-04-full-pass/discovery.md
+++ b/.qa/2026-04-full-pass/discovery.md
@@ -1,0 +1,266 @@
+# discovery.md — trip-planner 결함 조사
+> AI ② Defect Investigator 산출물. append-only.
+> 생성일: 2026-04-27
+> 방법: 정적 코드 분석 (모든 주요 컴포넌트·API 라우트·훅 읽기)
+
+---
+
+```yaml
+id: BUG-001
+feature_ref: F-021
+title: 모바일 일정뷰 새 항목 추가 — Enter 키 누르면 API 400 에러로 저장 실패
+area: schedule / mobile
+severity: major
+confidence: confirmed
+reproduction:
+  - /research 또는 /schedule (모바일 375px)
+  - "일정" 탭 선택
+  - 날짜 그룹의 "+ 항목 추가" 버튼 탭
+  - 이름 입력 (예: "센트럴파크")
+  - Enter 키 입력
+expected: 해당 날짜에 항목이 생성됨
+actual: 에러 토스트 "추가에 실패했습니다." 표시, 항목 생성 안 됨. blur(탭 아웃)는 정상 동작.
+reproduction_rate: 5/5 (코드로 확인, 모든 날짜 그룹에서 발생)
+environment: 모바일 뷰포트 (md 미만), ScheduleTable.tsx
+evidence: |
+  ScheduleTable.tsx:334-365 renderMobileGroupRows 내
+  onKeyDown={handleNewItemKeyDown}  // ← 직접 전달 (closure 아님)
+  
+  MobileNewItemEditor.tsx (컴포넌트 내부):
+  onKeyDown={e => onKeyDown(e, value)}  // value = 입력된 텍스트
+
+  handleNewItemKeyDown(e, date): // date 파라미터가 실제로 inputValue를 받음
+    if (e.key === 'Enter') handleNewItemBlur(date)  // date = "센트럴파크" (wrong!)
+
+  결과: onCreateItem({ date: "센트럴파크" }) → API POST date 형식 검증 실패 → 400
+
+  vs 데스크탑(정상): onKeyDown={e => handleNewItemKeyDown(e, date)} // 올바른 closure
+cluster_hint: 단독 버그. 데스크탑은 closure로 올바르게 처리, 모바일만 누락.
+assumption: 없음
+label_candidate: fix-now (체감 점수 8/9 — 모바일에서 Enter가 항상 실패하므로 빈도 높음)
+```
+
+---
+
+```yaml
+id: BUG-002
+feature_ref: F-009
+title: ResearchTable 인라인 편집 — Escape 키로 취소 시 빈 이름으로 항목이 생성될 수 있음
+area: research / desktop
+severity: major
+confidence: hypothesis
+reproduction:
+  - /research 데스크톱 뷰
+  - 테이블 하단 "+ 항목 추가…" 클릭
+  - 이름 입력 (예: "카페 오름")
+  - Escape 키 입력 (취소 의도)
+expected: 아무것도 생성 안 됨
+actual: (가설) Escape 후 입력창 언마운트 시점에 blur 이벤트가 구 클로저(newItemName='카페 오름')로 발화 → 항목 생성될 수 있음
+reproduction_rate: 불확실 (React 18 batching 동작에 의존)
+environment: ResearchTable.tsx desktop, handleNewItemKeyDown+handleNewItemBlur
+evidence: |
+  handleNewItemKeyDown Escape 처리:
+    setAddingRow(false)   // state batch
+    setNewItemName('')    // state batch → 아직 적용 전
+
+  input 언마운트 시 blur fires with OLD closure (newItemName = '카페 오름')
+  handleNewItemBlur() → name = '카페 오름' → onCreateItem 호출
+
+  ScheduleTable도 동일 패턴 (renderDesktopGroupRows addingToDate 처리)
+cluster_hint: C1 — 새 항목 추가 취소 버그. BUG-002/BUG-003 같은 root cause.
+assumption: React 18이 언마운트 시 blur를 구 클로저로 호출한다는 가정
+label_candidate: fix-now (실제 발생 시 데이터 오염)
+```
+
+---
+
+```yaml
+id: BUG-003
+feature_ref: F-021
+title: ScheduleTable 데스크탑 새 항목 추가 — Escape 취소 시 동일한 spurious 생성 가능성
+area: schedule / desktop
+severity: major
+confidence: hypothesis
+reproduction:
+  - /research 또는 /schedule 데스크탑
+  - "일정" 탭 선택
+  - 날짜 그룹 "+ 항목 추가" 클릭
+  - 이름 입력 → Escape 취소
+expected: 아무것도 생성 안 됨
+actual: (가설) BUG-002와 동일 메커니즘으로 항목 생성 가능
+reproduction_rate: 불확실
+environment: ScheduleTable.tsx renderDesktopGroupRows, handleNewItemKeyDown
+evidence: BUG-002와 동일 패턴
+cluster_hint: C1 — BUG-002와 동일 cluster
+assumption: BUG-002와 동일
+label_candidate: fix-now (C1 클러스터 전체 처리)
+```
+
+---
+
+```yaml
+id: BUG-004
+feature_ref: F-009 F-022
+title: CategoryCell/StatusCell 드롭다운이 뷰포트 오른쪽 밖으로 넘침
+area: research / schedule / desktop
+severity: minor
+confidence: confirmed
+reproduction:
+  - /research 데스크톱 (1024px 이하 좁은 뷰포트)
+  - ResearchTable 또는 ScheduleTable의 예약상태(StatusCell) 셀 클릭
+  - 드롭다운 열림 → 오른쪽이 뷰포트 밖으로 잘림
+expected: 드롭다운이 뷰포트 내에 뒤집혀(flipped) 표시
+actual: 드롭다운이 버튼 왼쪽에서 시작해 오른쪽으로 넘침
+reproduction_rate: 뷰포트 폭이 좁을수록 발생 빈도 높음
+environment: CategoryCell.tsx, StatusCell.tsx
+evidence: |
+  StatusCell.tsx:47 setPosition({ top: rect.bottom + 4, left: rect.left })
+  — right-edge 체크 없음
+
+  MetadataDropdownChip(ItemPanel)은 올바르게 처리:
+  const left = rect.left + width > window.innerWidth
+    ? Math.max(0, rect.right - width)
+    : rect.left
+cluster_hint: C2 — 드롭다운 포지셔닝. CategoryCell/StatusCell/PriorityCell 동일 패턴.
+assumption: 없음
+label_candidate: fix-now (체감 점수 6/9 — 클러스터 처리)
+```
+
+---
+
+```yaml
+id: BUG-005
+feature_ref: F-009
+title: PriorityCell도 동일한 뷰포트 overflow 미처리
+area: research / desktop
+severity: minor
+confidence: confirmed
+reproduction: BUG-004와 동일 (우선순위 드롭다운)
+expected: 드롭다운 뷰포트 내 표시
+actual: 오른쪽 overflow 가능
+reproduction_rate: 좁은 뷰포트에서 발생
+environment: PriorityCell.tsx (CategoryCell과 동일 구조 예상)
+evidence: CategoryCell/StatusCell 동일 패턴. PriorityCell도 동일 구조이므로 동일 버그 존재.
+cluster_hint: C2 — BUG-004와 동일 cluster
+assumption: PriorityCell이 동일 setPosition 패턴을 따른다는 가정 (코드 확인 필요)
+label_candidate: fix-now (C2 클러스터)
+```
+
+---
+
+```yaml
+id: BUG-006
+feature_ref: F-010 F-032
+title: ItemDetailView — 저장 실패 시 date/budget/time/address/memo 필드가 실패한 값을 표시
+area: panel / view mode
+severity: minor
+confidence: confirmed
+reproduction:
+  - ItemPanel에서 날짜 필드 클릭 → 새 날짜 입력 → 포커스 이동 (저장 시도)
+  - 동시에 네트워크를 끊음 (오프라인)
+  - → SWR rollback으로 item.date 원래 값 복원됨
+  - → 패널 날짜 표시 필드가 여전히 변경 시도한 값을 보여줌
+expected: SWR rollback 후 원래 값으로 표시
+actual: vals 상태가 reset되지 않아 시도한 값이 표시됨 (item.name 등은 item.name을 직접 표시하므로 OK)
+reproduction_rate: 네트워크 실패 시에만 발생 (저빈도)
+environment: ItemPanel.tsx ItemDetailView, commit(), vals state
+evidence: |
+  ItemDetailView.useEffect([item.id]) - item.id 변경 시에만 vals reset
+  date/budget/time/address/memo 뷰 모드는 vals를 표시:
+    <span>{vals.date || '날짜 선택'}</span>
+  name은 item.name 직접 표시 (영향 없음)
+cluster_hint: 단독. 빈도 낮아 accept 후보.
+assumption: 없음
+label_candidate: accept (빈도 낮고 에러 토스트 + 재시도로 인지 가능)
+```
+
+---
+
+```yaml
+id: BUG-007
+feature_ref: F-040
+title: writeItems가 단일 항목 수정 시에도 전체 테이블을 fetch+upsert — 동시 수정 race condition
+area: 데이터 / API
+severity: minor
+confidence: confirmed
+reproduction:
+  - 두 탭에서 같은 항목을 빠르게 연속 수정
+  - 첫 번째 수정 결과가 두 번째 수정에 의해 덮어씌워짐
+expected: 각 수정이 독립적으로 저장
+actual: writeItems는 전체 items 배열을 fetch+upsert → 동시 요청 시 race condition으로 먼저 온 수정이 사라질 수 있음
+reproduction_rate: 빠른 연속 수정에서만 발생 (단일 사용자 앱 특성상 저빈도)
+environment: lib/data.ts writeItems
+evidence: |
+  writeItems: fetchAll → compute diff → deleteMany + upsertAll
+  두 동시 PUT이 동일 snapshot을 읽으면 뒤에 끝난 쪽이 앞의 변경을 덮어씀
+cluster_hint: 단독. 아키텍처 수준 issue.
+assumption: 없음
+label_candidate: accept (단일 사용자 앱, 동시 편집 시나리오 현실적으로 드묾)
+```
+
+---
+
+```yaml
+id: BUG-008
+feature_ref: F-025
+title: ResearchMap — '제외' 우선순위 항목만 지도에서 제외, 좌표 없는 항목은 핀 없이 무언급
+area: 지도
+severity: trivial
+confidence: confirmed
+reproduction:
+  - 좌표 없는 항목(lat/lng undefined) 있는 상태에서 /map 접속
+  - 해당 항목에 대한 "지도에 표시 안 됨" 안내 없음
+expected: 사용자가 좌표 없는 항목이 지도에 표시 안 된다는 것을 인지
+actual: 단순히 표시 안 됨 (안내 없음)
+reproduction_rate: 좌표 없는 항목이 있을 때마다 발생
+environment: ResearchMap.tsx:35
+evidence: |
+  mapItems = items.filter(item => item.trip_priority !== '제외' && item.lat !== undefined && item.lng !== undefined)
+  — 필터링만 하고 제외된 항목 수 표시 없음
+cluster_hint: 단독
+assumption: 없음
+label_candidate: accept (UX 개선 수준, 체감 영향 낮음)
+```
+
+---
+
+```yaml
+id: BUG-009
+feature_ref: F-001
+title: README.md — 환경변수 SUPABASE_PUBLISHABLE_KEY vs 실제 코드 SUPABASE_SERVICE_KEY 불일치
+area: 문서
+severity: trivial
+confidence: confirmed
+reproduction:
+  - README.md 환경변수 섹션 참조 → SUPABASE_PUBLISHABLE_KEY 설정
+  - 앱 실행 → data.ts에서 SUPABASE_SERVICE_KEY 요구 → 앱 에러
+expected: README의 환경변수 이름이 코드와 일치
+actual: README는 SUPABASE_PUBLISHABLE_KEY, data.ts는 SUPABASE_SERVICE_KEY 사용
+reproduction_rate: 신규 설정 시 100%
+environment: README.md, lib/data.ts:12
+evidence: |
+  lib/data.ts: process.env.SUPABASE_SERVICE_KEY
+  README.md: SUPABASE_PUBLISHABLE_KEY | Supabase anon key
+cluster_hint: 단독
+assumption: 없음
+label_candidate: fix-now (신규 셋업 시 앱이 완전히 동작 안 함, trivial fix)
+```
+
+---
+
+## 매트릭스 커버리지 요약
+
+| 검증 차원 | 커버된 기능 수 | 미커버 | 비고 |
+|---|---|---|---|
+| 기능 정확성 | 35/42 | 7 | GmapsImport API 내부, map 클러스터링 |
+| 반응형/뷰포트 | 28/42 | 14 | 주요 인라인 편집 뷰포트 모두 확인 |
+| 상태/엣지 | 30/42 | 12 | 빈 상태, null 처리 중심으로 확인 |
+| 데이터 정합성 | 20/42 | 22 | SWR 낙관적 업데이트, writeItems race |
+| 인증·권한 | 10/10 | 0 | middleware 전수 확인 |
+| 네트워크 실패 | 15/42 | 27 | 코드 분석 위주, 실 테스트 미수행 |
+| 상호작용 | 25/42 | 17 | Enter/Tab/Esc 주요 플로우 확인 |
+| i18n/문구 | 10/42 | 32 | 주요 에러 메시지·라벨 확인 |
+| 접근성 | 스폿 체크 | - | aria-label 일부 확인 |
+| 성능 체감 | 코드 분석만 | - | 실 측정 미수행 |
+
+**종료 조건 달성**: 마지막 패스에서 new critical 0건, new major 1건(BUG-001) — 종료 기준 충족

--- a/.qa/2026-04-full-pass/features.md
+++ b/.qa/2026-04-full-pass/features.md
@@ -1,0 +1,662 @@
+# features.md — trip-planner 기능 지도
+> AI ① Feature Investigator 산출물. 결함 평가 없음.
+> 생성일: 2026-04-27
+
+## 개요
+개인 여행 플래너(NYC 2026년 7월). Next.js 14 App Router + React 18 + Supabase. 여행 항목을 생성·관리하며 리서치/일정/지도 뷰에서 탐색. 구글맵 저장 목록 일괄 임포트 가능.
+
+---
+
+## 인증 (Authentication)
+
+```yaml
+id: F-001
+name: 로그인
+area: 인증
+user_flow: /login → 아이디/비밀번호 입력 → POST /api/auth/login → JWT 쿠키 → /research 리다이렉트
+inputs: AUTH_ID(text), AUTH_PASSWORD(password)
+states: 입력 가능 | 로딩 | 성공 | 인증 실패
+permissions: 비로그인 가능
+dependencies: /api/auth/login, jose, next/navigation
+observed_behavior: 환경변수 기반 단일 계정. 성공 시 http-only 쿠키(maxAge 7일). 실패 시 401 + 에러 메시지. 성공 후 window.location.href로 full reload(라우터 캐시 무효화).
+spec_reference: specs/001-trip-planner-mvp
+uncertainty: 단일 계정 방식임을 확인. 다중 사용자 미지원.
+```
+
+```yaml
+id: F-002
+name: 로그아웃
+area: 인증
+user_flow: 사이드바 "로그아웃" 클릭 → POST /api/auth/logout → 쿠키 삭제 → /login 리다이렉트
+inputs: 없음
+states: 클릭 가능
+permissions: 로그인 필요
+dependencies: /api/auth/logout, useRouter
+observed_behavior: auth 쿠키를 maxAge=0으로 삭제. window.location.href=/login으로 전체 리로드.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-003
+name: 인증 미들웨어 (라우트 보호)
+area: 인증
+user_flow: 모든 보호 라우트 요청 → middleware.ts JWT 검증 → 유효: 통과 / 무효: /login 리다이렉트
+inputs: 쿠키의 auth 토큰
+states: 인증됨 | 미인증 | 만료
+permissions: 자동
+dependencies: middleware.ts, jose(verifyToken)
+observed_behavior: /research /schedule /items/* /gmaps-import /map 및 /api/items /api/geocode /api/gmaps/* 보호. 페이지는 /login 리다이렉트, API는 401 JSON.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+---
+
+## 항목 관리 (Item Management)
+
+```yaml
+id: F-004
+name: 항목 생성 (풀 폼)
+area: 항목관리
+user_flow: /items/new → ItemForm 렌더 → 필드 입력 → 저장 → POST /api/items → /research 리다이렉트
+inputs: 이름(필수), 분류, 우선순위, 예약상태, 날짜, 시작시간, 종료시간, 예산, 주소, 좌표, 링크배열, 메모
+states: 입력 | 유효성검증 | 지오코딩 | 저장 | 완료 | 에러
+permissions: 로그인 필요
+dependencies: /api/items(POST), /api/geocode(GET)
+observed_behavior: 이름 필수. 주소 blur 시 지오코딩 자동 실행. 날짜 2026-07-01~31 범위 검증. 날짜 없으면 시간 비활성. URL 빈 링크는 저장 제외. 저장 후 /research 리다이렉트.
+spec_reference: specs/007-item-metadata-ux, specs/008-item-end-time
+uncertainty: 지오코딩 실패 시 좌표 없이 저장됨 — 지도에 표시 불가.
+```
+
+```yaml
+id: F-005
+name: 항목 생성 (테이블 인라인)
+area: 항목관리
+user_flow: 테이블 하단 "+ 항목 추가…" 클릭 → 인라인 입력 → 이름 입력 → Enter/blur → POST /api/items
+inputs: 이름만 (나머지 기본값)
+states: 버튼 | 입력 | 저장 | 완료
+permissions: 로그인 필요
+dependencies: /api/items(POST), ResearchTable, ScheduleTable
+observed_behavior: 분류='기타', 우선순위='검토필요', links=[] 기본값. Escape=취소, Enter/blur=저장(이름 있을 때).
+spec_reference: specs/012-inline-table-view
+uncertainty: 없음
+```
+
+```yaml
+id: F-006
+name: 항목 조회 (상세 페이지)
+area: 항목관리
+user_flow: /items/[id] → SSR 렌더 → 배지·일정·위치·링크·메모 표시
+inputs: URL 파라미터 id (UUID)
+states: 렌더링 | 404
+permissions: 로그인 필요
+dependencies: readItems(lib/data.ts), next notFound()
+observed_behavior: SSR. 없는 항목은 notFound(). 링크는 target=_blank rel=noopener noreferrer. 메모는 whitespace-pre-wrap.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-007
+name: 항목 수정 (풀 폼)
+area: 항목관리
+user_flow: /items/[id]/edit → ItemForm(mode=edit) → 기존값 로드 → 수정 → PUT /api/items/[id] → /items/[id] 리다이렉트
+inputs: F-004와 동일, 기존값 초기화
+states: 로딩 | 편집 | 저장 | 완료
+permissions: 로그인 필요
+dependencies: /api/items/[id](PUT), /api/geocode(GET)
+observed_behavior: 삭제 버튼 노출. 날짜 비우면 time_start도 null 설정. 저장 후 /items/[id] 리다이렉트.
+spec_reference: specs/007-item-metadata-ux
+uncertainty: 없음
+```
+
+```yaml
+id: F-008
+name: 항목 삭제
+area: 항목관리
+user_flow: 삭제 버튼 → confirm 다이얼로그 → DELETE /api/items/[id] → 리스트 복귀
+inputs: 항목 ID
+states: 버튼 | 확인대기 | 삭제 | 완료
+permissions: 로그인 필요
+dependencies: /api/items/[id](DELETE), useItems
+observed_behavior: confirm() 표시. 확인 시 DELETE. ItemPanel에서 삭제 후 onDelete(id)로 패널 자동 닫힘.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-009
+name: 항목 수정 (인라인 — 테이블)
+area: 항목관리
+user_flow: ResearchTable/ScheduleTable 셀 클릭 → 인라인 입력 활성 → 값 수정 → Tab/Enter/blur → PUT /api/items/[id]
+inputs: 이름/분류/우선순위/예약상태/예산(Research), 시간/이름/분류/예약상태/예산(Schedule)
+states: 보기 | 편집 | 저장
+permissions: 로그인 필요
+dependencies: /api/items/[id](PUT), 셀 컴포넌트들
+observed_behavior: 드롭다운은 Portal로 document.body에 렌더. Tab=다음셀, Shift+Tab=이전셀, Enter=다음행, Esc=취소. 외부(data-portal/data-research-row 제외) 클릭 시 편집 종료. 드롭다운 선택 시 자동저장 후 다음셀 포커스.
+spec_reference: specs/012-inline-table-view
+uncertainty: 없음
+```
+
+```yaml
+id: F-010
+name: 항목 수정 (인라인 — 패널)
+area: 항목관리
+user_flow: ItemPanel(view 모드) → 필드 클릭 → 인라인 편집 → Enter/blur → PUT /api/items/[id]
+inputs: 이름/예산/날짜/시간/주소/메모/링크/분류/우선순위/예약상태
+states: 보기 | 편집 | 지오코딩 | 저장
+permissions: 로그인 필요
+dependencies: /api/items/[id](PUT), /api/geocode(GET), ItemDetailView
+observed_behavior: 필드 클릭으로 인라인 입력 전환. 주소 blur 시 지오코딩. 드롭다운은 Portal. Esc=원래값 복원. Enter/blur=저장.
+spec_reference: 없음
+uncertainty: 링크 편집 저장 타이밍 (개별 vs 일괄).
+```
+
+---
+
+## 리서치 뷰 (Research View)
+
+```yaml
+id: F-011
+name: 목록 뷰 — 모바일 카드
+area: 리서치뷰
+user_flow: /research → ItemList 렌더 → 카드 그리드
+inputs: items, selectedItemId, filterState, sortKey
+states: 로딩 | 빈상태 | 데이터 | 검색없음
+permissions: 로그인 필요
+dependencies: ItemList, ItemCard, GroupCard, FilterPanel, SortButton
+observed_behavior: md 이하에서만 표시. 빈상태='아직 항목이 없어요', 검색결과없음='검색 결과가 없어요'. 하단 FAB(+추가).
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-012
+name: 테이블 뷰 — 데스크톱
+area: 리서치뷰
+user_flow: /research → ResearchTable 렌더 → 인라인 편집 가능 테이블
+inputs: filteredItems, sortState
+states: 로딩 | 빈상태 | 데이터
+permissions: 로그인 필요
+dependencies: ResearchTable, ResearchTableRow, 셀 컴포넌트
+observed_behavior: md 이상에서만 표시. 컬럼 헤더 클릭으로 정렬. 행 호버 시 상세버튼(…). 하단 '+ 항목 추가…'.
+spec_reference: specs/012-inline-table-view
+uncertainty: 없음
+```
+
+```yaml
+id: F-013
+name: 검색 (이름·주소·메모)
+area: 리서치뷰
+user_flow: 검색바 → 텍스트 입력 → 실시간 필터
+inputs: 검색어
+states: 없음(전체) | 입력 | 결과있음 | 결과없음
+permissions: 로그인 필요
+dependencies: useMemo, ItemList, ResearchTable
+observed_behavior: trim().toLowerCase()로 정규화. name+address+memo를 공백 조인한 haystack에 포함 여부. 실시간(debounce 없음).
+spec_reference: specs/079-search-multi-field
+uncertainty: 없음
+```
+
+```yaml
+id: F-014
+name: 필터 (분류·우선순위·예약상태)
+area: 리서치뷰
+user_flow: 필터 버튼 → FilterPanel 열기 → 체크박스 선택 → 자동 적용
+inputs: categories[], tripPriorities[], reservationStatuses[], showExcluded
+states: 패널닫힘 | 패널열림 | 필터적용
+permissions: 로그인 필요
+dependencies: FilterPanel, FilterButton, ActiveFilterChips
+observed_behavior: 모바일=바텀시트, 데스크톱=포지션 드롭다운. '제외 포함' 옵션. 활성 필터는 칩으로 표시.
+spec_reference: specs/013-filter-ui-mobile
+uncertainty: 없음
+```
+
+```yaml
+id: F-015
+name: 정렬 (이름·날짜·예산·우선순위)
+area: 리서치뷰
+user_flow: SortButton → 정렬키 선택 → asc/desc 토글
+inputs: sortKey, sortDir
+states: 정렬없음 | 정렬적용
+permissions: 로그인 필요
+dependencies: SortButton, ItemList
+observed_behavior: 처음 선택=asc, 재선택=desc. localeCompare('ko') 한글 지원. 모바일 목록 뷰에서만 (데스크톱은 헤더 클릭).
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-016
+name: 체인 그룹핑 (모바일)
+area: 리서치뷰
+user_flow: ItemList → 동명(2개 이상) 항목 → GroupCard → 클릭으로 서브항목 펼침/접음
+inputs: items 배열 (이름 기반 자동 그룹)
+states: 접힘 | 펼침
+permissions: 로그인 필요
+dependencies: ItemList, GroupCard
+observed_behavior: name.trim().toLowerCase() 기준 그룹. 필터 적용 후 visibleItems만 포함. totalCount는 필터 전 전체. 정렬 시 group의 sortKey는 visibleItems의 최솟값/최댓값 사용.
+spec_reference: specs/011-chain-grouping
+uncertainty: 없음
+```
+
+```yaml
+id: F-017
+name: 활성 필터 칩
+area: 리서치뷰
+user_flow: 필터 선택 → ActiveFilterChips 렌더 → 칩 X로 개별 제거
+inputs: filterState
+states: 필터없음 | 필터있음
+permissions: 로그인 필요
+dependencies: ActiveFilterChips
+observed_behavior: 각 필터값·showExcluded에 칩 생성. X 클릭 시 해당 필터 제거.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-018
+name: 임포트 완료 하이라이트
+area: 리서치뷰
+user_flow: /research?imported=id1,id2 → 해당 항목 배경 강조 → 1초 후 해제
+inputs: URL 파라미터 imported
+states: 강조 | 해제
+permissions: 로그인 필요
+dependencies: useSearchParams, useRouter, setTimeout
+observed_behavior: 마운트 시 1회 실행. Set으로 highlightedIds 관리. 1초 후 초기화 + URL 파라미터 제거(replace).
+spec_reference: 없음
+uncertainty: 없음
+```
+
+---
+
+## 일정 뷰 (Schedule View)
+
+```yaml
+id: F-019
+name: 날짜별 그룹 일정 뷰
+area: 일정뷰
+user_flow: /schedule 또는 /research "일정" 탭 → ScheduleTable → 날짜별 그룹
+inputs: items 배열
+states: 로딩 | 빈상태 | 그룹표시
+permissions: 로그인 필요
+dependencies: ScheduleTable, DateGroupHeader, TableRow, MobileScheduleItemCard
+observed_behavior: 날짜순 정렬. '__undated__' 키로 날짜없는 항목 그룹화. 모바일=카드, 데스크톱=테이블. DateGroupHeader에 날짜·요일·일차(Day X)·예산합계. 헤더 클릭으로 접기. 오늘 날짜 강조.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-020
+name: 오늘 날짜 자동 스크롤
+area: 일정뷰
+user_flow: /schedule 마운트 → 오늘 DateGroupHeader 탐색 → scrollIntoView(smooth)
+inputs: 없음(시스템 날짜)
+states: 초기화 | 스크롤완료
+permissions: 로그인 필요
+dependencies: useRef, useEffect
+observed_behavior: 마운트 시 1회. new Date().toISOString().slice(0,10)으로 날짜 계산. 해당 그룹 있을 때만 스크롤.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-021
+name: 일정 뷰 인라인 아이템 생성
+area: 일정뷰
+user_flow: 날짜 그룹 "+ 항목 추가" → 입력 → Enter/blur → POST /api/items(date 자동지정)
+inputs: 이름(필수)
+states: 버튼 | 입력 | 저장 | 완료
+permissions: 로그인 필요
+dependencies: /api/items(POST), ScheduleTable
+observed_behavior: 분류='기타', trip_priority='검토필요', links=[], date=해당날짜 기본값.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-022
+name: 일정 테이블 (데스크톱)
+area: 일정뷰
+user_flow: 데스크톱 일정 뷰 → min-w-[720px] 테이블 → 인라인 편집
+inputs: items, 날짜그룹, 편집상태
+states: 테이블 | 편집
+permissions: 로그인 필요
+dependencies: ScheduleTable, TableRow, 셀 컴포넌트
+observed_behavior: 가로 스크롤 가능. 컬럼: 시간(w-16)/이름(min-w-[220px])/분류(w-12)/예약상태(w-28)/예산(w-24)/상세(w-8).
+spec_reference: specs/012-inline-table-view
+uncertainty: 없음
+```
+
+```yaml
+id: F-023
+name: 모바일 일정 카드
+area: 일정뷰
+user_flow: 모바일 일정 뷰 → MobileScheduleItemCard → 클릭 → ItemPanel
+inputs: item, onOpenPanel
+states: 카드 표시
+permissions: 로그인 필요
+dependencies: MobileScheduleItemCard, ItemPanel
+observed_behavior: rounded-2xl border bg-white. 이모지+이름, 분류, 예약상태닷, 시간범위, 예산. 호버=border-gray-300+shadow. active:scale-[0.99]. 클릭=onOpenPanel(item.id).
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-024
+name: 날짜 그룹 접기/펼치기
+area: 일정뷰
+user_flow: DateGroupHeader 클릭 → collapsedDates 변경 → 그룹 항목 숨김/표시
+inputs: date
+states: 펼침 | 접힘
+permissions: 로그인 필요
+dependencies: ScheduleTable, DateGroupHeader
+observed_behavior: collapsedDates Set에 date 추가/제거. 접힘 시 그룹 내 항목 렌더 안 함.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+---
+
+## 지도 (Map)
+
+```yaml
+id: F-025
+name: 지도 뷰 (전체/일정)
+area: 지도
+user_flow: /map → ResearchMap(전체) 또는 ScheduleMap(date 있는 항목) 표시
+inputs: items, mapView('all'|'schedule')
+states: 로딩 | 렌더링
+permissions: 로그인 필요
+dependencies: ResearchMap, ScheduleMap(동적로드 ssr:false), Leaflet
+observed_behavior: 풀 뷰(모바일 h-[calc(100vh-56px)]). 항목 클릭 → ItemPanel 열기.
+spec_reference: 없음
+uncertainty: Leaflet 마커, 클러스터, 인포윈도우 세부 동작 미확인 (ssr:false 동적로드).
+```
+
+```yaml
+id: F-026
+name: 지도 전체/일정 토글
+area: 지도
+user_flow: /map 상단 토글 → "전체" / "일정" 클릭 → mapView 변경
+inputs: mapView
+states: 전체 | 일정
+permissions: 로그인 필요
+dependencies: MapPageContent, useState
+observed_behavior: 활성=bg-gray-900 text-white, 비활성=text-gray-500.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+---
+
+## Google Maps 임포트 (GmapsImport)
+
+```yaml
+id: F-027
+name: GmapsImport URL 입력
+area: GmapsImport
+user_flow: /gmaps-import → URL 입력 → 제출 → POST /api/gmaps/preview
+inputs: 구글맵 리스트 URL
+states: 입력대기 | 제출중 | 성공 | 실패
+permissions: 로그인 필요
+dependencies: /api/gmaps/preview(POST)
+observed_behavior: 제출 중 버튼 disabled. 성공 시 candidates 배열 반환 + state='review'.
+spec_reference: specs/006-gmaps-import
+uncertainty: URL 형식 검증 기준 불명확.
+```
+
+```yaml
+id: F-028
+name: 임포트 후보 검토
+area: GmapsImport
+user_flow: state='review' → CandidateList → 체크박스 선택/해제 → 카테고리 오버라이드 → "가져오기"
+inputs: candidates(place/status/similarItem/selected/mappedCategory)
+states: 검토 | 선택중
+permissions: 로그인 필요
+dependencies: /api/gmaps/import(POST), CandidateList
+observed_behavior: 상태배지: new=초록, similar=황색, duplicate=회색. 체크박스로 selected 토글. 카테고리 드롭다운. 선택된 후보 있을 때만 "가져오기" 활성.
+spec_reference: specs/006-gmaps-import
+uncertainty: new/similar/duplicate 판정 로직 미확인.
+```
+
+```yaml
+id: F-029
+name: 임포트 실행
+area: GmapsImport
+user_flow: "가져오기" → state='importing' → POST /api/gmaps/import → state='done' → /research?imported=...
+inputs: selected candidates
+states: 임포트중 | 완료
+permissions: 로그인 필요
+dependencies: /api/gmaps/import(POST), useRouter
+observed_behavior: 임포트중 UI 비활성. {inserted, ids} 응답. done 후 /research?imported=ids 리다이렉트.
+spec_reference: specs/006-gmaps-import
+uncertainty: 없음
+```
+
+```yaml
+id: F-030
+name: 임포트 완료
+area: GmapsImport
+user_flow: state='done' → 완료 메시지 → 2초 후 /research 자동 리다이렉트
+inputs: insertedCount, insertedIds
+states: 완료 | 리다이렉트중
+permissions: 로그인 필요
+dependencies: useRouter, useEffect
+observed_behavior: '○개 장소가 추가되었습니다.'. useEffect에서 state='done' 감지 후 router.push.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+---
+
+## 항목 패널 (ItemPanel)
+
+```yaml
+id: F-031
+name: 항목 패널 (모달/사이드패널)
+area: 항목상세
+user_flow: 항목 선택 → ?item=id URL 파라미터 → ItemPanel 열기
+inputs: item, isOpen, onClose, onSave, onDelete
+states: 닫힘 | 열림(보기) | 열림(편집) | 변경사항확인
+permissions: 로그인 필요
+dependencies: ItemDetailView, PanelItemForm, createPortal
+observed_behavior: 모바일=바텀시트(h-[80vh], rounded-t-2xl, translateY). 데스크톱=사이드패널(w-[520px], translateX). Esc=닫기. 터치 드래그 down 50px=닫기. 배경클릭=닫기. visualViewport로 키보드 높이 감지.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-032
+name: 항목 상세 보기 (인라인 편집)
+area: 항목상세
+user_flow: ItemPanel(view) → 필드 클릭 → 인라인 편집 → Enter/blur → 저장
+inputs: item, openField, savingField
+states: 보기 | 편집중 | 저장중
+permissions: 로그인 필요
+dependencies: ItemDetailView, MetadataDropdownChip
+observed_behavior: 분류/우선순위/예약상태는 MetadataDropdownChip Portal 드롭다운. 선택 즉시 onQuickUpdate. 다른 필드는 Enter/blur로 저장.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-033
+name: 항목 패널 편집 모드
+area: 항목상세
+user_flow: '편집' 버튼 → PanelItemForm 렌더 → 수정 → 저장/취소
+inputs: item, onSave, onCancel
+states: 편집 | 저장 | 변경사항감지
+permissions: 로그인 필요
+dependencies: PanelItemForm
+observed_behavior: 변경사항 감지 시 onDirtyChange(true). 저장 시 PUT /api/items/[id] + onSave(). 취소 시 onCancel()로 view 복귀.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-034
+name: 항목 패널 삭제
+area: 항목상세
+user_flow: 패널 헤더 "삭제" 버튼(view 모드) → confirm → DELETE /api/items/[id] → 패널 닫힘
+inputs: item.id
+states: 버튼 | 확인대기 | 삭제 | 완료
+permissions: 로그인 필요
+dependencies: /api/items/[id](DELETE), useItems
+observed_behavior: view 모드에서만 노출. confirm() 후 deleteItem(id) 호출 + onDelete(id).
+spec_reference: 없음
+uncertainty: 없음
+```
+
+---
+
+## API 엔드포인트
+
+```yaml
+id: F-035
+name: 아이템 CRUD API
+area: 캐싱
+user_flow: GET/POST/PUT/DELETE /api/items → Supabase 연동
+inputs: 요청별 파라미터
+states: 성공 | 실패 | 인증오류
+permissions: 로그인 필요(미들웨어)
+dependencies: Supabase, lib/data.ts
+observed_behavior: GET=전체 목록, POST=생성, PUT=수정(id 파라미터), DELETE=삭제.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-036
+name: 지오코딩 API
+area: 캐싱
+user_flow: GET /api/geocode?q=주소 → 좌표 반환
+inputs: q(주소 문자열)
+states: 성공({lat,lng}) | 실패(null) | 에러(500)
+permissions: 로그인 필요
+dependencies: lib/geocode.ts, 외부 지오코딩 서비스
+observed_behavior: q 없으면 400. 성공 {lat,lng} 또는 {lat:null,lng:null}. 에러 500.
+spec_reference: 없음
+uncertainty: 외부 서비스(Nominatim?) 구현 미확인.
+```
+
+---
+
+## 네비게이션
+
+```yaml
+id: F-037
+name: 모바일 바텀 네비게이션
+area: 네비게이션
+user_flow: 모든 보호 페이지 → Navigation → 모바일 하단 바(목록/지도)
+inputs: pathname
+states: 목록활성 | 지도활성
+permissions: 로그인 필요
+dependencies: Navigation(Layout), usePathname, Link
+observed_behavior: fixed 바텀바(md:hidden). safe-area-inset-bottom. 활성=text-gray-900, 비활성=text-gray-400.
+spec_reference: specs/014-nav-ux-overhaul
+uncertainty: 없음
+```
+
+```yaml
+id: F-038
+name: 데스크톱 사이드바
+area: 네비게이션
+user_flow: md 이상 → fixed left-0 사이드바 → 메인 nav(목록/지도) + 보조 nav(지도연동/로그아웃)
+inputs: pathname
+states: 목록활성 | 지도활성
+permissions: 로그인 필요
+dependencies: Navigation, useRouter
+observed_behavior: w-44 사이드바. 헤더(NYC Trip, 2026년 7월). 활성 링크=bg-gray-900 text-white. 메인 콘텐츠 md:pl-44.
+spec_reference: specs/014-nav-ux-overhaul
+uncertainty: 없음
+```
+
+```yaml
+id: F-039
+name: 뷰 토글 (목록↔일정)
+area: 리서치뷰
+user_flow: /research 헤더 → ViewToggle → 목록/일정 클릭 → 뷰 전환
+inputs: view('items'|'schedule')
+states: 목록뷰 | 일정뷰
+permissions: 로그인 필요
+dependencies: ViewToggle, ItemList, ScheduleTable
+observed_behavior: view='items'일 때만 검색/필터 도구모음 표시.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+---
+
+## 데이터 & 훅
+
+```yaml
+id: F-040
+name: useItems 훅 (데이터 관리)
+area: 캐싱
+user_flow: 컴포넌트 마운트 → useItems() → GET /api/items → items + 제어함수 제공
+inputs: 없음
+states: 로딩 | 완료 | 에러
+permissions: 로그인 필요
+dependencies: /api/items(GET/POST/PUT/DELETE)
+observed_behavior: items, isLoading, error, createItem, updateItem, deleteItem 제공. 마운트 시 초기 로드.
+spec_reference: specs/005-data-caching-fast-ux
+uncertainty: 상태 업데이트가 optimistic인지 서버대기인지 불명확.
+```
+
+---
+
+## UI 컴포넌트
+
+```yaml
+id: F-041
+name: 로딩 스켈레톤
+area: 네비게이션
+user_flow: isLoading=true → 플레이스홀더 5개 표시 → 완료 시 실제 데이터로 대체
+inputs: 없음
+states: 로딩표시
+permissions: 로그인 필요
+dependencies: ItemCardSkeleton, ResearchTableSkeleton
+observed_behavior: gray-200 배경 플레이스홀더.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+```yaml
+id: F-042
+name: FAB (Floating Action Button)
+area: 네비게이션
+user_flow: 모바일 목록 뷰 하단 우측 "+ 추가" → /items/new
+inputs: 없음
+states: 버튼표시
+permissions: 로그인 필요
+dependencies: FAB, Link
+observed_behavior: 모바일만(md:hidden). pb-28으로 바텀 네비 위에 위치.
+spec_reference: 없음
+uncertainty: 없음
+```
+
+---
+
+## 기능 ID 요약 (42개)
+
+| 영역 | IDs |
+|---|---|
+| 인증 | F-001~003 |
+| 항목 관리 | F-004~010 |
+| 리서치 뷰 | F-011~018 |
+| 일정 뷰 | F-019~024 |
+| 지도 | F-025~026 |
+| GmapsImport | F-027~030 |
+| 항목 패널 | F-031~034 |
+| API | F-035~036 |
+| 네비게이션 | F-037~039 |
+| 데이터 & 훅 | F-040 |
+| UI 컴포넌트 | F-041~042 |
+
+## 불확실 영역 Top 3
+
+1. **GmapsImport 상태 판정** (F-027~029) — new/similar/duplicate 판정 알고리즘, URL 형식 검증 기준 미확인
+2. **useItems 상태 업데이트 타이밍** (F-040) — optimistic vs 서버대기 불명확. race condition 처리 수준 미확인
+3. **지도 컴포넌트** (F-025) — Leaflet 마커·클러스터·인포윈도우 세부 동작 (ssr:false 동적로드로 정적 분석 제한)

--- a/.qa/2026-04-full-pass/triage.md
+++ b/.qa/2026-04-full-pass/triage.md
@@ -1,0 +1,42 @@
+# triage.md — trip-planner 결함 트리아지
+> AI ③ Defect Triage 산출물. 체감 영향 점수 기준.
+> 생성일: 2026-04-27
+> 점수 체계: 빈도(1-3) + 짜증(1-3) + 우회(1-3) → 합계 7-9=fix-now / 5-6=후보 / 3-4=accept
+
+---
+
+## fix-now (수정 대상)
+
+| ID | 제목 | 빈도 | 짜증 | 우회 | 합계 | 클러스터 |
+|----|------|------|------|------|------|----------|
+| BUG-001 | 모바일 일정뷰 Enter 키 → API 400 항상 실패 | 3 | 3 | 2 | **8** | 단독 |
+| BUG-002 | ResearchTable Escape 취소 → 항목 spurious 생성 | 2 | 3 | 1 | **6** | C1 |
+| BUG-003 | ScheduleTable Escape 취소 → 항목 spurious 생성 | 2 | 3 | 1 | **6** | C1 |
+| BUG-004 | StatusCell 드롭다운 우측 viewport 오버플로우 | 2 | 2 | 2 | **6** | C2 |
+| BUG-005 | PriorityCell 드롭다운 우측 viewport 오버플로우 | 2 | 2 | 2 | **6** | C2 |
+| BUG-009 | README 환경변수 이름 오류 (신규 셋업 시 앱 불동) | 3 | 3 | 1 | **7** | 단독 |
+
+**BUG-002/003 점수 근거**: confidence=hypothesis이지만 데이터 오염(원치 않는 항목 생성)이 발생하면 사용자가 직접 찾아 삭제해야 하므로 우회 난이도 1. 실제 발생 여부는 브라우저 환경에 의존하지만 React 18 이벤트 위임 구조상 blur 발화 가능성이 높아 fix-now로 상향.
+
+**BUG-004/005 클러스터 처리**: 개별 점수 6점(후보)이나 CategoryCell도 동일 패턴이므로 C2 클러스터로 묶어 한 번에 수정.
+
+---
+
+## accept (미수정 — 빈도/체감 낮음)
+
+| ID | 제목 | 빈도 | 짜증 | 우회 | 합계 | 이유 |
+|----|------|------|------|------|------|------|
+| BUG-006 | ItemDetailView 저장 실패 후 vals stale 표시 | 1 | 2 | 2 | 5 | 네트워크 실패 시에만, 에러 토스트 + 새로고침으로 인지·복구 가능 |
+| BUG-007 | writeItems 전체 테이블 read+upsert race | 1 | 2 | 2 | 5 | 단일 사용자, 동시 탭 편집 시나리오 현실적으로 드묾 |
+| BUG-008 | 지도 좌표 없는 항목 미안내 | 2 | 1 | 3 | 6 | UX 개선 수준, 기능에 지장 없음 |
+
+---
+
+## 수정 계획
+
+```
+PR-1  feat(fix): BUG-001 — 모바일 일정뷰 Enter 키 closure 수정
+PR-2  feat(fix): BUG-002/003 — C1 Escape 취소 blur race 방지
+PR-3  feat(fix): BUG-004/005 — C2 드롭다운 viewport 오버플로우 수정 (CategoryCell 포함)
+PR-4  fix: BUG-009 — README 환경변수 이름 정정
+```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm run dev
 | `AUTH_PASSWORD` | 로그인 비밀번호 | 직접 설정 (임의 문자열) |
 | `JWT_SECRET` | JWT 서명 키 | 직접 생성 (충분히 긴 랜덤 문자열) |
 | `SUPABASE_URL` | Supabase 프로젝트 URL | [Supabase 대시보드](https://supabase.com) → Project Settings → API |
-| `SUPABASE_PUBLISHABLE_KEY` | Supabase anon key | [Supabase 대시보드](https://supabase.com) → Project Settings → API |
+| `SUPABASE_SERVICE_KEY` | Supabase service role key | [Supabase 대시보드](https://supabase.com) → Project Settings → API |
 
 ## 스크립트
 

--- a/components/Research/ResearchTable.tsx
+++ b/components/Research/ResearchTable.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { TripItem, TripPriority } from '@/types'
 import { TRIP_PRIORITY_META } from '@/lib/itemOptions'
 import NameCell from '@/components/Schedule/cells/NameCell'
@@ -73,6 +73,7 @@ export default function ResearchTable({
   }
   const [addingRow, setAddingRow] = useState(false)
   const [newItemName, setNewItemName] = useState('')
+  const cancelNewItemRef = useRef(false)
   const newItemInputRef = useCallback((el: HTMLInputElement | null) => {
     if (el) setTimeout(() => el.focus(), 0)
   }, [])
@@ -142,6 +143,10 @@ export default function ResearchTable({
   }, [])
 
   function handleNewItemBlur() {
+    if (cancelNewItemRef.current) {
+      cancelNewItemRef.current = false
+      return
+    }
     const name = newItemName.trim()
     if (name) {
       onCreateItem({
@@ -160,6 +165,7 @@ export default function ResearchTable({
       e.preventDefault()
       handleNewItemBlur()
     } else if (e.key === 'Escape') {
+      cancelNewItemRef.current = true
       setAddingRow(false)
       setNewItemName('')
     }

--- a/components/Schedule/ScheduleTable.tsx
+++ b/components/Schedule/ScheduleTable.tsx
@@ -161,6 +161,7 @@ export default function ScheduleTable({
   const [undatedCollapsed, setUndatedCollapsed] = useState(false)
   const [addingToDate, setAddingToDate] = useState<string | null>(null)
   const [newItemName, setNewItemName] = useState('')
+  const cancelNewItemRef = useRef(false)
   const newItemInputRef = useCallback((el: HTMLInputElement | null) => {
     if (el) setTimeout(() => el.focus(), 0)
   }, [])
@@ -252,6 +253,10 @@ export default function ScheduleTable({
   }, [])
 
   function handleNewItemBlur(date: string | null) {
+    if (cancelNewItemRef.current) {
+      cancelNewItemRef.current = false
+      return
+    }
     const name = newItemName.trim()
     if (name) {
       onCreateItem({
@@ -271,6 +276,7 @@ export default function ScheduleTable({
       e.preventDefault()
       handleNewItemBlur(date)
     } else if (e.key === 'Escape') {
+      cancelNewItemRef.current = true
       setAddingToDate(null)
       setNewItemName('')
     }
@@ -344,7 +350,7 @@ export default function ScheduleTable({
             value={newItemName}
             onChange={setNewItemName}
             onBlur={() => handleNewItemBlur(date)}
-            onKeyDown={handleNewItemKeyDown}
+            onKeyDown={e => handleNewItemKeyDown(e, date)}
           />
         ) : (
           <button

--- a/components/Schedule/cells/CategoryCell.tsx
+++ b/components/Schedule/cells/CategoryCell.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { Category } from '@/types'
 import { CATEGORY_META, CATEGORY_OPTIONS } from '@/lib/itemOptions'
@@ -49,6 +49,16 @@ export default function CategoryCell({
       window.removeEventListener('scroll', updatePosition, true)
     }
   }, [isEditing, onClose])
+
+  useLayoutEffect(() => {
+    if (!position || !dropdownRef.current) return
+    const dropRect = dropdownRef.current.getBoundingClientRect()
+    if (dropRect.right > window.innerWidth) {
+      setPosition(prev =>
+        prev ? { ...prev, left: Math.max(0, prev.left - (dropRect.right - window.innerWidth)) } : prev
+      )
+    }
+  }, [position])
 
   const emoji = CATEGORY_META[value]?.emoji ?? '🔖'
 

--- a/components/Schedule/cells/PriorityCell.tsx
+++ b/components/Schedule/cells/PriorityCell.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { TripPriority } from '@/types'
 import { TRIP_PRIORITY_META, TRIP_PRIORITY_OPTIONS } from '@/lib/itemOptions'
@@ -50,6 +50,16 @@ export default function PriorityCell({
       window.removeEventListener('scroll', updatePosition, true)
     }
   }, [isEditing, onClose])
+
+  useLayoutEffect(() => {
+    if (!position || !dropdownRef.current) return
+    const dropRect = dropdownRef.current.getBoundingClientRect()
+    if (dropRect.right > window.innerWidth) {
+      setPosition(prev =>
+        prev ? { ...prev, left: Math.max(0, prev.left - (dropRect.right - window.innerWidth)) } : prev
+      )
+    }
+  }, [position])
 
   return (
     <>

--- a/components/Schedule/cells/StatusCell.tsx
+++ b/components/Schedule/cells/StatusCell.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { ReservationStatus } from '@/types'
 import { RESERVATION_STATUS_META, RESERVATION_STATUS_OPTIONS } from '@/lib/itemOptions'
@@ -63,6 +63,16 @@ export default function StatusCell({
       window.removeEventListener('scroll', updatePosition, true)
     }
   }, [isEditing, onClose])
+
+  useLayoutEffect(() => {
+    if (!position || !dropdownRef.current) return
+    const dropRect = dropdownRef.current.getBoundingClientRect()
+    if (dropRect.right > window.innerWidth) {
+      setPosition(prev =>
+        prev ? { ...prev, left: Math.max(0, prev.left - (dropRect.right - window.innerWidth)) } : prev
+      )
+    }
+  }, [position])
 
   return (
     <>


### PR DESCRIPTION
## 개요

2026-04-27 Full QA Pass 결과로 발견된 버그 중 **fix-now** 판정을 받은 6건을 수정합니다.

## 수정 내용

### BUG-001 + BUG-003 — 모바일 일정뷰 새 항목 키보드 입력 오류 (ScheduleTable.tsx)

- **BUG-001**: `MobileNewItemEditor`의 `onKeyDown` prop에 closure가 누락되어 Enter 키 입력 시 date 파라미터 대신 사용자 입력 텍스트가 전달 → API 400 에러 항상 발생. `onKeyDown={e => handleNewItemKeyDown(e, date)}`로 수정.
- **BUG-003**: Escape 취소 후 input 언마운트 시 stale closure blur가 발화되어 항목이 spurious 생성되는 race condition. `cancelNewItemRef`로 방지.

### BUG-002 — ResearchTable Escape 취소 spurious 생성 방지 (ResearchTable.tsx)

BUG-003과 동일한 root cause (C1 클러스터). `cancelNewItemRef` 패턴 적용.

### BUG-004 + BUG-005 — CategoryCell/StatusCell/PriorityCell 드롭다운 viewport 오버플로우 (C2 클러스터)

좁은 뷰포트에서 드롭다운이 오른쪽으로 잘리는 버그. `useLayoutEffect`로 렌더링 후 실제 너비를 측정하고 오버플로우 시 `left`를 보정. ItemPanel `MetadataDropdownChip`의 기존 처리 방식과 일관성 확보.

### BUG-009 — README 환경변수 이름 오류 (README.md)

`SUPABASE_PUBLISHABLE_KEY` → `SUPABASE_SERVICE_KEY` (lib/data.ts 실제 참조 이름과 일치).

## 미수정 (accept)

| ID | 이유 |
|----|------|
| BUG-006 | 네트워크 실패 시에만, 에러 토스트 + 새로고침으로 복구 가능 |
| BUG-007 | 단일 사용자 앱, 동시 편집 현실적으로 드묾 |
| BUG-008 | UX 개선 수준, 기능 지장 없음 |

## 테스트

- TypeScript 타입 체크 통과 (`npx tsc --noEmit`)
- 각 수정 사항을 코드 레벨에서 검증 완료