### PR TITLE
refactor: 사이드 패널 가로 스크롤 탭을 모드 토글 + day 그리드로 변경

### DIFF
--- a/components/Map/MapSidePanel.tsx
+++ b/components/Map/MapSidePanel.tsx
@@ -82,46 +82,76 @@ export default function MapSidePanel({
     return days.find(d => d.date === selectedDate) ?? null
   }, [days, selectedDate])
 
+  const mode: 'candidates' | 'day' = selectedDate === null ? 'candidates' : 'day'
+
+  function handleModeChange(next: 'candidates' | 'day') {
+    if (next === 'candidates') {
+      onSelectDate(null)
+    } else if (selectedDate === null && days.length > 0) {
+      onSelectDate(days[0].date)
+    }
+  }
+
   return (
     <aside className="flex h-full flex-col bg-white">
-      {/* Scope tabs */}
-      <nav
-        className="flex flex-shrink-0 gap-1 overflow-x-auto border-b border-gray-200 bg-gray-50/50 px-2 py-2"
-        style={{ scrollbarWidth: 'thin' }}
-      >
+      {/* Mode toggle (segmented) */}
+      <div className="flex flex-shrink-0 border-b border-gray-200 bg-gray-50/50 p-1.5">
         <button
           type="button"
-          onClick={() => onSelectDate(null)}
-          className={`flex flex-shrink-0 items-baseline gap-1 rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-            selectedDate === null
-              ? 'bg-gray-900 text-white'
-              : 'bg-white text-gray-700 hover:bg-gray-100'
+          onClick={() => handleModeChange('candidates')}
+          className={`flex flex-1 items-baseline justify-center gap-1 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+            mode === 'candidates'
+              ? 'bg-white text-gray-900 shadow-sm'
+              : 'text-gray-600 hover:text-gray-900'
           }`}
         >
           후보
           <span className="text-[10px] tabular-nums opacity-70">{candidates.length}</span>
         </button>
-        {days.map(day => {
-          const active = day.date === selectedDate
-          const { tab } = formatDateLabel(day.date)
-          return (
-            <button
-              key={day.date}
-              type="button"
-              onClick={() => onSelectDate(day.date)}
-              className={`flex flex-shrink-0 items-baseline gap-1 rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-                active ? 'bg-gray-900 text-white' : 'bg-white text-gray-700 hover:bg-gray-100'
-              }`}
-              title={`${tab} · ${day.stopCount}곳`}
-            >
-              <span className="text-[10px] font-semibold tracking-wider opacity-70">
-                D{day.dayOffset + 1}
-              </span>
-              <span className="tabular-nums">{tab}</span>
-            </button>
-          )
-        })}
-      </nav>
+        <button
+          type="button"
+          onClick={() => handleModeChange('day')}
+          disabled={days.length === 0}
+          className={`flex flex-1 items-baseline justify-center gap-1 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+            mode === 'day'
+              ? 'bg-white text-gray-900 shadow-sm'
+              : 'text-gray-600 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50'
+          }`}
+        >
+          일정
+          {days.length > 0 && (
+            <span className="text-[10px] tabular-nums opacity-70">{days.length}일</span>
+          )}
+        </button>
+      </div>
+
+      {/* Day grid (only in day mode) */}
+      {mode === 'day' && days.length > 0 && (
+        <div className="flex flex-shrink-0 flex-wrap gap-1.5 border-b border-gray-200 px-3 py-2">
+          {days.map(day => {
+            const active = day.date === selectedDate
+            const { tab } = formatDateLabel(day.date)
+            return (
+              <button
+                key={day.date}
+                type="button"
+                onClick={() => onSelectDate(day.date)}
+                className={`flex items-baseline gap-1 rounded-md border px-2 py-1 text-xs font-medium transition-colors ${
+                  active
+                    ? 'border-gray-900 bg-gray-900 text-white'
+                    : 'border-gray-200 bg-white text-gray-700 hover:border-gray-400'
+                }`}
+                title={`${tab} · ${day.stopCount}곳`}
+              >
+                <span className="text-[10px] font-semibold tracking-wider opacity-70">
+                  D{day.dayOffset + 1}
+                </span>
+                <span className="tabular-nums">{tab}</span>
+              </button>
+            )
+          })}
+        </div>
+      )}
 
       {selectedDate === null ? (
         <CandidatesView


### PR DESCRIPTION
## 요약

좌측 사이드 패널의 가로 스크롤 스코프 탭을 **모드 토글(segmented) + day 그리드(wrap)** 구조로 교체. 가로 스크롤 사라짐, 후보 모드에선 chrome 최소화.

## 동작

**후보 모드 (기본)**:
\`\`\`
┌────────────────────────────┐
│ [ 후보(15) ●][   일정 10일 ] │  ← segmented
├────────────────────────────┤
│ 검색·카테고리 칩·리스트       │
└────────────────────────────┘
\`\`\`

**일정 모드**:
\`\`\`
┌────────────────────────────┐
│ [ 후보 ][   일정 10일 ●  ]  │
├────────────────────────────┤
│ [D1·7/1][D2·7/2][D3·7/3]   │  ← flex-wrap, 가로 스크롤 X
│ [D4·7/4][D5·7/5][D6·7/6]   │
│ [D7·7/7][D8·7/8][D9·7/9]   │
│ [D10·7/10]                 │
├────────────────────────────┤
│ 날짜 헤더 + 스택바 + 타임라인 │
└────────────────────────────┘
\`\`\`

## 디자인 결정

- 후보 모드가 평소 기본이라, 일정 모드일 때만 day 그리드를 노출 → chrome 최소화
- 일정 토글 클릭 시 첫 day 자동 선택 (back to 후보 클릭 시 \`selectedDate=null\`)
- 확정된 일정이 없으면 "일정" 토글 비활성화

## 변경 범위

- 단일 파일: \`components/Map/MapSidePanel.tsx\`
- CRUD/API/데이터 모델 변경 없음

## 테스트

- [x] \`npx tsc --noEmit\` 통과
- [x] \`npm run lint\` 무경고
- [x] \`npm run build\` 성공
- [ ] 데스크톱: 후보↔일정 토글 동작, day 그리드에서 wrap 정상, 가로 스크롤 없음
- [ ] 모바일: 320px 폭에서 day 그리드 wrap 확인
- [ ] 확정 일정 0개일 때 "일정" 토글 disabled 확인