### PR TITLE
fix: 자정 크로스오버 일정이 종료일에 중복 표시되는 문제 수정

### DIFF
--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -27,19 +27,27 @@ function nextDate(date: string): string {
 
 function occursOnDate(item: TripItem, date: string): boolean {
   if (!item.date) return false
-  if (!item.end_date) return item.date === date
-  return item.date <= date && date <= item.end_date
+  if (item.date === date) return true
+  // end_date 까지 확장하는 건 종일/다일 일정(time_start 없음)에만 적용.
+  // 자정을 넘기는 단일 일정이 종료일 리스트에 끼어들지 않도록.
+  if (item.end_date && !item.time_start) {
+    return item.date <= date && date <= item.end_date
+  }
+  return false
 }
 
 function buildDaySummaries(items: TripItem[]): DaySummary[] {
   const confirmed = items.filter(i => i.trip_priority === '확정' && i.date)
   const dateSet = new Set<string>()
   for (const i of confirmed) {
-    const end = i.end_date ?? i.date!
-    let cur = i.date!
-    while (cur <= end) {
-      dateSet.add(cur)
-      cur = nextDate(cur)
+    // 시작일은 항상 포함. end_date 까지 확장은 종일/다일 일정에만.
+    dateSet.add(i.date!)
+    if (i.end_date && !i.time_start) {
+      let cur = nextDate(i.date!)
+      while (cur <= i.end_date) {
+        dateSet.add(cur)
+        cur = nextDate(cur)
+      }
     }
   }
   const sortedDates = Array.from(dateSet).sort()

--- a/components/Map/MapSidePanel.tsx
+++ b/components/Map/MapSidePanel.tsx
@@ -53,8 +53,14 @@ function matchesQuery(item: TripItem, q: string): boolean {
 
 function occursOnDate(item: TripItem, date: string): boolean {
   if (!item.date) return false
-  if (!item.end_date) return item.date === date
-  return item.date <= date && date <= item.end_date
+  if (item.date === date) return true
+  // end_date 까지 확장하는 건 종일/다일 일정(time_start 없음)에만 적용.
+  // time_start 가 있는 일정은 시작일에만 표시 — 자정을 넘기는 단일 일정이
+  // 종료일 리스트에 끼어들지 않도록.
+  if (item.end_date && !item.time_start) {
+    return item.date <= date && date <= item.end_date
+  }
+  return false
 }
 
 export default function MapSidePanel({


### PR DESCRIPTION
## Summary

- `occursOnDate` 가 `date != end_date` 인 일정을 양일 모두 포함시키던 문제 수정
- 7/7 23:30 → 7/8 01:00 같은 자정 크로스오버 단일 일정이 day-grid 7/8 리스트 맨 아래에 끼어들던 현상 해결
- 새 규칙: 시작일에는 항상 표시 / `end_date` 확장은 `time_start` 없는 종일·다일 일정(호텔 등)에만 적용
- `buildDaySummaries` 도 동일 규칙으로 통일

## Test plan

- [ ] 7/7 23:30 → 7/8 01:00 항목이 day-grid 7/7 에만 표시되는지 확인
- [ ] 다일 호텔 항목(time_start 없음)이 모든 숙박 날짜에 펼쳐지는지 확인
- [ ] ScheduleTable 등 다른 뷰의 그룹화에 영향 없는지 확인