### PR TITLE
feat: /map 페이지 map-centric 다중 패널 레이아웃 재설계

### DIFF
--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,16 +1,18 @@
 'use client'
 
-import { Suspense, useEffect, useState } from 'react'
+import { Suspense, useEffect, useMemo, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import dynamic from 'next/dynamic'
 import Navigation from '@/components/Layout/Navigation'
 import { useItems } from '@/lib/hooks/useItems'
+import DayTabs, { type DaySummary } from '@/components/Schedule/DayTabs'
+import DayTimeline from '@/components/Schedule/DayTimeline'
+import MapCandidatePanel from '@/components/Map/MapCandidatePanel'
+import { CATEGORY_OPTIONS } from '@/lib/itemOptions'
+import type { Category, TripItem } from '@/types'
 
-const ResearchMap = dynamic(() => import('@/components/Map/ResearchMap'), { ssr: false })
-const ScheduleMap = dynamic(() => import('@/components/Map/ScheduleMap'), { ssr: false })
+const TripPlannerMap = dynamic(() => import('@/components/Map/TripPlannerMap'), { ssr: false })
 const ItemPanel = dynamic(() => import('@/components/Panel/ItemPanel'), { ssr: false })
-
-type MapView = 'all' | 'schedule'
 
 export default function MapPage() {
   return (
@@ -20,17 +22,79 @@ export default function MapPage() {
   )
 }
 
+function nextDate(date: string): string {
+  const [y, m, d] = date.split('-').map(Number)
+  return new Date(Date.UTC(y, m - 1, d + 1)).toISOString().slice(0, 10)
+}
+
+function occursOnDate(item: TripItem, date: string): boolean {
+  if (!item.date) return false
+  if (!item.end_date) return item.date === date
+  return item.date <= date && date <= item.end_date
+}
+
+function buildDaySummaries(items: TripItem[]): DaySummary[] {
+  const confirmed = items.filter(i => i.trip_priority === '확정' && i.date)
+  const dateSet = new Set<string>()
+  for (const i of confirmed) {
+    const end = i.end_date ?? i.date!
+    let cur = i.date!
+    while (cur <= end) {
+      dateSet.add(cur)
+      cur = nextDate(cur)
+    }
+  }
+  const sortedDates = Array.from(dateSet).sort()
+  if (sortedDates.length === 0) return []
+
+  const tripStart = sortedDates[0]
+  return sortedDates.map(date => {
+    const dayItems = confirmed.filter(i => occursOnDate(i, date))
+    const counts = new Map<Category, number>()
+    for (const it of dayItems) {
+      counts.set(it.category, (counts.get(it.category) ?? 0) + 1)
+    }
+    const breakdown = CATEGORY_OPTIONS.filter(c => counts.has(c)).map(c => ({
+      category: c,
+      count: counts.get(c)!,
+    }))
+    const offsetMs = new Date(date).getTime() - new Date(tripStart).getTime()
+    const dayOffset = Math.round(offsetMs / (1000 * 60 * 60 * 24))
+    return {
+      date,
+      dayOffset,
+      stopCount: dayItems.length,
+      breakdown,
+    }
+  })
+}
+
 function MapPageContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const { items, isLoading } = useItems()
-  const [mapView, setMapView] = useState<MapView>('all')
 
   const [selectedItemId, setSelectedItemId] = useState<string | null>(
-    () => searchParams.get('item')
+    () => searchParams.get('item'),
   )
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
 
   const selectedItem = items.find(i => i.id === selectedItemId) ?? null
+  const days = useMemo(() => buildDaySummaries(items), [items])
+
+  // 첫 렌더 시 첫 day 자동 선택
+  useEffect(() => {
+    if (selectedDate === null && days.length > 0) {
+      setSelectedDate(days[0].date)
+    }
+  }, [days, selectedDate])
+
+  const dayItems = useMemo(() => {
+    if (!selectedDate) return [] as TripItem[]
+    return items
+      .filter(i => i.trip_priority === '확정' && occursOnDate(i, selectedDate))
+      .sort((a, b) => (a.time_start ?? '99:99').localeCompare(b.time_start ?? '99:99'))
+  }, [items, selectedDate])
 
   // invalid item ID 처리
   useEffect(() => {
@@ -61,31 +125,62 @@ function MapPageContent() {
 
   return (
     <div className="md:pl-44">
-      <div className="relative h-[calc(100vh-56px)] md:h-screen">
-        {/* 지도 뷰 토글 */}
-        <div className="absolute top-3 left-1/2 -translate-x-1/2 z-[1000] flex rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
-          <button
-            onClick={() => setMapView('all')}
-            className={`px-3 py-1.5 text-sm font-medium transition-colors ${
-              mapView === 'all' ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-50'
-            }`}
-          >
-            전체
-          </button>
-          <button
-            onClick={() => setMapView('schedule')}
-            className={`px-3 py-1.5 text-sm font-medium transition-colors ${
-              mapView === 'schedule' ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-50'
-            }`}
-          >
-            일정
-          </button>
+      {/* Desktop layout: left candidates | center map | bottom day strip */}
+      <div className="hidden md:flex h-screen flex-col">
+        <div className="flex min-h-0 flex-1">
+          <div className="w-[300px] flex-shrink-0 border-r border-gray-200">
+            <MapCandidatePanel
+              items={items}
+              selectedItemId={selectedItemId}
+              onSelectItem={handleSelectItem}
+            />
+          </div>
+          <div className="relative min-w-0 flex-1">
+            <TripPlannerMap
+              items={items}
+              selectedDate={selectedDate}
+              selectedItemId={selectedItemId}
+              onSelectItem={handleSelectItem}
+            />
+          </div>
         </div>
+        {days.length > 0 && (
+          <div className="flex-shrink-0 border-t border-gray-200 bg-white">
+            <DayTabs days={days} selectedDate={selectedDate} onSelect={setSelectedDate} />
+            <div className="border-t border-gray-100">
+              <DayTimeline
+                items={dayItems}
+                selectedItemId={selectedItemId}
+                onSelectItem={handleSelectItem}
+              />
+            </div>
+          </div>
+        )}
+      </div>
 
-        {mapView === 'all' ? (
-          <ResearchMap items={items} onSelectItem={handleSelectItem} />
-        ) : (
-          <ScheduleMap items={items} onSelectItem={handleSelectItem} />
+      {/* Mobile layout: map fullscreen + bottom day tabs (timeline scrolls) */}
+      <div className="md:hidden flex h-[calc(100vh-56px)] flex-col">
+        <div className="relative min-h-0 flex-1">
+          <TripPlannerMap
+            items={items}
+            selectedDate={selectedDate}
+            selectedItemId={selectedItemId}
+            onSelectItem={handleSelectItem}
+          />
+        </div>
+        {days.length > 0 && (
+          <div className="flex-shrink-0 border-t border-gray-200 bg-white">
+            <DayTabs days={days} selectedDate={selectedDate} onSelect={setSelectedDate} />
+            {dayItems.length > 0 && (
+              <div className="border-t border-gray-100">
+                <DayTimeline
+                  items={dayItems}
+                  selectedItemId={selectedItemId}
+                  onSelectItem={handleSelectItem}
+                />
+              </div>
+            )}
+          </div>
         )}
       </div>
 

--- a/components/Map/MapCandidatePanel.tsx
+++ b/components/Map/MapCandidatePanel.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import type { Category, TripItem } from '@/types'
+import { CATEGORY_META, CATEGORY_OPTIONS, TRIP_PRIORITY_META } from '@/lib/itemOptions'
+
+interface MapCandidatePanelProps {
+  items: TripItem[]
+  selectedItemId: string | null
+  onSelectItem: (id: string) => void
+}
+
+function categoryCounts(items: TripItem[]): Map<Category, number> {
+  const counts = new Map<Category, number>()
+  for (const it of items) {
+    counts.set(it.category, (counts.get(it.category) ?? 0) + 1)
+  }
+  return counts
+}
+
+function matchesQuery(item: TripItem, q: string): boolean {
+  if (!q) return true
+  const needle = q.toLowerCase()
+  return (
+    item.name.toLowerCase().includes(needle) ||
+    (item.address ?? '').toLowerCase().includes(needle) ||
+    (item.memo ?? '').toLowerCase().includes(needle)
+  )
+}
+
+export default function MapCandidatePanel({
+  items,
+  selectedItemId,
+  onSelectItem,
+}: MapCandidatePanelProps) {
+  const [query, setQuery] = useState('')
+  const [categoryFilter, setCategoryFilter] = useState<Category | null>(null)
+
+  const candidates = useMemo(
+    () => items.filter(i => i.trip_priority !== '제외'),
+    [items],
+  )
+
+  const counts = useMemo(() => categoryCounts(candidates), [candidates])
+
+  const filtered = useMemo(() => {
+    return candidates
+      .filter(i => (categoryFilter ? i.category === categoryFilter : true))
+      .filter(i => matchesQuery(i, query))
+      .sort((a, b) => {
+        const oa = TRIP_PRIORITY_META[a.trip_priority]?.order ?? 99
+        const ob = TRIP_PRIORITY_META[b.trip_priority]?.order ?? 99
+        if (oa !== ob) return ob - oa
+        return a.name.localeCompare(b.name)
+      })
+  }, [candidates, categoryFilter, query])
+
+  return (
+    <aside className="flex h-full flex-col bg-white">
+      <header className="flex-shrink-0 border-b border-gray-200 px-4 pt-4 pb-3">
+        <div className="mb-3 flex items-baseline justify-between">
+          <h2 className="text-sm font-semibold text-gray-900">
+            후보 <span className="text-gray-500 tabular-nums">({candidates.length})</span>
+          </h2>
+        </div>
+        <input
+          type="search"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          placeholder="검색…"
+          className="w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm placeholder:text-gray-400 focus:border-gray-400 focus:bg-white focus:outline-none"
+          style={{ fontSize: 14 }}
+        />
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          <button
+            type="button"
+            onClick={() => setCategoryFilter(null)}
+            className={`rounded-full px-2.5 py-0.5 text-[11px] font-medium transition-colors ${
+              categoryFilter === null
+                ? 'bg-gray-900 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            모두
+          </button>
+          {CATEGORY_OPTIONS.filter(c => (counts.get(c) ?? 0) > 0).map(c => {
+            const active = categoryFilter === c
+            const color = CATEGORY_META[c]?.color ?? '#cbd5e1'
+            return (
+              <button
+                key={c}
+                type="button"
+                onClick={() => setCategoryFilter(active ? null : c)}
+                className={`flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] transition-colors ${
+                  active
+                    ? 'bg-gray-900 text-white'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+              >
+                <span
+                  className="inline-block h-2 w-2 rounded-full"
+                  style={{ backgroundColor: color }}
+                />
+                {c}
+                <span className="tabular-nums opacity-70">{counts.get(c)}</span>
+              </button>
+            )
+          })}
+        </div>
+      </header>
+
+      <ul className="min-h-0 flex-1 divide-y divide-gray-100 overflow-y-auto">
+        {filtered.length === 0 ? (
+          <li className="px-4 py-6 text-center text-xs text-gray-400">결과가 없습니다</li>
+        ) : (
+          filtered.map(item => {
+            const active = item.id === selectedItemId
+            const color = CATEGORY_META[item.category]?.color ?? '#cbd5e1'
+            const emoji = CATEGORY_META[item.category]?.emoji ?? '📌'
+            const isConfirmed = item.trip_priority === '확정'
+            return (
+              <li key={item.id}>
+                <button
+                  type="button"
+                  onClick={() => onSelectItem(item.id)}
+                  className={`flex w-full items-start gap-2 px-4 py-2.5 text-left transition-colors ${
+                    active ? 'bg-gray-100' : 'hover:bg-gray-50'
+                  }`}
+                >
+                  <span
+                    className="mt-1 inline-block h-2 w-2 flex-shrink-0 rounded-full"
+                    style={{ backgroundColor: color }}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-1.5">
+                      <span className="text-xs">{emoji}</span>
+                      <span className="truncate text-xs font-semibold text-gray-900">
+                        {item.name}
+                      </span>
+                      {isConfirmed && (
+                        <span className="flex-shrink-0 rounded bg-green-50 px-1 py-px text-[9px] font-semibold tracking-wide text-green-700">
+                          확정
+                        </span>
+                      )}
+                    </span>
+                    {item.address && (
+                      <span className="mt-0.5 block truncate text-[10px] text-gray-500">
+                        {item.address}
+                      </span>
+                    )}
+                  </span>
+                </button>
+              </li>
+            )
+          })
+        )}
+      </ul>
+    </aside>
+  )
+}

--- a/components/Map/TripPlannerMap.tsx
+++ b/components/Map/TripPlannerMap.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { useMemo } from 'react'
+import { MapContainer, TileLayer, Marker, Polyline, Tooltip } from 'react-leaflet'
+import L from 'leaflet'
+import type { TripItem } from '@/types'
+import { CATEGORY_META } from '@/lib/itemOptions'
+
+interface TripPlannerMapProps {
+  items: TripItem[]
+  selectedDate: string | null
+  selectedItemId: string | null
+  onSelectItem: (id: string) => void
+}
+
+function chipIcon(emoji: string, opts: { dim?: boolean; selected?: boolean }) {
+  const opacity = opts.dim ? 0.55 : 1
+  const border = opts.selected ? '#0f172a' : '#e2e8f0'
+  const borderWidth = opts.selected ? 2 : 1.5
+  return L.divIcon({
+    html: `<div style="
+      display:inline-flex;align-items:center;justify-content:center;
+      padding:2px 6px;background:white;
+      border:${borderWidth}px solid ${border};
+      border-radius:9999px;
+      box-shadow:0 1px 4px rgba(0,0,0,0.15);
+      font-size:14px;line-height:1;white-space:nowrap;
+      opacity:${opacity};
+    ">${emoji}</div>`,
+    className: '',
+    iconSize: [28, 24],
+    iconAnchor: [14, 12],
+  })
+}
+
+function numberIcon(num: number, selected: boolean) {
+  const bg = selected ? '#0f172a' : '#374151'
+  return L.divIcon({
+    html: `<div style="
+      width:28px;height:28px;border-radius:50%;
+      background:${bg};color:white;
+      display:flex;align-items:center;justify-content:center;
+      font-size:12px;font-weight:700;
+      border:2.5px solid white;
+      box-shadow:0 2px 6px rgba(0,0,0,0.3);
+    ">${num}</div>`,
+    className: '',
+    iconSize: [28, 28],
+    iconAnchor: [14, 14],
+  })
+}
+
+function occursOnDate(item: TripItem, date: string): boolean {
+  if (!item.date) return false
+  if (!item.end_date) return item.date === date
+  return item.date <= date && date <= item.end_date
+}
+
+export default function TripPlannerMap({
+  items,
+  selectedDate,
+  selectedItemId,
+  onSelectItem,
+}: TripPlannerMapProps) {
+  const visibleItems = useMemo(
+    () =>
+      items.filter(
+        i => i.trip_priority !== '제외' && i.lat !== undefined && i.lng !== undefined,
+      ),
+    [items],
+  )
+
+  const dayItems = useMemo(() => {
+    if (!selectedDate) return [] as TripItem[]
+    return visibleItems
+      .filter(i => occursOnDate(i, selectedDate))
+      .sort((a, b) => (a.time_start ?? '99:99').localeCompare(b.time_start ?? '99:99'))
+  }, [visibleItems, selectedDate])
+
+  const dayItemIds = useMemo(() => new Set(dayItems.map(i => i.id)), [dayItems])
+  const polyline = dayItems.map(i => [i.lat!, i.lng!] as [number, number])
+
+  return (
+    <MapContainer
+      center={[40.7128, -74.006]}
+      zoom={13}
+      style={{ height: '100%', width: '100%' }}
+      className="touch-none"
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+        url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+      />
+
+      {visibleItems
+        .filter(i => !dayItemIds.has(i.id))
+        .map(item => (
+          <Marker
+            key={item.id}
+            position={[item.lat!, item.lng!]}
+            icon={chipIcon(CATEGORY_META[item.category]?.emoji ?? '📌', {
+              dim: selectedDate !== null,
+              selected: item.id === selectedItemId,
+            })}
+            eventHandlers={{ click: () => onSelectItem(item.id) }}
+          >
+            <Tooltip direction="top" offset={[0, -12]} opacity={0.9}>
+              <span className="text-xs font-medium">{item.name}</span>
+            </Tooltip>
+          </Marker>
+        ))}
+
+      {dayItems.map((item, idx) => (
+        <Marker
+          key={item.id}
+          position={[item.lat!, item.lng!]}
+          icon={numberIcon(idx + 1, item.id === selectedItemId)}
+          eventHandlers={{ click: () => onSelectItem(item.id) }}
+          zIndexOffset={1000}
+        >
+          <Tooltip direction="top" offset={[0, -14]} opacity={0.95}>
+            <span className="text-xs font-medium">
+              {idx + 1}. {item.name}
+            </span>
+          </Tooltip>
+        </Marker>
+      ))}
+
+      {polyline.length > 1 && (
+        <Polyline positions={polyline} color="#0f172a" weight={2.5} opacity={0.6} />
+      )}
+    </MapContainer>
+  )
+}

--- a/components/Schedule/DayTabs.tsx
+++ b/components/Schedule/DayTabs.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import type { Category } from '@/types'
+import CategoryStackBar from './CategoryStackBar'
+
+export interface DaySummary {
+  date: string
+  dayOffset: number
+  stopCount: number
+  breakdown: { category: Category; count: number }[]
+}
+
+interface DayTabsProps {
+  days: DaySummary[]
+  selectedDate: string | null
+  onSelect: (date: string) => void
+}
+
+const WEEKDAYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+
+function formatTab(date: string): { weekday: string; label: string } {
+  const [y, m, d] = date.split('-').map(Number)
+  const dt = new Date(Date.UTC(y, m - 1, d))
+  return {
+    weekday: WEEKDAYS[dt.getUTCDay()],
+    label: `${m}/${d}`,
+  }
+}
+
+export default function DayTabs({ days, selectedDate, onSelect }: DayTabsProps) {
+  if (days.length === 0) {
+    return (
+      <div className="px-4 py-3 text-xs text-gray-400">
+        확정된 일정이 없습니다
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex gap-1 overflow-x-auto px-2 py-2" style={{ scrollbarWidth: 'thin' }}>
+      {days.map(day => {
+        const { weekday, label } = formatTab(day.date)
+        const active = day.date === selectedDate
+        return (
+          <button
+            key={day.date}
+            type="button"
+            onClick={() => onSelect(day.date)}
+            className={`flex-shrink-0 flex flex-col items-start gap-1 rounded-lg border px-3 py-2 text-left transition-colors ${
+              active
+                ? 'border-gray-900 bg-gray-900 text-white'
+                : 'border-gray-200 bg-white text-gray-700 hover:border-gray-400'
+            }`}
+            style={{ minWidth: 92 }}
+          >
+            <div className="flex items-baseline gap-2">
+              <span className="text-[10px] font-semibold tracking-wider opacity-70">
+                D{day.dayOffset + 1}
+              </span>
+              <span className="text-[10px] tracking-wide opacity-60">{weekday}</span>
+            </div>
+            <div className="flex w-full items-baseline justify-between gap-2">
+              <span className="text-sm font-bold tabular-nums">{label}</span>
+              <span className={`text-[10px] tabular-nums ${active ? 'opacity-80' : 'text-gray-500'}`}>
+                {day.stopCount}곳
+              </span>
+            </div>
+            {day.breakdown.length > 0 && (
+              <div className={`w-full ${active ? 'opacity-90' : ''}`}>
+                <CategoryStackBar breakdown={day.breakdown} />
+              </div>
+            )}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/Schedule/DayTimeline.tsx
+++ b/components/Schedule/DayTimeline.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { Fragment } from 'react'
+import type { TripItem } from '@/types'
+import { CATEGORY_META } from '@/lib/itemOptions'
+import { formatDistance, haversineKm } from '@/lib/distance'
+
+interface DayTimelineProps {
+  items: TripItem[]
+  selectedItemId: string | null
+  onSelectItem: (id: string) => void
+}
+
+function distance(a: TripItem, b: TripItem): number | null {
+  if (a.lat == null || a.lng == null || b.lat == null || b.lng == null) return null
+  const km = haversineKm({ lat: a.lat, lng: a.lng }, { lat: b.lat, lng: b.lng })
+  if (km < 0.05) return null
+  return km
+}
+
+function formatTime(item: TripItem): string {
+  if (item.time_start && item.time_end) return `${item.time_start}-${item.time_end}`
+  if (item.time_start) return item.time_start
+  return '시간 미정'
+}
+
+export default function DayTimeline({ items, selectedItemId, onSelectItem }: DayTimelineProps) {
+  if (items.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-gray-400">
+        이 날에 배정된 스톱이 없습니다
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-stretch gap-0 overflow-x-auto px-3 py-3" style={{ scrollbarWidth: 'thin' }}>
+      {items.map((item, idx) => {
+        const prev = idx > 0 ? items[idx - 1] : null
+        const km = prev ? distance(prev, item) : null
+        const emoji = CATEGORY_META[item.category]?.emoji ?? '📌'
+        const color = CATEGORY_META[item.category]?.color ?? '#cbd5e1'
+        const active = item.id === selectedItemId
+        return (
+          <Fragment key={item.id}>
+            {km != null && (
+              <div
+                aria-hidden="true"
+                className="flex flex-shrink-0 items-center px-1.5 text-[10px] tabular-nums text-gray-400"
+              >
+                <span className="inline-block h-px w-3 bg-gray-200" />
+                <span className="px-1">{formatDistance(km)}</span>
+                <span className="inline-block h-px w-3 bg-gray-200" />
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={() => onSelectItem(item.id)}
+              className={`flex-shrink-0 rounded-lg border px-3 py-2 text-left transition-colors ${
+                active
+                  ? 'border-gray-900 bg-gray-50 ring-1 ring-gray-900'
+                  : 'border-gray-200 bg-white hover:border-gray-400'
+              }`}
+              style={{ minWidth: 180, maxWidth: 220, borderLeftWidth: 3, borderLeftColor: color }}
+            >
+              <div className="flex items-center gap-1.5 text-[10px] tabular-nums text-gray-500">
+                <span
+                  className="flex h-4 w-4 items-center justify-center rounded-full bg-gray-900 text-[9px] font-bold text-white"
+                >
+                  {idx + 1}
+                </span>
+                <span>{formatTime(item)}</span>
+              </div>
+              <div className="mt-1 flex items-start gap-1.5">
+                <span className="text-sm leading-tight">{emoji}</span>
+                <span className="line-clamp-2 text-xs font-semibold leading-tight text-gray-900">
+                  {item.name}
+                </span>
+              </div>
+            </button>
+          </Fragment>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
## 요약

캡쳐 시안에 맞춰 `/map`을 풀스크린 단일 지도에서 **map-centric 다중 패널**로 재구성:

- **좌측 후보 패널** — 검색 + 카테고리 필터 칩(개수 포함) + 우선순위/이름 정렬 리스트
- **중앙 지도** — 선택 day 스톱은 번호(1, 2, 3...) 마커 + polyline 동선, 그 외는 옅은 카테고리 칩
- **하단 일자 탭** — D1, D2, ... 가로 스크롤. 각 탭에 카테고리 컬러 스택바(균형 미리보기)
- **하단 미니 타임라인** — 선택 day의 스톱을 가로 카드로, 사이에 직선거리 separator

## 모바일

3-패널 압축 대신 단순화:
- 지도 풀스크린 + 하단 일자 탭/타임라인
- 좌측 후보 리스트는 기존 \`/research\` 페이지에서 (네비 동선 유지)

## 변경 범위

- 신규: \`components/Map/TripPlannerMap.tsx\`, \`components/Map/MapCandidatePanel.tsx\`, \`components/Schedule/DayTabs.tsx\`, \`components/Schedule/DayTimeline.tsx\`
- 수정: \`app/map/page.tsx\` (레이아웃 전면 재구성)
- 삭제 대신 통합: 기존 \`ResearchMap\`/\`ScheduleMap\` 토글은 \`TripPlannerMap\` 단일 컴포넌트로 합침. (기존 두 파일은 다른 페이지에서 미사용이지만 일단 보존)

## 영향 범위 — CRUD 무관

- \`app/api/*\` 변경 없음
- \`lib/data.ts\`, \`types/index.ts\`, \`supabase/\`, \`middleware.ts\` 변경 없음
- 데이터 모델·인증·CRUD 흐름 그대로

## 의도적으로 미포함

- 우측 D1-D10 overview 패널 — 하단 일자 탭이 day 전환을 이미 커버 (정보 중복 회피)
- 후보 lifecycle 3단 그룹 (관심/검토중/보류) — power user 기능, 정보 과다 위험
- 후보→day 드래그앤드롭 — 별도 페이즈
- Atlas/Board/Reel 모드 스위처 — over-engineering
- 이동 시간 표기 — routing API 도입 시 별도 페이즈

## 테스트

- [x] \`npx tsc --noEmit\` 통과
- [x] \`npm run lint\` 무경고
- [x] \`npm run build\` 성공
- [ ] 데스크톱: 좌측 후보 검색/필터, 지도에서 후보 클릭→선택, 일자 탭 전환→번호 마커 표시, 미니 타임라인 거리 표시
- [ ] 모바일: 지도 풀스크린, 하단 일자 탭/타임라인 동작
- [ ] CRUD: 항목 생성/수정/삭제가 \`/research\`, \`/schedule\`, \`/map\` 모든 페이지에서 정상 동작