### PR TITLE
feat: 일자별 카테고리 컬러 스택바 + 연속 항목 간 직선거리 표시

### DIFF
--- a/components/Schedule/CategoryStackBar.tsx
+++ b/components/Schedule/CategoryStackBar.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import type { Category } from '@/types'
+import { CATEGORY_META } from '@/lib/itemOptions'
+
+interface CategoryStackBarProps {
+  breakdown: { category: Category; count: number }[]
+}
+
+export default function CategoryStackBar({ breakdown }: CategoryStackBarProps) {
+  const total = breakdown.reduce((sum, b) => sum + b.count, 0)
+  if (total === 0) return null
+
+  return (
+    <div
+      className="flex h-1.5 w-full overflow-hidden rounded-full bg-gray-100"
+      role="img"
+      aria-label={breakdown.map(b => `${b.category} ${b.count}`).join(', ')}
+    >
+      {breakdown.map(({ category, count }) => {
+        const pct = (count / total) * 100
+        const color = CATEGORY_META[category]?.color ?? '#cbd5e1'
+        return (
+          <div
+            key={category}
+            className="h-full"
+            style={{ width: `${pct}%`, backgroundColor: color }}
+            title={`${category} · ${count}`}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/components/Schedule/DateGroupHeader.tsx
+++ b/components/Schedule/DateGroupHeader.tsx
@@ -1,11 +1,15 @@
 'use client'
 
+import type { Category } from '@/types'
+import CategoryStackBar from './CategoryStackBar'
+
 interface DateGroupHeaderProps {
   date: string
   dayOffset: number | null
   totalBudget: number
   isCollapsed: boolean
   isToday?: boolean
+  categoryBreakdown?: { category: Category; count: number }[]
   onToggleCollapse: () => void
   onAddItem: () => void
 }
@@ -25,13 +29,16 @@ export default function DateGroupHeader({
   totalBudget,
   isCollapsed,
   isToday = false,
+  categoryBreakdown,
   onToggleCollapse,
   onAddItem,
 }: DateGroupHeaderProps) {
   const isUndated = date === '__undated__'
+  const showBar = !isUndated && categoryBreakdown && categoryBreakdown.length > 0
 
   return (
-    <div className="flex items-center gap-2 px-3 py-3 bg-white border-b border-gray-200 sticky top-0 z-10">
+    <div className="bg-white border-b border-gray-200 sticky top-0 z-10">
+      <div className="flex items-center gap-2 px-3 py-3">
       <button
         type="button"
         onClick={onToggleCollapse}
@@ -88,6 +95,12 @@ export default function DateGroupHeader({
           추가
         </button>
       </div>
+      </div>
+      {showBar && (
+        <div className="px-3 pb-2">
+          <CategoryStackBar breakdown={categoryBreakdown!} />
+        </div>
+      )}
     </div>
   )
 }

--- a/components/Schedule/DistanceSeparator.tsx
+++ b/components/Schedule/DistanceSeparator.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { formatDistance } from '@/lib/distance'
+
+interface DistanceSeparatorProps {
+  km: number
+  variant: 'desktop' | 'mobile'
+}
+
+export default function DistanceSeparator({ km, variant }: DistanceSeparatorProps) {
+  if (variant === 'desktop') {
+    return (
+      <div
+        aria-hidden="true"
+        className="flex min-w-[720px] items-center px-3 py-1 text-[11px] text-gray-400"
+      >
+        <div className="flex w-16 flex-shrink-0 items-center justify-center">
+          <span className="h-3 w-px bg-gray-200" />
+        </div>
+        <div className="flex min-w-[220px] flex-1 items-center gap-2">
+          <span className="h-px w-3 bg-gray-200" />
+          <span className="tabular-nums">{formatDistance(km)}</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div aria-hidden="true" className="flex items-center gap-2 pl-12 pr-2">
+      <span className="h-3 w-px bg-gray-200" />
+      <span className="text-[11px] tabular-nums text-gray-400">{formatDistance(km)}</span>
+    </div>
+  )
+}

--- a/components/Schedule/ScheduleTable.tsx
+++ b/components/Schedule/ScheduleTable.tsx
@@ -1,11 +1,13 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { ReservationStatus, TripItem } from '@/types'
-import { CATEGORY_META, RESERVATION_STATUS_META } from '@/lib/itemOptions'
+import { useCallback, useEffect, useMemo, useRef, useState, Fragment } from 'react'
+import type { Category, ReservationStatus, TripItem } from '@/types'
+import { CATEGORY_META, CATEGORY_OPTIONS, RESERVATION_STATUS_META } from '@/lib/itemOptions'
+import { haversineKm } from '@/lib/distance'
 import { EDITABLE_FIELDS, type EditableField } from './TableRow'
 import TableRow from './TableRow'
 import DateGroupHeader from './DateGroupHeader'
+import DistanceSeparator from './DistanceSeparator'
 
 interface EditingCell {
   itemId: string
@@ -63,6 +65,23 @@ function getStatusMeta(value: ReservationStatus | null | undefined) {
     }[value],
     label: shortLabel[value],
   }
+}
+
+function buildCategoryBreakdown(items: TripItem[]): { category: Category; count: number }[] {
+  const counts = new Map<Category, number>()
+  for (const it of items) {
+    counts.set(it.category, (counts.get(it.category) ?? 0) + 1)
+  }
+  return CATEGORY_OPTIONS
+    .filter(c => counts.has(c))
+    .map(c => ({ category: c, count: counts.get(c)! }))
+}
+
+function distanceBetween(a: TripItem, b: TripItem): number | null {
+  if (a.lat == null || a.lng == null || b.lat == null || b.lng == null) return null
+  const km = haversineKm({ lat: a.lat, lng: a.lng }, { lat: b.lat, lng: b.lng })
+  if (km < 0.05) return null
+  return km
 }
 
 function formatDate(dateStr: string): string {
@@ -285,19 +304,26 @@ export default function ScheduleTable({
   function renderDesktopGroupRows(date: string, groupItems: TripItem[]) {
     return (
       <>
-        {groupItems.map(item => (
-          <div key={item.id} data-schedule-row="true">
-            <TableRow
-              item={item}
-              editingField={editingCell?.itemId === item.id ? editingCell.field : null}
-              onCellActivate={field => setEditingCell({ itemId: item.id, field })}
-              onCellSave={(field, value) => onUpdateItem(item.id, { [field]: value })}
-              onCellDeactivate={() => setEditingCell(null)}
-              onNavigate={handleNavigate}
-              onOpenPanel={onOpenPanel}
-            />
-          </div>
-        ))}
+        {groupItems.map((item, idx) => {
+          const prev = idx > 0 ? groupItems[idx - 1] : null
+          const km = prev ? distanceBetween(prev, item) : null
+          return (
+            <Fragment key={item.id}>
+              {km != null && <DistanceSeparator km={km} variant="desktop" />}
+              <div data-schedule-row="true">
+                <TableRow
+                  item={item}
+                  editingField={editingCell?.itemId === item.id ? editingCell.field : null}
+                  onCellActivate={field => setEditingCell({ itemId: item.id, field })}
+                  onCellSave={(field, value) => onUpdateItem(item.id, { [field]: value })}
+                  onCellDeactivate={() => setEditingCell(null)}
+                  onNavigate={handleNavigate}
+                  onOpenPanel={onOpenPanel}
+                />
+              </div>
+            </Fragment>
+          )
+        })}
         {addingToDate === date ? (
           <div className="flex min-w-[720px] items-center border-b border-gray-50 bg-blue-50/30">
             <div className="w-16 flex-shrink-0 px-3 py-2.5" />
@@ -339,10 +365,17 @@ export default function ScheduleTable({
 
   function renderMobileGroupRows(date: string, groupItems: TripItem[]) {
     return (
-      <div className="space-y-3 px-3 py-3">
-        {groupItems.map(item => (
-          <MobileScheduleItemCard key={item.id} item={item} onOpenPanel={onOpenPanel} />
-        ))}
+      <div className="space-y-2 px-3 py-3">
+        {groupItems.map((item, idx) => {
+          const prev = idx > 0 ? groupItems[idx - 1] : null
+          const km = prev ? distanceBetween(prev, item) : null
+          return (
+            <Fragment key={item.id}>
+              {km != null && <DistanceSeparator km={km} variant="mobile" />}
+              <MobileScheduleItemCard item={item} onOpenPanel={onOpenPanel} />
+            </Fragment>
+          )
+        })}
         {addingToDate === date ? (
           <MobileNewItemEditor
             date={date}
@@ -394,6 +427,7 @@ export default function ScheduleTable({
           const isCollapsed = collapsedDates.has(date)
           const dayOffset = getDayOffset(date)
           const isToday = date === todayKey
+          const categoryBreakdown = buildCategoryBreakdown(groupItems)
 
           return (
             <div key={date} ref={isToday ? todayRef : undefined} className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
@@ -403,6 +437,7 @@ export default function ScheduleTable({
                 totalBudget={totalBudget}
                 isCollapsed={isCollapsed}
                 isToday={isToday}
+                categoryBreakdown={categoryBreakdown}
                 onToggleCollapse={() =>
                   setCollapsedDates(prev => {
                     const next = new Set(prev)
@@ -495,6 +530,7 @@ export default function ScheduleTable({
                 const isCollapsed = collapsedDates.has(date)
                 const dayOffset = getDayOffset(date)
                 const isToday = date === todayKey
+                const categoryBreakdown = buildCategoryBreakdown(groupItems)
 
                 return (
                   <div key={date} ref={isToday ? todayRef : undefined}>
@@ -504,6 +540,7 @@ export default function ScheduleTable({
                       totalBudget={totalBudget}
                       isCollapsed={isCollapsed}
                       isToday={isToday}
+                      categoryBreakdown={categoryBreakdown}
                       onToggleCollapse={() =>
                         setCollapsedDates(prev => {
                           const next = new Set(prev)

--- a/lib/distance.ts
+++ b/lib/distance.ts
@@ -1,0 +1,26 @@
+const EARTH_RADIUS_KM = 6371
+
+function toRad(deg: number): number {
+  return (deg * Math.PI) / 180
+}
+
+export function haversineKm(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number },
+): number {
+  const dLat = toRad(b.lat - a.lat)
+  const dLng = toRad(b.lng - a.lng)
+  const lat1 = toRad(a.lat)
+  const lat2 = toRad(b.lat)
+
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2
+  return 2 * EARTH_RADIUS_KM * Math.asin(Math.min(1, Math.sqrt(h)))
+}
+
+export function formatDistance(km: number): string {
+  if (km < 1) return `${Math.round(km * 1000)} m`
+  if (km < 10) return `${km.toFixed(1)} km`
+  return `${Math.round(km)} km`
+}

--- a/lib/itemOptions.ts
+++ b/lib/itemOptions.ts
@@ -56,18 +56,18 @@ export const CHIP_BASE_TONE = 'bg-white border border-gray-200'
 export const CHIP_TONE = `${CHIP_BASE_TONE} text-gray-700`
 export const PLACEHOLDER_TONE = `${CHIP_BASE_TONE} text-gray-400`
 
-export const CATEGORY_META: Record<Category, { emoji: string }> = {
-  교통: { emoji: '🚌' },
-  숙박: { emoji: '🏨' },
-  명소: { emoji: '🏛️' },
-  식당: { emoji: '🍽️' },
-  카페: { emoji: '☕' },
-  쇼핑: { emoji: '🛍️' },
-  문화시설: { emoji: '🎨' },
-  '공연·스포츠': { emoji: '🎭' },
-  액티비티: { emoji: '🎯' },
-  휴양: { emoji: '🌴' },
-  기타: { emoji: '🔖' },
+export const CATEGORY_META: Record<Category, { emoji: string; color: string }> = {
+  교통: { emoji: '🚌', color: '#94a3b8' },
+  숙박: { emoji: '🏨', color: '#0ea5e9' },
+  명소: { emoji: '🏛️', color: '#f97316' },
+  식당: { emoji: '🍽️', color: '#ef4444' },
+  카페: { emoji: '☕', color: '#a16207' },
+  쇼핑: { emoji: '🛍️', color: '#ec4899' },
+  문화시설: { emoji: '🎨', color: '#8b5cf6' },
+  '공연·스포츠': { emoji: '🎭', color: '#10b981' },
+  액티비티: { emoji: '🎯', color: '#f59e0b' },
+  휴양: { emoji: '🌴', color: '#22c55e' },
+  기타: { emoji: '🔖', color: '#cbd5e1' },
 }
 
 export const TRIP_PRIORITY_META: Record<TripPriority, { description: string; order: number; emoji: string; style: BadgeStyle }> = {


### PR DESCRIPTION
## 요약

- **카테고리 컬러 스택바**: 일자 헤더 하단에 카테고리 구성 비율을 한 줄 스택바로 시각화. 균형 점검(식당만 4개? 명소만 몰림?)을 한눈에.
- **항목 간 직선거리**: 좌표가 있는 연속 일정 사이에 Haversine 직선거리 표시 (`0.9 km` 등). 외부 API 의존성·비용 0.
- 시간 추정은 부정확 위험으로 의도적 제외 — 정확한 routing API 도입 시점에 별도 페이즈로 추가 예정.

## 변경 범위

- `components/Schedule/CategoryStackBar.tsx` (신규)
- `components/Schedule/DistanceSeparator.tsx` (신규)
- `components/Schedule/DateGroupHeader.tsx` — `categoryBreakdown` prop 추가, 헤더 하단에 스택바 렌더링
- `components/Schedule/ScheduleTable.tsx` — 데스크톱·모바일 양쪽 그룹 렌더에서 거리 separator 삽입
- `lib/distance.ts` (신규) — Haversine 거리 + 단위 포맷터
- `lib/itemOptions.ts` — `CATEGORY_META`에 `color` 필드 추가 (기존 사용처는 모두 `.emoji`만 참조하므로 안전)

## 영향 범위 — CRUD 무관

- `app/api/*` 변경 없음
- `lib/data.ts`, `types/index.ts`, `supabase/`, `middleware.ts` 변경 없음
- 데이터 모델·인증·CRUD 흐름 모두 그대로

## 모바일

- 스택바: 일자 카드 헤더 하단에 한 줄로 들어감 — 추가 공간 거의 없음
- 거리: 카드 사이 small connector로 표시

## 테스트

- [x] `npm run build` 성공
- [x] `npm run lint` 무경고
- [x] `npx tsc --noEmit` 통과
- [ ] 데스크톱: 일정 페이지에서 일자 헤더 스택바 + 항목 사이 거리 표시 확인
- [ ] 모바일: 일정 페이지에서 카드 사이 거리 표시 확인
- [ ] 좌표가 없는 항목 사이에는 거리 표시되지 않음 확인
- [ ] 같은 위치(50m 미만) 항목 사이에는 거리 표시되지 않음 확인