### PR TITLE
chore: QA 캠페인 종료 보고서 (known-issues.md, closeout.md)

### DIFF
--- a/.qa/2026-04-full-pass/closeout.md
+++ b/.qa/2026-04-full-pass/closeout.md
@@ -1,0 +1,122 @@
+# closeout.md — QA 캠페인 최종 보고서
+> 2026-04-27 Full Pass 종료 보고
+> 캠페인 기간: 2026-04-27 (단일 세션, 완전 자동화 실행)
+
+---
+
+## 실행 요약
+
+| 단계 | 담당 AI | 산출물 | 상태 |
+|------|---------|--------|------|
+| ① Feature Investigation | Explore 에이전트 (Haiku) | features.md (F-001-F-042) | ✅ |
+| ② Defect Investigation | 정적 코드 분석 | discovery.md (BUG-001-BUG-009) | ✅ |
+| ③ Self-triage | 체감 점수 기반 | triage.md | ✅ |
+| ④ Fix + Merge | 코드 수정 + PR #84 | main 브랜치 반영 | ✅ |
+| ⑤ Closeout | — | 본 문서 + known-issues.md | ✅ |
+
+---
+
+## 결함 요약
+
+총 **9개** 결함 발견 → **6개 수정** (main 병합 완료), **3개 accept** (known-issues.md 기록)
+
+### 수정 완료 (fix-now)
+
+| ID | 제목 | 심각도 | 수정 내용 |
+|----|------|--------|-----------|
+| BUG-001 | 모바일 일정뷰 Enter 키 → API 400 항상 실패 | major | `ScheduleTable.tsx` MobileNewItemEditor `onKeyDown` closure 추가 |
+| BUG-002 | ResearchTable Escape 취소 → spurious 항목 생성 | major | `cancelNewItemRef`로 Escape 후 blur 무시 |
+| BUG-003 | ScheduleTable Escape 취소 → spurious 항목 생성 | major | 동일 패턴 적용 |
+| BUG-004 | StatusCell 드롭다운 우측 viewport 오버플로우 | minor | `useLayoutEffect`로 렌더 후 overflow 보정 |
+| BUG-005 | PriorityCell 드롭다운 우측 viewport 오버플로우 | minor | 동일 패턴 적용 (CategoryCell 포함) |
+| BUG-009 | README 환경변수 이름 오류 | trivial | `SUPABASE_PUBLISHABLE_KEY` → `SUPABASE_SERVICE_KEY` |
+
+병합 PR: [#84](https://github.com/Useful-Dogus/trip-planner/pull/84)
+
+### 수정 보류 (accept)
+
+| ID | 제목 | 이유 |
+|----|------|------|
+| BUG-006 | ItemDetailView 저장 실패 후 vals stale | 저빈도, 에러 토스트 + 새로고침으로 복구 가능 |
+| BUG-007 | writeItems race condition | 단일 사용자 앱, 동시 편집 거의 없음 |
+| BUG-008 | 지도 좌표 없는 항목 미안내 | UX 개선 수준, 기능 지장 없음 |
+
+---
+
+## 주요 수정 상세
+
+### BUG-001: 모바일 Enter 키 — 가장 큰 체감 개선 (8/9점)
+
+모바일에서 새 항목 추가 시 Enter를 누를 때마다 API 400 에러가 발생했다.
+`MobileNewItemEditor`의 `onKeyDown` prop이 closure 없이 함수를 직접 전달해,
+date 파라미터 자리에 사용자 입력 텍스트가 전달된 것이 원인.
+
+```tsx
+// 수정 전 (버그)
+onKeyDown={handleNewItemKeyDown}
+
+// 수정 후
+onKeyDown={e => handleNewItemKeyDown(e, date)}
+```
+
+### BUG-002/003: Escape blur race — 데이터 오염 방지
+
+새 항목 입력 중 Escape로 취소할 때, state 배치 업데이트 후 input 언마운트 시
+stale closure를 참조한 blur 이벤트가 발화되어 원치 않는 항목이 생성될 수 있었다.
+
+```tsx
+// cancelNewItemRef 패턴으로 해결
+const cancelNewItemRef = useRef(false)
+
+function handleNewItemBlur() {
+  if (cancelNewItemRef.current) {
+    cancelNewItemRef.current = false
+    return
+  }
+  // ... 정상 생성 로직
+}
+
+} else if (e.key === 'Escape') {
+  cancelNewItemRef.current = true  // blur가 와도 생성 건너뜀
+  setAddingRow(false)
+  setNewItemName('')
+}
+```
+
+### BUG-004/005: 드롭다운 viewport 오버플로우 — useLayoutEffect 패턴
+
+ItemPanel의 `MetadataDropdownChip`에는 올바른 right-edge 처리가 있었으나
+`CategoryCell`/`StatusCell`/`PriorityCell`에는 누락되어 있었다.
+드롭다운 너비를 사전에 알 수 없으므로 `useLayoutEffect`로 렌더 후 측정해 보정.
+
+```tsx
+useLayoutEffect(() => {
+  if (!position || !dropdownRef.current) return
+  const dropRect = dropdownRef.current.getBoundingClientRect()
+  if (dropRect.right > window.innerWidth) {
+    setPosition(prev =>
+      prev ? { ...prev, left: Math.max(0, prev.left - (dropRect.right - window.innerWidth)) } : prev
+    )
+  }
+}, [position])
+```
+
+`useLayoutEffect`는 브라우저 페인트 전에 동기 실행되므로 visual flicker 없음.
+
+---
+
+## 검증
+
+- TypeScript 타입 체크: `npx tsc --noEmit` — 오류 0건
+- 정적 코드 분석으로 각 수정 사항의 정확성 확인
+
+---
+
+## 종료 판정
+
+**캠페인 종료 기준 충족**
+
+- 마지막 패스에서 new critical: 0건
+- new major: 0건 (BUG-001은 직전 패스에서 이미 발견)
+- fix-now 6건 전원 수정 후 main 병합 완료
+- accept 결함 3건 known-issues.md 문서화 완료

--- a/.qa/2026-04-full-pass/known-issues.md
+++ b/.qa/2026-04-full-pass/known-issues.md
@@ -1,0 +1,51 @@
+# known-issues.md — 수정 보류 결함
+> 2026-04-27 Full QA Pass accept 판정 결함. 향후 참고용.
+
+---
+
+## BUG-006 — ItemDetailView 저장 실패 후 필드 표시 값 stale
+
+**영역**: panel / view mode  
+**심각도**: minor  
+**체감 점수**: 5/9 (빈도1 + 짜증2 + 우회2)
+
+저장 실패(네트워크 오류) 후 SWR rollback으로 서버 데이터는 원복되지만,
+ItemDetailView의 `vals` 로컬 상태가 `item.id` 변경 시에만 reset되어
+date/budget/time/address/memo 필드가 실패한 값을 계속 표시한다.
+name 필드는 `item.name`을 직접 참조하므로 영향 없음.
+
+**재현**: 오프라인 상태에서 날짜 필드 수정 후 포커스 이동 → 에러 토스트 → 패널 날짜가 시도한 값 표시.
+
+**accept 이유**: 네트워크 실패 시에만 발생 (저빈도), 에러 토스트 + 새로고침으로 사용자 인지·복구 가능.
+
+**수정 방법 (참고)**: `useEffect` 의존성에 `item.date`, `item.budget` 등 추가하거나, 저장 실패 시 `setVals(v => ({ ...v, [field]: item[field] }))` 롤백.
+
+---
+
+## BUG-007 — writeItems 전체 테이블 read+upsert race condition
+
+**영역**: 데이터 / API  
+**심각도**: minor  
+**체감 점수**: 5/9 (빈도1 + 짜증2 + 우회2)
+
+`lib/data.ts` `writeItems`는 단일 항목 수정 시에도 전체 테이블을 fetch 후 diff+upsert한다.
+두 탭에서 같은 항목을 빠르게 연속 수정하면 동일 snapshot을 읽은 뒤 덮어쓸 수 있다.
+
+**accept 이유**: 단일 사용자 앱 특성상 동시 편집 시나리오가 현실적으로 거의 발생하지 않음.
+
+**수정 방법 (참고)**: API route를 PATCH 기반으로 변경해 단일 항목만 수정하거나, Supabase의 row-level update를 직접 사용.
+
+---
+
+## BUG-008 — 지도에서 좌표 없는 항목 미표시 안내 없음
+
+**영역**: 지도  
+**심각도**: trivial  
+**체감 점수**: 6/9 (빈도2 + 짜증1 + 우회3)
+
+`ResearchMap.tsx`의 mapItems 필터가 `lat/lng undefined` 항목을 제거하지만
+지도 상단에 "N개 항목이 좌표 없음" 같은 안내가 없어 사용자가 누락을 인지 못할 수 있다.
+
+**accept 이유**: UX 개선 수준. 기능 동작에 지장 없고 체감 영향이 낮음.
+
+**수정 방법 (참고)**: 필터 전후 count 비교 후 차이가 있을 때 info toast 또는 지도 하단 badge 표시.


### PR DESCRIPTION
2026-04-27 Full QA Pass 종료 문서 추가.

- `known-issues.md` — accept 판정 결함 3건 기록 (BUG-006/007/008)
- `closeout.md` — 캠페인 전체 요약, 수정 내역, 종료 판정