### PR TITLE
디자인 시스템 정비 — 테마 토글 / 다크모드 완성도 / /plan 통합 / ItemPanel 결선

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -242,6 +242,56 @@
   filter: var(--tile-filter);
 }
 
+/* leaflet divIcon 마커 (TripPlannerMap, ResearchMap, ScheduleMap 공용) */
+.tp-chip-marker {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 6px;
+  background: rgb(var(--bg-elevated));
+  color: rgb(var(--fg));
+  border: 1.5px solid rgb(var(--border));
+  border-radius: 9999px;
+  box-shadow: 0 1px 4px rgb(var(--shadow) / 0.20);
+  font-size: 14px;
+  line-height: 1;
+  white-space: nowrap;
+}
+.tp-chip-marker.is-selected {
+  border-width: 2px;
+  border-color: rgb(var(--accent));
+}
+.tp-chip-marker.is-dim {
+  opacity: 0.55;
+}
+.tp-number-marker {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgb(var(--fg-muted));
+  color: rgb(var(--bg-elevated));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  border: 2.5px solid rgb(var(--bg-elevated));
+  box-shadow: 0 2px 6px rgb(var(--shadow) / 0.30);
+}
+.tp-number-marker.is-selected {
+  background: rgb(var(--accent));
+}
+.tp-number-marker.is-small {
+  width: 26px;
+  height: 26px;
+  font-size: 11px;
+}
+
+/* polyline (day route) */
+.tp-day-route {
+  stroke: rgb(var(--accent));
+}
+
 /* leaflet 컨트롤·attribution 다크 모드 보정 */
 :root.dark .leaflet-control,
 :root.dark .leaflet-bar,

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,30 +7,30 @@
 /* ============================================================
  * 시맨틱 디자인 토큰
  * - 색은 RGB triple 로 정의해 Tailwind 의 rgb(var(--x) / <alpha-value>) 와 호환
- * - 다크 모드는 prefers-color-scheme 기반 자동 적용 (토글 없음)
+ * - 다크 모드는 html.dark 클래스로 적용 (테마 토글 가능)
  * ========================================================== */
 @layer base {
   :root {
     /* surface */
     --bg: 255 255 255;
-    --bg-subtle: 248 250 252;        /* slate-50 */
+    --bg-subtle: 248 250 252;
     --bg-elevated: 255 255 255;
-    --bg-overlay: 15 23 42;          /* slate-900 (overlay 색, opacity 는 호출부에서) */
+    --bg-overlay: 15 23 42;
 
     /* text */
-    --fg: 15 23 42;                  /* slate-900 */
-    --fg-muted: 71 85 105;           /* slate-600 */
-    --fg-subtle: 148 163 184;        /* slate-400 */
+    --fg: 15 23 42;
+    --fg-muted: 71 85 105;
+    --fg-subtle: 148 163 184;
     --fg-on-accent: 255 255 255;
 
     /* line */
-    --border: 226 232 240;           /* slate-200 */
-    --border-strong: 203 213 225;    /* slate-300 */
+    --border: 226 232 240;
+    --border-strong: 203 213 225;
 
     /* accent — Teal */
-    --accent: 13 148 136;            /* teal-600 */
-    --accent-hover: 15 118 110;      /* teal-700 */
-    --accent-subtle: 240 253 250;    /* teal-50 */
+    --accent: 13 148 136;
+    --accent-hover: 15 118 110;
+    --accent-subtle: 240 253 250;
 
     /* status */
     --success-bg: 240 253 244;
@@ -46,10 +46,10 @@
     --info-fg: 30 64 175;
     --info-border: 191 219 254;
 
-    /* shadow base color (slate-900) */
+    /* shadow base */
     --shadow: 15 23 42;
 
-    /* category — light mode hex (인라인 스타일 호환) */
+    /* category — 라이트 hex */
     --cat-transit: #94a3b8;
     --cat-stay: #0ea5e9;
     --cat-sight: #f97316;
@@ -61,63 +61,130 @@
     --cat-activity: #f59e0b;
     --cat-leisure: #22c55e;
     --cat-other: #cbd5e1;
+
+    /* trip priority — 라이트 hex (인라인 style 호환용. className 으로 마이그레이션 됨) */
+    --priority-review-bg: #f8fafc;
+    --priority-review-fg: #94a3b8;
+    --priority-review-border: #e2e8f0;
+    --priority-maybe-bg: #eff6ff;
+    --priority-maybe-fg: #3b82f6;
+    --priority-maybe-border: #bfdbfe;
+    --priority-want-bg: #f5f3ff;
+    --priority-want-fg: #7c3aed;
+    --priority-want-border: #ddd6fe;
+    --priority-confirm-bg: #f0fdf4;
+    --priority-confirm-fg: #16a34a;
+    --priority-confirm-border: #bbf7d0;
+    --priority-exclude-bg: #f8fafc;
+    --priority-exclude-fg: #cbd5e1;
+    --priority-exclude-border: #e2e8f0;
+
+    /* reservation — 라이트 hex */
+    --reservation-check-bg: #fffbeb;
+    --reservation-check-fg: #d97706;
+    --reservation-check-border: #fde68a;
+    --reservation-none-bg: #f8fafc;
+    --reservation-none-fg: #94a3b8;
+    --reservation-none-border: #e2e8f0;
+    --reservation-needed-bg: #fff7ed;
+    --reservation-needed-fg: #ea580c;
+    --reservation-needed-border: #fed7aa;
+    --reservation-done-bg: #f0fdf4;
+    --reservation-done-fg: #16a34a;
+    --reservation-done-border: #bbf7d0;
+
+    /* leaflet tile filter (라이트는 무필터) */
+    --tile-filter: none;
   }
 
-  @media (prefers-color-scheme: dark) {
-    :root {
-      /* 층 구조: base → elevated 한 단계씩 밝게 (Apple/Fluent 권장) */
-      --bg: 11 16 32;                /* deep navy */
-      --bg-subtle: 19 26 46;
-      --bg-elevated: 26 34 58;
-      --bg-overlay: 0 0 0;
+  /* 다크 모드: html.dark 클래스로 적용 */
+  :root.dark {
+    --bg: 11 16 32;
+    --bg-subtle: 19 26 46;
+    --bg-elevated: 26 34 58;
+    --bg-overlay: 0 0 0;
 
-      --fg: 241 245 249;             /* slate-100 */
-      --fg-muted: 148 163 184;       /* slate-400 */
-      --fg-subtle: 100 116 139;      /* slate-500 */
-      --fg-on-accent: 11 16 32;
+    --fg: 241 245 249;
+    --fg-muted: 148 163 184;
+    --fg-subtle: 100 116 139;
+    --fg-on-accent: 11 16 32;
 
-      --border: 30 41 59;            /* slate-800 */
-      --border-strong: 51 65 85;     /* slate-700 */
+    --border: 30 41 59;
+    --border-strong: 51 65 85;
 
-      /* accent: 다크에서 채도 -10%, 명도 +15% (Fluent 권장) */
-      --accent: 45 212 191;          /* teal-400 */
-      --accent-hover: 94 234 212;    /* teal-300 */
-      --accent-subtle: 19 78 74;     /* teal-900 */
+    --accent: 45 212 191;
+    --accent-hover: 94 234 212;
+    --accent-subtle: 19 78 74;
 
-      --success-bg: 6 78 59;
-      --success-fg: 187 247 208;
-      --success-border: 21 128 61;
-      --warning-bg: 113 63 18;
-      --warning-fg: 254 240 138;
-      --warning-border: 161 98 7;
-      --critical-bg: 127 29 29;
-      --critical-fg: 254 202 202;
-      --critical-border: 185 28 28;
-      --info-bg: 30 58 138;
-      --info-fg: 191 219 254;
-      --info-border: 37 99 235;
+    --success-bg: 6 78 59;
+    --success-fg: 187 247 208;
+    --success-border: 21 128 61;
+    --warning-bg: 113 63 18;
+    --warning-fg: 254 240 138;
+    --warning-border: 161 98 7;
+    --critical-bg: 127 29 29;
+    --critical-fg: 254 202 202;
+    --critical-border: 185 28 28;
+    --info-bg: 30 58 138;
+    --info-fg: 191 219 254;
+    --info-border: 37 99 235;
 
-      --shadow: 0 0 0;
+    --shadow: 0 0 0;
 
-      /* category 다크 톤 (채도 살짝 낮춤) */
-      --cat-transit: #b6c3d2;
-      --cat-stay: #38bdf8;
-      --cat-sight: #fb923c;
-      --cat-food: #f87171;
-      --cat-cafe: #d97706;
-      --cat-shop: #f472b6;
-      --cat-culture: #a78bfa;
-      --cat-show: #34d399;
-      --cat-activity: #fbbf24;
-      --cat-leisure: #4ade80;
-      --cat-other: #cbd5e1;
-    }
+    --cat-transit: #b6c3d2;
+    --cat-stay: #38bdf8;
+    --cat-sight: #fb923c;
+    --cat-food: #f87171;
+    --cat-cafe: #d97706;
+    --cat-shop: #f472b6;
+    --cat-culture: #a78bfa;
+    --cat-show: #34d399;
+    --cat-activity: #fbbf24;
+    --cat-leisure: #4ade80;
+    --cat-other: #cbd5e1;
+
+    /* trip priority dark — 라이트 톤보다 어두운 배경 + 밝은 fg */
+    --priority-review-bg: #1e293b;
+    --priority-review-fg: #94a3b8;
+    --priority-review-border: #334155;
+    --priority-maybe-bg: #1e3a8a;
+    --priority-maybe-fg: #93c5fd;
+    --priority-maybe-border: #1d4ed8;
+    --priority-want-bg: #4c1d95;
+    --priority-want-fg: #c4b5fd;
+    --priority-want-border: #6d28d9;
+    --priority-confirm-bg: #14532d;
+    --priority-confirm-fg: #86efac;
+    --priority-confirm-border: #166534;
+    --priority-exclude-bg: #1e293b;
+    --priority-exclude-fg: #64748b;
+    --priority-exclude-border: #334155;
+
+    /* reservation dark */
+    --reservation-check-bg: #78350f;
+    --reservation-check-fg: #fcd34d;
+    --reservation-check-border: #92400e;
+    --reservation-none-bg: #1e293b;
+    --reservation-none-fg: #94a3b8;
+    --reservation-none-border: #334155;
+    --reservation-needed-bg: #7c2d12;
+    --reservation-needed-fg: #fdba74;
+    --reservation-needed-border: #9a3412;
+    --reservation-done-bg: #14532d;
+    --reservation-done-fg: #86efac;
+    --reservation-done-border: #166534;
+
+    /* leaflet 다크 모드 보정 (밝기/색상 반전) */
+    --tile-filter: invert(1) hue-rotate(180deg) brightness(0.9) contrast(0.95) saturate(0.7);
   }
 
   html {
-    color-scheme: light dark;
+    color-scheme: light;
     -webkit-text-size-adjust: 100%;
     text-rendering: optimizeLegibility;
+  }
+  html.dark {
+    color-scheme: dark;
   }
 
   body {
@@ -125,12 +192,10 @@
     font-feature-settings: 'ss01', 'ss02', 'cv11';
   }
 
-  /* 표·시간·금액 등 숫자 정렬 */
   .tabular {
     font-variant-numeric: tabular-nums;
   }
 
-  /* 글로벌 포커스 스타일: keyboard 사용자에게만 가시 */
   :focus {
     outline: none;
   }
@@ -140,31 +205,26 @@
     border-radius: 6px;
   }
 
-  /* placeholder 톤 */
   ::placeholder {
     color: rgb(var(--fg-subtle));
     opacity: 1;
   }
 
-  /* 셀렉션 */
   ::selection {
     background-color: rgb(var(--accent) / 0.18);
     color: rgb(var(--fg));
   }
 
-  /* 기본 link 톤 정리 (각 컴포넌트에서 override) */
   a {
     color: inherit;
   }
 }
 
 @layer utilities {
-  /* sheet/dialog 등이 사용하는 backdrop blur 헬퍼 */
   .bg-overlay {
     background-color: rgb(var(--bg-overlay) / 0.40);
   }
 
-  /* skeleton shimmer */
   .skeleton {
     background-image: linear-gradient(
       90deg,
@@ -177,9 +237,34 @@
   }
 }
 
+/* leaflet 지도 tile 다크 모드 필터 (다크에서 흰 지도가 그대로 보이지 않게) */
+.leaflet-tile-pane {
+  filter: var(--tile-filter);
+}
+
+/* leaflet 컨트롤·attribution 다크 모드 보정 */
+:root.dark .leaflet-control,
+:root.dark .leaflet-bar,
+:root.dark .leaflet-control-attribution {
+  background-color: rgb(var(--bg-elevated)) !important;
+  color: rgb(var(--fg)) !important;
+}
+:root.dark .leaflet-bar a {
+  background-color: rgb(var(--bg-elevated)) !important;
+  color: rgb(var(--fg)) !important;
+  border-color: rgb(var(--border)) !important;
+}
+:root.dark .leaflet-bar a:hover {
+  background-color: rgb(var(--bg-subtle)) !important;
+}
+:root.dark .leaflet-popup-content-wrapper,
+:root.dark .leaflet-popup-tip {
+  background-color: rgb(var(--bg-elevated)) !important;
+  color: rgb(var(--fg)) !important;
+}
+
 /* ============================================================
  * Reduced motion
- * - 시스템 환경에서 모션 감소 요청 시 transform 슬라이드 → fade 또는 즉시
  * ========================================================== */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/app/gmaps-import/page.tsx
+++ b/app/gmaps-import/page.tsx
@@ -104,7 +104,7 @@ export default function GmapsImportPage() {
   }
 
   return (
-    <div className="md:pl-44 min-h-screen bg-white">
+    <div className="md:pl-44 min-h-screen bg-bg-elevated">
       <div className="max-w-2xl mx-auto px-4 py-8 pb-24 md:pb-8">
         <div className="mb-6">
           <h1 className="text-xl font-bold text-fg">구글맵 연동</h1>
@@ -115,7 +115,7 @@ export default function GmapsImportPage() {
 
         {/* idle / loading */}
         {(state === 'idle' || state === 'loading') && (
-          <div className="bg-white rounded-xl border border-border p-6">
+          <div className="bg-bg-elevated rounded-xl border border-border p-6">
             <UrlInput
               onSubmit={handleUrlSubmit}
               loading={state === 'loading'}
@@ -126,7 +126,7 @@ export default function GmapsImportPage() {
 
         {/* review */}
         {state === 'review' && (
-          <div className="bg-white rounded-xl border border-border p-6">
+          <div className="bg-bg-elevated rounded-xl border border-border p-6">
             <CandidateList
               candidates={candidates}
               onChange={setCandidates}
@@ -147,7 +147,7 @@ export default function GmapsImportPage() {
 
         {/* importing */}
         {state === 'importing' && (
-          <div className="bg-white rounded-xl border border-border p-6">
+          <div className="bg-bg-elevated rounded-xl border border-border p-6">
             <CandidateList
               candidates={candidates}
               onChange={setCandidates}
@@ -159,7 +159,7 @@ export default function GmapsImportPage() {
 
         {/* done: 이동 중 표시 */}
         {state === 'done' && (
-          <div className="bg-white rounded-xl border border-border p-8 text-center">
+          <div className="bg-bg-elevated rounded-xl border border-border p-8 text-center">
             <div className="w-12 h-12 rounded-full bg-success-bg flex items-center justify-center mx-auto mb-4">
               <svg
                 className="w-6 h-6 text-green-600"

--- a/app/gmaps-import/page.tsx
+++ b/app/gmaps-import/page.tsx
@@ -134,7 +134,7 @@ export default function GmapsImportPage() {
               importing={false}
             />
             {error && (
-              <p className="mt-3 text-sm text-red-600">{error}</p>
+              <p className="mt-3 text-sm text-critical-fg">{error}</p>
             )}
             <button
               onClick={handleReset}
@@ -160,7 +160,7 @@ export default function GmapsImportPage() {
         {/* done: 이동 중 표시 */}
         {state === 'done' && (
           <div className="bg-white rounded-xl border border-border p-8 text-center">
-            <div className="w-12 h-12 rounded-full bg-green-100 flex items-center justify-center mx-auto mb-4">
+            <div className="w-12 h-12 rounded-full bg-success-bg flex items-center justify-center mx-auto mb-4">
               <svg
                 className="w-6 h-6 text-green-600"
                 fill="none"

--- a/app/items/[id]/page.tsx
+++ b/app/items/[id]/page.tsx
@@ -74,7 +74,7 @@ export default async function ItemDetailPage({ params }: { params: { id: string 
                     href={link.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 transition-colors"
+                    className="flex items-center gap-2 text-sm text-accent hover:text-accent-hover transition-colors"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,9 +26,26 @@ export const viewport = {
   maximumScale: 5,
 }
 
+/**
+ * 초기 렌더 깜빡임 방지: <head> 안에서 동기적으로 저장된 테마를 읽어 dark 클래스를 적용.
+ * React hydration 전에 실행되어야 하므로 inline script 사용.
+ */
+const themeInitScript = `
+(function(){
+  try {
+    var saved = localStorage.getItem('trip-planner.theme') || 'system';
+    var dark = saved === 'dark' || (saved === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    if (dark) document.documentElement.classList.add('dark');
+  } catch (e) {}
+})();
+`
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ko">
+    <html lang="ko" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body className="bg-bg text-fg font-sans antialiased">
         <Providers>{children}</Providers>
       </body>

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -57,7 +57,7 @@ export default function LoginForm() {
 
         <form
           onSubmit={handleSubmit}
-          className="bg-white rounded-2xl shadow-sm border border-border p-6 space-y-4"
+          className="bg-bg-elevated rounded-2xl shadow-sm border border-border p-6 space-y-4"
         >
           <div>
             <label className="block text-xs font-semibold text-fg-muted uppercase tracking-wide mb-1.5">

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,180 +1,29 @@
 'use client'
 
-import { Suspense, useEffect, useMemo, useState } from 'react'
+import { Suspense } from 'react'
+import { useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import dynamic from 'next/dynamic'
-import Navigation from '@/components/Layout/Navigation'
-import { useItems } from '@/lib/hooks/useItems'
-import MapSidePanel, { type DaySummary } from '@/components/Map/MapSidePanel'
-import { CATEGORY_OPTIONS } from '@/lib/itemOptions'
-import type { Category, TripItem } from '@/types'
 
-const TripPlannerMap = dynamic(() => import('@/components/Map/TripPlannerMap'), {
-  ssr: false,
-})
-const ItemPanel = dynamic(() => import('@/components/Panel/ItemPanel'), { ssr: false })
-
+/**
+ * /map 은 /plan 으로 통합되었습니다.
+ * 북마크 호환을 위해 search params 를 그대로 넘기며 redirect 합니다.
+ */
 export default function MapPage() {
   return (
     <Suspense fallback={null}>
-      <MapPageContent />
+      <MapRedirect />
     </Suspense>
   )
 }
 
-function nextDate(date: string): string {
-  const [y, m, d] = date.split('-').map(Number)
-  return new Date(Date.UTC(y, m - 1, d + 1)).toISOString().slice(0, 10)
-}
-
-function occursOnDate(item: TripItem, date: string): boolean {
-  if (!item.date) return false
-  if (item.date === date) return true
-  // end_date 까지 확장하는 건 종일/다일 일정(time_start 없음)에만 적용.
-  if (item.end_date && !item.time_start) {
-    return item.date <= date && date <= item.end_date
-  }
-  return false
-}
-
-function buildDaySummaries(items: TripItem[]): DaySummary[] {
-  const confirmed = items.filter((i) => i.trip_priority === '확정' && i.date)
-  const dateSet = new Set<string>()
-  for (const i of confirmed) {
-    dateSet.add(i.date!)
-    if (i.end_date && !i.time_start) {
-      let cur = nextDate(i.date!)
-      while (cur <= i.end_date) {
-        dateSet.add(cur)
-        cur = nextDate(cur)
-      }
-    }
-  }
-  const sortedDates = Array.from(dateSet).sort()
-  if (sortedDates.length === 0) return []
-
-  const tripStart = sortedDates[0]
-  return sortedDates.map((date) => {
-    const dayItems = confirmed.filter((i) => occursOnDate(i, date))
-    const counts = new Map<Category, number>()
-    for (const it of dayItems) {
-      counts.set(it.category, (counts.get(it.category) ?? 0) + 1)
-    }
-    const breakdown = CATEGORY_OPTIONS.filter((c) => counts.has(c)).map((c) => ({
-      category: c,
-      count: counts.get(c)!,
-    }))
-    const offsetMs = new Date(date).getTime() - new Date(tripStart).getTime()
-    const dayOffset = Math.round(offsetMs / (1000 * 60 * 60 * 24))
-    return {
-      date,
-      dayOffset,
-      stopCount: dayItems.length,
-      breakdown,
-    }
-  })
-}
-
-function MapPageContent() {
+function MapRedirect() {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const { items, isLoading } = useItems()
-
-  const [selectedItemId, setSelectedItemId] = useState<string | null>(() =>
-    searchParams.get('item'),
-  )
-  const [selectedDate, setSelectedDate] = useState<string | null>(null)
-
-  const selectedItem = items.find((i) => i.id === selectedItemId) ?? null
-  const days = useMemo(() => buildDaySummaries(items), [items])
 
   useEffect(() => {
-    if (isLoading || !selectedItemId) return
-    if (!items.find((i) => i.id === selectedItemId)) {
-      setSelectedItemId(null)
-      const params = new URLSearchParams(searchParams.toString())
-      params.delete('item')
-      router.replace(params.toString() ? `/map?${params.toString()}` : '/map', {
-        scroll: false,
-      })
-    }
-  }, [items, isLoading]) // eslint-disable-line react-hooks/exhaustive-deps
+    const qs = searchParams.toString()
+    router.replace(qs ? `/plan?${qs}` : '/plan')
+  }, [router, searchParams])
 
-  function handleSelectItem(id: string) {
-    const next = selectedItemId === id ? null : id
-    setSelectedItemId(next)
-    const params = new URLSearchParams(searchParams.toString())
-    if (next) params.set('item', next)
-    else params.delete('item')
-    router.replace(params.toString() ? `/map?${params.toString()}` : '/map', {
-      scroll: false,
-    })
-  }
-
-  function handleClosePanel() {
-    setSelectedItemId(null)
-    const params = new URLSearchParams(searchParams.toString())
-    params.delete('item')
-    router.replace(params.toString() ? `/map?${params.toString()}` : '/map', {
-      scroll: false,
-    })
-  }
-
-  const sidePanel = (
-    <MapSidePanel
-      items={items}
-      days={days}
-      selectedDate={selectedDate}
-      selectedItemId={selectedItemId}
-      onSelectDate={setSelectedDate}
-      onSelectItem={handleSelectItem}
-    />
-  )
-
-  return (
-    <div className="md:pl-44 bg-bg text-fg">
-      {/* Desktop: side panel | map */}
-      <div className="hidden md:flex h-screen">
-        <div className="w-[360px] flex-shrink-0 border-r border-border bg-bg-elevated">
-          {sidePanel}
-        </div>
-        <div className="relative min-w-0 flex-1">
-          <TripPlannerMap
-            items={items}
-            selectedDate={selectedDate}
-            selectedItemId={selectedItemId}
-            onSelectItem={handleSelectItem}
-          />
-        </div>
-      </div>
-
-      {/* Mobile: map fullscreen + bottom drawer with same panel */}
-      <div className="md:hidden flex h-[calc(100vh-56px)] flex-col">
-        <div className="relative min-h-0 flex-1">
-          <TripPlannerMap
-            items={items}
-            selectedDate={selectedDate}
-            selectedItemId={selectedItemId}
-            onSelectItem={handleSelectItem}
-          />
-        </div>
-        <div
-          className="flex-shrink-0 border-t border-border bg-bg-elevated"
-          style={{ height: '40vh' }}
-        >
-          {sidePanel}
-        </div>
-      </div>
-
-      <Navigation />
-
-      <ItemPanel
-        item={selectedItem}
-        isOpen={selectedItemId !== null}
-        onClose={handleClosePanel}
-        onSave={() => {}}
-        onDelete={handleClosePanel}
-      />
-    </div>
-  )
+  return null
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
 
 export default function Home() {
-  redirect('/research')
+  redirect('/plan')
 }

--- a/app/plan/page.tsx
+++ b/app/plan/page.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { Suspense } from 'react'
+import PlanScreen from '@/components/Plan/PlanScreen'
+
+export default function PlanPage() {
+  return (
+    <Suspense fallback={null}>
+      <PlanScreen basePath="/plan" />
+    </Suspense>
+  )
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,15 +2,18 @@
 
 import { SWRProvider } from '@/lib/providers/SWRProvider'
 import { ToastProvider } from '@/components/UI/Toast'
+import { ThemeProvider } from '@/components/Theme/ThemeProvider'
 import OfflineBanner from '@/components/UI/OfflineBanner'
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <SWRProvider>
-      <ToastProvider>
-        <OfflineBanner />
-        {children}
-      </ToastProvider>
-    </SWRProvider>
+    <ThemeProvider>
+      <SWRProvider>
+        <ToastProvider>
+          <OfflineBanner />
+          {children}
+        </ToastProvider>
+      </SWRProvider>
+    </ThemeProvider>
   )
 }

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -9,21 +9,19 @@ import ItemList from '@/components/Items/ItemList'
 import ItemCardSkeleton from '@/components/UI/ItemCardSkeleton'
 import ResearchTableSkeleton from '@/components/UI/ResearchTableSkeleton'
 import ResearchTable from '@/components/Research/ResearchTable'
-import ScheduleTable from '@/components/Schedule/ScheduleTable'
 import FAB from '@/components/UI/FAB'
 import FilterButton from '@/components/Research/FilterButton'
 import FilterPanel from '@/components/Research/FilterPanel'
 import ActiveFilterChips from '@/components/Research/ActiveFilterChips'
 import { Input } from '@/components/UI/Input'
+import ThemeToggle from '@/components/Theme/ThemeToggle'
 import { useItems } from '@/lib/hooks/useItems'
+import { useToast } from '@/components/UI/Toast'
 import type { FilterState } from '@/components/Items/ItemList'
 import { getActiveFilterCount } from '@/components/Items/ItemList'
 import type { Category, ReservationStatus, TripPriority } from '@/types'
-import { cn } from '@/lib/cn'
 
 const ItemPanel = dynamic(() => import('@/components/Panel/ItemPanel'), { ssr: false })
-
-type ViewMode = 'items' | 'schedule'
 
 export default function ResearchPage() {
   return (
@@ -37,7 +35,7 @@ function ResearchPageContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const { items, isLoading, updateItem, createItem } = useItems()
-  const [view, setView] = useState<ViewMode>('items')
+  const { showToast } = useToast()
 
   const [selectedItemId, setSelectedItemId] = useState<string | null>(() =>
     searchParams.get('item'),
@@ -93,7 +91,8 @@ function ResearchPageContent() {
       chips.push({
         id: 'excluded',
         label: '제외 포함',
-        onRemove: () => setFilterState((prev) => ({ ...prev, showExcluded: false })),
+        onRemove: () =>
+          setFilterState((prev) => ({ ...prev, showExcluded: false })),
       })
     }
     return chips
@@ -189,53 +188,49 @@ function ResearchPageContent() {
 
   return (
     <div className="md:pl-44 bg-bg text-fg min-h-screen">
-      {/* 헤더 */}
       <header className="px-4 md:px-8 pt-4">
         <div className="flex items-center justify-between mb-4">
           <h1 className="text-xl font-bold text-fg">목록</h1>
-          <ViewToggle view={view} onChange={setView} />
+          <div className="md:hidden">
+            <ThemeToggle />
+          </div>
         </div>
 
-        {view === 'items' && (
-          <div className="hidden md:block mb-4">
-            <div className="flex items-center gap-2">
-              <div className="flex-1 min-w-0">
-                <Input
-                  type="search"
-                  hideLabel
-                  label="검색"
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                  placeholder="이름·주소·메모로 검색"
-                  leading={<Search className="size-4" aria-hidden="true" />}
-                />
-              </div>
-              <div className="relative flex items-center gap-1.5 flex-shrink-0">
-                <FilterButton
-                  activeCount={activeCount}
-                  onClick={() => setFilterPanelOpen((v) => !v)}
-                />
-                <FilterPanel
-                  isOpen={filterPanelOpen}
-                  filterState={filterState}
-                  onChange={setFilterState}
-                  onClose={() => setFilterPanelOpen(false)}
-                />
-              </div>
+        <div className="hidden md:block mb-4">
+          <div className="flex items-center gap-2">
+            <div className="flex-1 min-w-0">
+              <Input
+                type="search"
+                hideLabel
+                label="검색"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="이름·주소·메모로 검색"
+                leading={<Search className="size-4" aria-hidden="true" />}
+              />
             </div>
-            {activeChips.length > 0 && (
-              <div className="mt-2">
-                <ActiveFilterChips chips={activeChips} />
-              </div>
-            )}
-            <p
-              className="text-xs text-fg-subtle mt-2 tabular"
-              aria-live="polite"
-            >
-              {filteredItems.length}개 항목
-            </p>
+            <div className="relative flex items-center gap-1.5 flex-shrink-0">
+              <FilterButton
+                activeCount={activeCount}
+                onClick={() => setFilterPanelOpen((v) => !v)}
+              />
+              <FilterPanel
+                isOpen={filterPanelOpen}
+                filterState={filterState}
+                onChange={setFilterState}
+                onClose={() => setFilterPanelOpen(false)}
+              />
+            </div>
           </div>
-        )}
+          {activeChips.length > 0 && (
+            <div className="mt-2">
+              <ActiveFilterChips chips={activeChips} />
+            </div>
+          )}
+          <p className="text-xs text-fg-subtle mt-2 tabular" aria-live="polite">
+            {filteredItems.length}개 항목
+          </p>
+        </div>
       </header>
 
       {isLoading ? (
@@ -249,7 +244,7 @@ function ResearchPageContent() {
             <ResearchTableSkeleton />
           </div>
         </>
-      ) : view === 'items' ? (
+      ) : (
         <>
           <div className="md:hidden px-4 pb-28">
             <ItemList
@@ -271,15 +266,6 @@ function ResearchPageContent() {
             />
           </div>
         </>
-      ) : (
-        <div className="px-4 md:px-8 pb-24 md:pb-6">
-          <ScheduleTable
-            items={items}
-            onUpdateItem={updateItem}
-            onCreateItem={createItem}
-            onOpenPanel={handleSelectItem}
-          />
-        </div>
       )}
 
       <Navigation />
@@ -288,47 +274,12 @@ function ResearchPageContent() {
         item={selectedItem}
         isOpen={selectedItemId !== null}
         onClose={handleClosePanel}
-        onSave={() => {}}
-        onDelete={handleClosePanel}
+        onSave={() => showToast({ type: 'success', message: '저장했어요' })}
+        onDelete={() => {
+          handleClosePanel()
+          showToast({ type: 'success', message: '삭제했어요' })
+        }}
       />
-    </div>
-  )
-}
-
-function ViewToggle({
-  view,
-  onChange,
-}: {
-  view: ViewMode
-  onChange: (v: ViewMode) => void
-}) {
-  return (
-    <div
-      role="tablist"
-      aria-label="보기 모드"
-      className="inline-flex rounded-lg border border-border overflow-hidden bg-bg-elevated"
-    >
-      {(['items', 'schedule'] as const).map((v) => {
-        const active = view === v
-        return (
-          <button
-            key={v}
-            role="tab"
-            type="button"
-            aria-selected={active}
-            onClick={() => onChange(v)}
-            className={cn(
-              'px-3 py-1.5 text-sm font-medium transition-colors duration-150',
-              'focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent',
-              active
-                ? 'bg-accent text-accent-fg'
-                : 'text-fg-muted hover:bg-bg-subtle',
-            )}
-          >
-            {v === 'items' ? '목록' : '일정'}
-          </button>
-        )
-      })}
     </div>
   )
 }

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -6,7 +6,9 @@ import dynamic from 'next/dynamic'
 import Navigation from '@/components/Layout/Navigation'
 import ItemCardSkeleton from '@/components/UI/ItemCardSkeleton'
 import ScheduleTable from '@/components/Schedule/ScheduleTable'
+import ThemeToggle from '@/components/Theme/ThemeToggle'
 import { useItems } from '@/lib/hooks/useItems'
+import { useToast } from '@/components/UI/Toast'
 
 const ItemPanel = dynamic(() => import('@/components/Panel/ItemPanel'), { ssr: false })
 
@@ -22,6 +24,7 @@ function SchedulePageContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const { items, isLoading, updateItem, createItem } = useItems()
+  const { showToast } = useToast()
 
   const [selectedItemId, setSelectedItemId] = useState<string | null>(() =>
     searchParams.get('item'),
@@ -67,7 +70,12 @@ function SchedulePageContent() {
   return (
     <div className="md:pl-44 bg-bg text-fg min-h-screen">
       <header className="max-w-3xl mx-auto px-4 pt-4">
-        <h1 className="text-xl font-bold text-fg mb-4">일정</h1>
+        <div className="flex items-center justify-between mb-4">
+          <h1 className="text-xl font-bold text-fg">일정</h1>
+          <div className="md:hidden">
+            <ThemeToggle />
+          </div>
+        </div>
       </header>
 
       {isLoading ? (
@@ -93,8 +101,11 @@ function SchedulePageContent() {
         item={selectedItem}
         isOpen={selectedItemId !== null}
         onClose={handleClosePanel}
-        onSave={() => {}}
-        onDelete={handleClosePanel}
+        onSave={() => showToast({ type: 'success', message: '저장했어요' })}
+        onDelete={() => {
+          handleClosePanel()
+          showToast({ type: 'success', message: '삭제했어요' })
+        }}
       />
     </div>
   )

--- a/components/GmapsImport/CandidateList.tsx
+++ b/components/GmapsImport/CandidateList.tsx
@@ -16,8 +16,8 @@ const STATUS_LABEL: Record<ImportCandidate['status'], string> = {
 }
 
 const STATUS_COLOR: Record<ImportCandidate['status'], string> = {
-  new: 'bg-green-100 text-green-700',
-  similar: 'bg-yellow-100 text-yellow-700',
+  new: 'bg-success-bg text-success-fg',
+  similar: 'bg-warning-bg text-warning-fg',
   duplicate: 'bg-bg-subtle text-fg-muted',
 }
 

--- a/components/GmapsImport/CandidateList.tsx
+++ b/components/GmapsImport/CandidateList.tsx
@@ -90,7 +90,7 @@ export default function CandidateList({
               candidate.status === 'duplicate'
                 ? 'border-border bg-gray-50 opacity-60'
                 : candidate.selected
-                ? 'border-border bg-white'
+                ? 'border-border bg-bg-elevated'
                 : 'border-border bg-gray-50'
             }`}
           >

--- a/components/GmapsImport/UrlInput.tsx
+++ b/components/GmapsImport/UrlInput.tsx
@@ -48,7 +48,7 @@ export default function UrlInput({ onSubmit, loading, error }: UrlInputProps) {
       </form>
 
       {error && (
-        <p className="mt-2 text-sm text-red-600">{error}</p>
+        <p className="mt-2 text-sm text-critical-fg">{error}</p>
       )}
     </div>
   )

--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -203,7 +203,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
             className={`${inputClass}${nameError ? ' border-red-400 focus:ring-red-200' : ''}`}
             placeholder="장소 또는 활동 이름"
           />
-          {nameError && <p className="text-xs text-red-500 mt-1">{nameError}</p>}
+          {nameError && <p className="text-xs text-critical-fg mt-1">{nameError}</p>}
         </div>
 
         <SelectField label={ITEM_FIELD_LABELS.category} value={form.category} onChange={value => setField('category', value as Category)} options={CATEGORY_OPTIONS.map(value => ({ value, label: value }))} />
@@ -294,7 +294,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
               <input type="text" value={link.label} onChange={e => updateLink(i, 'label', e.target.value)} className={inputClass} placeholder="이름 (예: 공식 사이트)" />
               <input type="url" value={link.url} onChange={e => updateLink(i, 'url', e.target.value)} className={inputClass} placeholder="https://..." />
             </div>
-            <button type="button" onClick={() => removeLink(i)} className="mt-1.5 text-fg-subtle hover:text-red-400 text-xl leading-none transition-colors">×</button>
+            <button type="button" onClick={() => removeLink(i)} className="mt-1.5 text-fg-subtle hover:text-critical-fg text-xl leading-none transition-colors">×</button>
           </div>
         ))}
         <button type="button" onClick={addLink} className="w-full text-sm text-fg-subtle hover:text-fg-muted border border-dashed border-border-strong rounded-lg px-4 py-2 transition-colors">
@@ -307,7 +307,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
         <textarea ref={memoRef} value={form.memo} onChange={e => setField('memo', e.target.value)} className={`${inputClass} resize-none overflow-hidden`} rows={4} placeholder="자유롭게 메모..." />
       </section>
 
-      {error && <p className="text-sm text-red-500">{error}</p>}
+      {error && <p className="text-sm text-critical-fg">{error}</p>}
 
       <div
         className="fixed left-0 right-0 md:static bg-white/95 backdrop-blur border-t md:border-t-0 px-4 py-3 md:px-0 md:py-0 z-40"
@@ -315,7 +315,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
       >
         <div className="max-w-lg mx-auto md:max-w-none flex gap-3">
           {mode === 'edit' && (
-            <button type="button" onClick={handleDelete} disabled={loading} className="px-4 py-2.5 rounded-lg text-sm font-medium text-red-500 border border-red-200 hover:bg-red-50 transition-colors">
+            <button type="button" onClick={handleDelete} disabled={loading} className="px-4 py-2.5 rounded-lg text-sm font-medium text-critical-fg border border-critical-border hover:bg-critical-bg transition-colors">
               삭제
             </button>
           )}

--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -185,7 +185,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
     }
   }
 
-  const inputClass = 'w-full border border-border-strong rounded-lg px-3 py-2 text-fg text-sm focus:outline-none focus:ring-2 focus:ring-border-strong bg-white'
+  const inputClass = 'w-full border border-border-strong rounded-lg px-3 py-2 text-fg text-sm focus:outline-none focus:ring-2 focus:ring-border-strong bg-bg-elevated'
   const labelClass = 'block text-sm font-medium text-fg mb-1'
 
   return (
@@ -310,7 +310,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
       {error && <p className="text-sm text-critical-fg">{error}</p>}
 
       <div
-        className="fixed left-0 right-0 md:static bg-white/95 backdrop-blur border-t md:border-t-0 px-4 py-3 md:px-0 md:py-0 z-40"
+        className="fixed left-0 right-0 md:static bg-bg-elevated/95 backdrop-blur border-t md:border-t-0 px-4 py-3 md:px-0 md:py-0 z-40"
         style={{ bottom: 'calc(3.5rem + env(safe-area-inset-bottom))' }}
       >
         <div className="max-w-lg mx-auto md:max-w-none flex gap-3">
@@ -345,7 +345,7 @@ function SelectField({
   return (
     <div>
       <label className="block text-sm font-medium text-fg mb-1">{label}</label>
-      <select value={value} onChange={e => onChange(e.target.value)} className="w-full border border-border-strong rounded-lg px-3 py-2 text-fg text-sm focus:outline-none focus:ring-2 focus:ring-border-strong bg-white">
+      <select value={value} onChange={e => onChange(e.target.value)} className="w-full border border-border-strong rounded-lg px-3 py-2 text-fg text-sm focus:outline-none focus:ring-2 focus:ring-border-strong bg-bg-elevated">
         {options.map(option => (
           <option key={option.value || 'empty'} value={option.value}>
             {option.label}

--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -13,8 +13,8 @@ interface NavItem {
 }
 
 const NAV_ITEMS: NavItem[] = [
+  { href: '/plan', label: '계획', icon: Map },
   { href: '/research', label: '목록', icon: List },
-  { href: '/map', label: '지도', icon: Map },
   { href: '/schedule', label: '일정', icon: CalendarDays },
 ]
 

--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { List, Map, CalendarDays, Download, LogOut } from 'lucide-react'
+import ThemeToggle from '@/components/Theme/ThemeToggle'
 import { cn } from '@/lib/cn'
 
 interface NavItem {
@@ -95,6 +96,10 @@ export default function Navigation() {
           })}
         </ul>
         <div className="border-t border-border pt-3 mt-2 space-y-0.5">
+          <div className="px-3 py-2 flex items-center justify-between gap-2">
+            <span className="text-xs text-fg-subtle">테마</span>
+            <ThemeToggle />
+          </div>
           <Link
             href="/gmaps-import"
             className={cn(

--- a/components/Map/ResearchMap.tsx
+++ b/components/Map/ResearchMap.tsx
@@ -7,19 +7,7 @@ import { CATEGORY_META } from '@/lib/itemOptions'
 
 function createEmojiChipIcon(emoji: string) {
   return L.divIcon({
-    html: `<div style="
-      display:inline-flex;
-      align-items:center;
-      justify-content:center;
-      padding:2px 6px;
-      background:white;
-      border:1.5px solid #e2e8f0;
-      border-radius:9999px;
-      box-shadow:0 1px 4px rgba(0,0,0,0.15);
-      font-size:14px;
-      line-height:1;
-      white-space:nowrap;
-    ">${emoji}</div>`,
+    html: `<div class="tp-chip-marker">${emoji}</div>`,
     className: '',
     iconSize: [28, 24],
     iconAnchor: [14, 12],

--- a/components/Map/ScheduleMap.tsx
+++ b/components/Map/ScheduleMap.tsx
@@ -61,7 +61,7 @@ export default function ScheduleMap({ items, onSelectItem }: ScheduleMapProps) {
               className={`flex-shrink-0 px-3 py-1 rounded-full text-xs font-medium border shadow-sm transition-colors ${
                 selectedDate === date
                   ? 'bg-accent text-white border-accent'
-                  : 'bg-white text-fg border-border hover:border-border-strong'
+                  : 'bg-bg-elevated text-fg border-border hover:border-border-strong'
               }`}
             >
               {date}

--- a/components/Map/ScheduleMap.tsx
+++ b/components/Map/ScheduleMap.tsx
@@ -13,19 +13,7 @@ interface ScheduleMapProps {
 
 function createNumberIcon(num: number) {
   return L.divIcon({
-    html: `<div style="
-      width:26px;height:26px;
-      border-radius:50%;
-      background:#374151;
-      color:white;
-      display:flex;
-      align-items:center;
-      justify-content:center;
-      font-size:11px;
-      font-weight:700;
-      border:2.5px solid white;
-      box-shadow:0 1px 4px rgba(0,0,0,0.3);
-    ">${num}</div>`,
+    html: `<div class="tp-number-marker is-small">${num}</div>`,
     className: '',
     iconSize: [26, 26],
     iconAnchor: [13, 13],
@@ -122,7 +110,12 @@ export default function ScheduleMap({ items, onSelectItem }: ScheduleMapProps) {
         ))}
 
         {polylinePositions.length > 1 && (
-          <Polyline positions={polylinePositions} color="#94A3B8" weight={2} opacity={0.7} />
+          <Polyline
+            positions={polylinePositions}
+            pathOptions={{ className: 'tp-day-route' }}
+            weight={2}
+            opacity={0.7}
+          />
         )}
       </MapContainer>
     </div>

--- a/components/Map/TripPlannerMap.tsx
+++ b/components/Map/TripPlannerMap.tsx
@@ -14,19 +14,15 @@ interface TripPlannerMapProps {
 }
 
 function chipIcon(emoji: string, opts: { dim?: boolean; selected?: boolean }) {
-  const opacity = opts.dim ? 0.55 : 1
-  const border = opts.selected ? '#0f172a' : '#e2e8f0'
-  const borderWidth = opts.selected ? 2 : 1.5
+  const cls = [
+    'tp-chip-marker',
+    opts.selected && 'is-selected',
+    opts.dim && 'is-dim',
+  ]
+    .filter(Boolean)
+    .join(' ')
   return L.divIcon({
-    html: `<div style="
-      display:inline-flex;align-items:center;justify-content:center;
-      padding:2px 6px;background:white;
-      border:${borderWidth}px solid ${border};
-      border-radius:9999px;
-      box-shadow:0 1px 4px rgba(0,0,0,0.15);
-      font-size:14px;line-height:1;white-space:nowrap;
-      opacity:${opacity};
-    ">${emoji}</div>`,
+    html: `<div class="${cls}">${emoji}</div>`,
     className: '',
     iconSize: [28, 24],
     iconAnchor: [14, 12],
@@ -34,16 +30,9 @@ function chipIcon(emoji: string, opts: { dim?: boolean; selected?: boolean }) {
 }
 
 function numberIcon(num: number, selected: boolean) {
-  const bg = selected ? '#0f172a' : '#374151'
+  const cls = ['tp-number-marker', selected && 'is-selected'].filter(Boolean).join(' ')
   return L.divIcon({
-    html: `<div style="
-      width:28px;height:28px;border-radius:50%;
-      background:${bg};color:white;
-      display:flex;align-items:center;justify-content:center;
-      font-size:12px;font-weight:700;
-      border:2.5px solid white;
-      box-shadow:0 2px 6px rgba(0,0,0,0.3);
-    ">${num}</div>`,
+    html: `<div class="${cls}">${num}</div>`,
     className: '',
     iconSize: [28, 28],
     iconAnchor: [14, 14],
@@ -127,7 +116,7 @@ export default function TripPlannerMap({
       ))}
 
       {polyline.length > 1 && (
-        <Polyline positions={polyline} color="#0f172a" weight={2.5} opacity={0.6} />
+        <Polyline positions={polyline} pathOptions={{ className: 'tp-day-route' }} weight={2.5} opacity={0.6} />
       )}
     </MapContainer>
   )

--- a/components/Panel/ItemPanel.tsx
+++ b/components/Panel/ItemPanel.tsx
@@ -157,7 +157,7 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         style={panelStyle}
-        className={`fixed z-[1010] bg-white shadow-2xl transition-transform duration-300 ease-in-out flex flex-col bottom-0 left-0 right-0 rounded-t-2xl h-[80vh] md:h-screen md:bottom-auto md:right-0 md:top-0 md:left-auto md:w-[520px] md:rounded-none md:rounded-l-2xl ${
+        className={`fixed z-[1010] bg-bg-elevated shadow-2xl transition-transform duration-300 ease-in-out flex flex-col bottom-0 left-0 right-0 rounded-t-2xl h-[80vh] md:h-screen md:bottom-auto md:right-0 md:top-0 md:left-auto md:w-[520px] md:rounded-none md:rounded-l-2xl ${
           isOpen ? 'translate-y-0 md:translate-y-0 md:translate-x-0' : 'translate-y-full md:translate-y-0 md:translate-x-full'
         }`}
       >
@@ -204,7 +204,7 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
         </div>
 
         {confirmingClose && (
-          <div className="absolute bottom-0 left-0 right-0 bg-white border-t-2 border-warning-border px-5 pt-4 pb-6 z-10">
+          <div className="absolute bottom-0 left-0 right-0 bg-bg-elevated border-t-2 border-warning-border px-5 pt-4 pb-6 z-10">
             <p className="text-sm font-medium text-fg mb-3">변경사항이 있습니다. 저장하지 않고 나가시겠습니까?</p>
             <div className="flex gap-3">
               <button onClick={handleDiscardAndClose} className="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium text-white bg-accent hover:bg-accent-hover transition-colors">나가기</button>
@@ -760,7 +760,7 @@ function MetadataDropdownChip({
       {isOpen && position && createPortal(
         <div
           ref={dropdownRef}
-          className="fixed z-[1200] rounded-xl border border-border bg-white shadow-lg p-1"
+          className="fixed z-[1200] rounded-xl border border-border bg-bg-elevated shadow-lg p-1"
           style={{ top: position.top, left: position.left, width: position.width }}
         >
           <div className="px-3 py-2 text-[11px] font-medium text-fg-subtle">{label}</div>

--- a/components/Panel/ItemPanel.tsx
+++ b/components/Panel/ItemPanel.tsx
@@ -149,7 +149,7 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
 
   return (
     <>
-      <div className={`fixed inset-0 bg-black/30 z-[1000] transition-opacity duration-300 ${isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'}`} onClick={confirmingClose ? () => setConfirmingClose(false) : tryClose} aria-hidden="true" />
+      <div className={`fixed inset-0 bg-overlay z-[1000] transition-opacity duration-300 ${isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'}`} onClick={confirmingClose ? () => setConfirmingClose(false) : tryClose} aria-hidden="true" />
 
       <div
         ref={panelRef}
@@ -162,11 +162,11 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
         }`}
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-border flex-shrink-0">
-          <div className="absolute top-2 left-1/2 -translate-x-1/2 w-10 h-1 bg-gray-200 rounded-full md:hidden" />
+          <div className="absolute top-2 left-1/2 -translate-x-1/2 w-10 h-1 bg-border rounded-full md:hidden" />
           <span className="text-sm font-semibold text-fg">{mode === 'edit' ? '편집' : '상세 정보'}</span>
           <div className="flex items-center gap-2">
             {mode === 'edit' && displayItem && (
-              <button onClick={() => handleDelete(displayItem.id)} aria-label="항목 삭제" className="px-3 py-1.5 text-xs font-medium text-red-500 border border-red-200 rounded-lg hover:bg-red-50 transition-colors">
+              <button onClick={() => handleDelete(displayItem.id)} aria-label="항목 삭제" className="px-3 py-1.5 text-xs font-medium text-critical-fg border border-critical-border rounded-lg hover:bg-critical-bg transition-colors">
                 삭제
               </button>
             )}
@@ -204,7 +204,7 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
         </div>
 
         {confirmingClose && (
-          <div className="absolute bottom-0 left-0 right-0 bg-white border-t-2 border-amber-100 px-5 pt-4 pb-6 z-10">
+          <div className="absolute bottom-0 left-0 right-0 bg-white border-t-2 border-warning-border px-5 pt-4 pb-6 z-10">
             <p className="text-sm font-medium text-fg mb-3">변경사항이 있습니다. 저장하지 않고 나가시겠습니까?</p>
             <div className="flex gap-3">
               <button onClick={handleDiscardAndClose} className="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium text-white bg-accent hover:bg-accent-hover transition-colors">나가기</button>
@@ -579,7 +579,7 @@ function ItemDetailView({
                     <button
                       type="button"
                       onClick={() => { const next = links.filter((_, idx) => idx !== i); saveLinks(next); setEditingLinkIdx(null) }}
-                      className="text-fg-subtle hover:text-red-400 text-xl leading-none transition-colors flex-shrink-0"
+                      className="text-fg-subtle hover:text-critical-fg text-xl leading-none transition-colors flex-shrink-0"
                     >×</button>
                   </div>
                 </div>
@@ -590,7 +590,7 @@ function ItemDetailView({
                     target="_blank"
                     rel="noopener noreferrer"
                     onClick={e => e.stopPropagation()}
-                    className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 transition-colors min-w-0 flex-1"
+                    className="flex items-center gap-2 text-sm text-accent hover:text-accent-hover transition-colors min-w-0 flex-1"
                   >
                     <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
                       <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
@@ -667,7 +667,7 @@ function ItemDetailView({
       <div className="pt-2">
         <button
           onClick={onDeleteRequest}
-          className="w-full px-4 py-2.5 rounded-lg text-sm font-medium text-red-500 border border-red-200 hover:bg-red-50 transition-colors"
+          className="w-full px-4 py-2.5 rounded-lg text-sm font-medium text-critical-fg border border-critical-border hover:bg-critical-bg transition-colors"
         >
           삭제
         </button>

--- a/components/Panel/PanelItemForm.tsx
+++ b/components/Panel/PanelItemForm.tsx
@@ -172,7 +172,7 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
               className={`${inputClass}${nameError ? ' border-red-400 focus:ring-red-200' : ''}`}
               placeholder="장소 또는 활동 이름"
             />
-            {nameError && <p className="text-xs text-red-500 mt-1">{nameError}</p>}
+            {nameError && <p className="text-xs text-critical-fg mt-1">{nameError}</p>}
           </div>
           <SelectField label={ITEM_FIELD_LABELS.category} value={form.category} onChange={value => setField('category', value as Category)} options={CATEGORY_OPTIONS.map(value => ({ value, label: value }))} />
           <SelectField label={ITEM_FIELD_LABELS.trip_priority} value={form.trip_priority} onChange={value => setField('trip_priority', value as TripPriority)} options={TRIP_PRIORITY_OPTIONS.map(value => ({ value, label: `${value} - ${TRIP_PRIORITY_META[value].description}` }))} />
@@ -260,7 +260,7 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
                 <input type="text" value={link.label} onChange={e => updateLink(i, 'label', e.target.value)} className={inputClass} placeholder="이름 (예: 공식 사이트)" />
                 <input type="url" value={link.url} onChange={e => updateLink(i, 'url', e.target.value)} className={inputClass} placeholder="https://..." />
               </div>
-              <button type="button" onClick={() => removeLink(i)} className="mt-1.5 text-fg-subtle hover:text-red-400 text-xl leading-none transition-colors">×</button>
+              <button type="button" onClick={() => removeLink(i)} className="mt-1.5 text-fg-subtle hover:text-critical-fg text-xl leading-none transition-colors">×</button>
             </div>
           ))}
           <button type="button" onClick={addLink} className="w-full text-sm text-fg-subtle hover:text-fg-muted border border-dashed border-border-strong rounded-lg px-4 py-2 transition-colors">
@@ -271,7 +271,7 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
 
       <div className="flex-shrink-0 px-5 py-3 border-t border-border space-y-2">
         {nameError && (
-          <p className="text-xs text-red-500">{nameError}</p>
+          <p className="text-xs text-critical-fg">{nameError}</p>
         )}
         <div className="flex gap-3">
           <button type="button" onClick={onCancel} className="px-4 py-2.5 rounded-lg text-sm font-medium text-fg-muted border border-border hover:bg-bg-subtle transition-colors">

--- a/components/Panel/PanelItemForm.tsx
+++ b/components/Panel/PanelItemForm.tsx
@@ -155,7 +155,7 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
     setField('links', form.links.filter((_, idx) => idx !== i))
   }
 
-  const inputClass = 'w-full border border-border-strong rounded-lg px-3 py-2 text-fg text-base focus:outline-none focus:ring-2 focus:ring-border-strong bg-white'
+  const inputClass = 'w-full border border-border-strong rounded-lg px-3 py-2 text-fg text-base focus:outline-none focus:ring-2 focus:ring-border-strong bg-bg-elevated'
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col h-full">
@@ -308,7 +308,7 @@ function SelectField({
 }) {
   return (
     <Field label={label}>
-      <select value={value} onChange={e => onChange(e.target.value)} className="w-full border border-border-strong rounded-lg px-3 py-2 text-fg text-base focus:outline-none focus:ring-2 focus:ring-border-strong bg-white">
+      <select value={value} onChange={e => onChange(e.target.value)} className="w-full border border-border-strong rounded-lg px-3 py-2 text-fg text-base focus:outline-none focus:ring-2 focus:ring-border-strong bg-bg-elevated">
         {options.map(option => (
           <option key={option.value || 'empty'} value={option.value}>
             {option.label}

--- a/components/Plan/PlanScreen.tsx
+++ b/components/Plan/PlanScreen.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import dynamic from 'next/dynamic'
+import Navigation from '@/components/Layout/Navigation'
+import MapSidePanel, { type DaySummary } from '@/components/Map/MapSidePanel'
+import ThemeToggle from '@/components/Theme/ThemeToggle'
+import FAB from '@/components/UI/FAB'
+import { useItems } from '@/lib/hooks/useItems'
+import { useToast } from '@/components/UI/Toast'
+import { CATEGORY_OPTIONS } from '@/lib/itemOptions'
+import type { Category, TripItem } from '@/types'
+
+const TripPlannerMap = dynamic(() => import('@/components/Map/TripPlannerMap'), {
+  ssr: false,
+})
+const ItemPanel = dynamic(() => import('@/components/Panel/ItemPanel'), { ssr: false })
+
+interface PlanScreenProps {
+  /** URL 동기화에 사용할 라우트 경로 (예: '/plan' 또는 '/map') */
+  basePath: string
+}
+
+function nextDate(date: string): string {
+  const [y, m, d] = date.split('-').map(Number)
+  return new Date(Date.UTC(y, m - 1, d + 1)).toISOString().slice(0, 10)
+}
+
+function occursOnDate(item: TripItem, date: string): boolean {
+  if (!item.date) return false
+  if (item.date === date) return true
+  if (item.end_date && !item.time_start) {
+    return item.date <= date && date <= item.end_date
+  }
+  return false
+}
+
+function buildDaySummaries(items: TripItem[]): DaySummary[] {
+  const confirmed = items.filter((i) => i.trip_priority === '확정' && i.date)
+  const dateSet = new Set<string>()
+  for (const i of confirmed) {
+    dateSet.add(i.date!)
+    if (i.end_date && !i.time_start) {
+      let cur = nextDate(i.date!)
+      while (cur <= i.end_date) {
+        dateSet.add(cur)
+        cur = nextDate(cur)
+      }
+    }
+  }
+  const sortedDates = Array.from(dateSet).sort()
+  if (sortedDates.length === 0) return []
+
+  const tripStart = sortedDates[0]
+  return sortedDates.map((date) => {
+    const dayItems = confirmed.filter((i) => occursOnDate(i, date))
+    const counts = new Map<Category, number>()
+    for (const it of dayItems) {
+      counts.set(it.category, (counts.get(it.category) ?? 0) + 1)
+    }
+    const breakdown = CATEGORY_OPTIONS.filter((c) => counts.has(c)).map((c) => ({
+      category: c,
+      count: counts.get(c)!,
+    }))
+    const offsetMs = new Date(date).getTime() - new Date(tripStart).getTime()
+    const dayOffset = Math.round(offsetMs / (1000 * 60 * 60 * 24))
+    return {
+      date,
+      dayOffset,
+      stopCount: dayItems.length,
+      breakdown,
+    }
+  })
+}
+
+export default function PlanScreen({ basePath }: PlanScreenProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { items, isLoading } = useItems()
+  const { showToast } = useToast()
+
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(() =>
+    searchParams.get('item'),
+  )
+  const [selectedDate, setSelectedDate] = useState<string | null>(() =>
+    searchParams.get('day'),
+  )
+
+  const selectedItem = items.find((i) => i.id === selectedItemId) ?? null
+  const days = useMemo(() => buildDaySummaries(items), [items])
+
+  // URL ↔ state 동기화 헬퍼
+  function pushUrl(updates: { item?: string | null; day?: string | null }) {
+    const params = new URLSearchParams(searchParams.toString())
+    if ('item' in updates) {
+      if (updates.item) params.set('item', updates.item)
+      else params.delete('item')
+    }
+    if ('day' in updates) {
+      if (updates.day) params.set('day', updates.day)
+      else params.delete('day')
+    }
+    const qs = params.toString()
+    router.replace(qs ? `${basePath}?${qs}` : basePath, { scroll: false })
+  }
+
+  // invalid item ID 처리
+  useEffect(() => {
+    if (isLoading || !selectedItemId) return
+    if (!items.find((i) => i.id === selectedItemId)) {
+      setSelectedItemId(null)
+      pushUrl({ item: null })
+    }
+  }, [items, isLoading]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  function handleSelectItem(id: string) {
+    const next = selectedItemId === id ? null : id
+    setSelectedItemId(next)
+    pushUrl({ item: next })
+  }
+
+  function handleClosePanel() {
+    setSelectedItemId(null)
+    pushUrl({ item: null })
+  }
+
+  function handleSelectDate(date: string | null) {
+    setSelectedDate(date)
+    pushUrl({ day: date })
+  }
+
+  function handleSaved() {
+    showToast({ type: 'success', message: '저장했어요' })
+  }
+
+  function handleDeleted(id: string) {
+    setSelectedItemId(null)
+    pushUrl({ item: null })
+    showToast({ type: 'success', message: '삭제했어요' })
+  }
+
+  const sidePanel = (
+    <MapSidePanel
+      items={items}
+      days={days}
+      selectedDate={selectedDate}
+      selectedItemId={selectedItemId}
+      onSelectDate={handleSelectDate}
+      onSelectItem={handleSelectItem}
+    />
+  )
+
+  return (
+    <div className="md:pl-44 bg-bg text-fg">
+      {/* Desktop: side panel | map */}
+      <div className="hidden md:flex h-screen">
+        <div className="w-[360px] flex-shrink-0 border-r border-border bg-bg-elevated">
+          {sidePanel}
+        </div>
+        <div className="relative min-w-0 flex-1">
+          <TripPlannerMap
+            items={items}
+            selectedDate={selectedDate}
+            selectedItemId={selectedItemId}
+            onSelectItem={handleSelectItem}
+          />
+        </div>
+      </div>
+
+      {/* Mobile: map fullscreen + bottom drawer with same panel */}
+      <div className="md:hidden flex h-[calc(100vh-56px)] flex-col relative">
+        <div className="relative min-h-0 flex-1">
+          <TripPlannerMap
+            items={items}
+            selectedDate={selectedDate}
+            selectedItemId={selectedItemId}
+            onSelectItem={handleSelectItem}
+          />
+          {/* 모바일 우측 상단 떠있는 테마 토글 + FAB */}
+          <div className="absolute top-3 right-3 z-[600]">
+            <ThemeToggle />
+          </div>
+          <FAB className="bottom-[calc(40vh+1rem)] right-4" />
+        </div>
+        <div
+          className="flex-shrink-0 border-t border-border bg-bg-elevated"
+          style={{ height: '40vh' }}
+        >
+          {sidePanel}
+        </div>
+      </div>
+
+      <Navigation />
+
+      <ItemPanel
+        item={selectedItem}
+        isOpen={selectedItemId !== null}
+        onClose={handleClosePanel}
+        onSave={handleSaved}
+        onDelete={handleDeleted}
+      />
+    </div>
+  )
+}

--- a/components/Research/ResearchTable.tsx
+++ b/components/Research/ResearchTable.tsx
@@ -188,7 +188,7 @@ export default function ResearchTable({
   return (
     <div className="border border-border rounded-xl overflow-x-auto">
       {/* 컬럼 헤더 */}
-      <div className="flex items-center border-b border-border bg-white">
+      <div className="flex items-center border-b border-border bg-bg-elevated">
         <button
           type="button"
           onClick={() => handleSortHeader('name')}

--- a/components/Research/ResearchTable.tsx
+++ b/components/Research/ResearchTable.tsx
@@ -243,7 +243,7 @@ export default function ResearchTable({
 
       {/* 새 항목 추가 행 */}
       {addingRow ? (
-        <div className="flex items-center border-b border-border bg-blue-50/30">
+        <div className="flex items-center border-b border-border bg-info-bg/30">
           <div className="flex-1 min-w-0 px-3 py-2.5">
             <input
               ref={newItemInputRef}

--- a/components/Schedule/DateGroupHeader.tsx
+++ b/components/Schedule/DateGroupHeader.tsx
@@ -48,7 +48,7 @@ export default function DateGroupHeader({
           {formatDate(date)}
         </span>
         {isToday && (
-          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700">
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-info-bg text-info-fg">
             오늘
           </span>
         )}

--- a/components/Schedule/DateGroupHeader.tsx
+++ b/components/Schedule/DateGroupHeader.tsx
@@ -37,7 +37,7 @@ export default function DateGroupHeader({
   const showBar = !isUndated && categoryBreakdown && categoryBreakdown.length > 0
 
   return (
-    <div className="bg-white border-b border-border sticky top-0 z-10">
+    <div className="bg-bg-elevated border-b border-border sticky top-0 z-10">
       <div className="flex items-center gap-2 px-3 py-3">
       <button
         type="button"

--- a/components/Schedule/DayTimeline.tsx
+++ b/components/Schedule/DayTimeline.tsx
@@ -48,7 +48,7 @@ export default function DayTimeline({ items, selectedItemId, onSelectItem }: Day
                 aria-hidden="true"
                 className="flex items-center gap-2 pl-7 pr-4 py-1 text-[10px] tabular-nums text-fg-subtle"
               >
-                <span className="inline-block h-3 w-px bg-gray-200" />
+                <span className="inline-block h-3 w-px bg-border" />
                 <span>{formatDistance(km)}</span>
               </li>
             )}

--- a/components/Schedule/DistanceSeparator.tsx
+++ b/components/Schedule/DistanceSeparator.tsx
@@ -15,10 +15,10 @@ export default function DistanceSeparator({ km, variant }: DistanceSeparatorProp
         className="flex min-w-[720px] items-center px-3 py-1 text-[11px] text-fg-subtle"
       >
         <div className="flex w-16 flex-shrink-0 items-center justify-center">
-          <span className="h-3 w-px bg-gray-200" />
+          <span className="h-3 w-px bg-border" />
         </div>
         <div className="flex min-w-[220px] flex-1 items-center gap-2">
-          <span className="h-px w-3 bg-gray-200" />
+          <span className="h-px w-3 bg-border" />
           <span className="tabular-nums">{formatDistance(km)}</span>
         </div>
       </div>
@@ -27,7 +27,7 @@ export default function DistanceSeparator({ km, variant }: DistanceSeparatorProp
 
   return (
     <div aria-hidden="true" className="flex items-center gap-2 pl-12 pr-2">
-      <span className="h-3 w-px bg-gray-200" />
+      <span className="h-3 w-px bg-border" />
       <span className="text-[11px] tabular-nums text-fg-subtle">{formatDistance(km)}</span>
     </div>
   )

--- a/components/Schedule/ScheduleTable.tsx
+++ b/components/Schedule/ScheduleTable.tsx
@@ -44,7 +44,7 @@ function formatTimeRange(item: TripItem) {
 function getStatusMeta(value: ReservationStatus | null | undefined) {
   if (!value) {
     return {
-      dotClass: 'bg-gray-200',
+      dotClass: 'bg-border',
       label: '예약 정보 없음',
     }
   }
@@ -58,10 +58,10 @@ function getStatusMeta(value: ReservationStatus | null | undefined) {
 
   return {
     dotClass: {
-      예약완료: 'bg-green-500',
-      '필요(미예약)': 'bg-orange-400',
-      불필요: 'bg-gray-300',
-      '확인 필요': 'bg-yellow-400',
+      예약완료: 'bg-success-bg0',
+      '필요(미예약)': 'bg-warning-fg',
+      불필요: 'bg-border-strong',
+      '확인 필요': 'bg-warning-fg',
     }[value],
     label: shortLabel[value],
   }
@@ -153,8 +153,8 @@ function MobileNewItemEditor({
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>, currentValue: string) => void
 }) {
   return (
-    <div className="rounded-2xl border border-dashed border-blue-200 bg-blue-50/40 p-4">
-      <div className="mb-2 text-xs font-medium text-blue-700">{formatDate(date)}</div>
+    <div className="rounded-2xl border border-dashed border-info-border bg-info-bg/40 p-4">
+      <div className="mb-2 text-xs font-medium text-info-fg">{formatDate(date)}</div>
       <input
         ref={inputRef}
         value={value}
@@ -325,7 +325,7 @@ export default function ScheduleTable({
           )
         })}
         {addingToDate === date ? (
-          <div className="flex min-w-[720px] items-center border-b border-gray-50 bg-blue-50/30">
+          <div className="flex min-w-[720px] items-center border-b border-gray-50 bg-info-bg/30">
             <div className="w-16 flex-shrink-0 px-3 py-2.5" />
             <div className="min-w-[220px] flex-1 px-3 py-2.5">
               <input

--- a/components/Schedule/ScheduleTable.tsx
+++ b/components/Schedule/ScheduleTable.tsx
@@ -109,7 +109,7 @@ function MobileScheduleItemCard({
     <button
       type="button"
       onClick={() => onOpenPanel(item.id)}
-      className="w-full rounded-2xl border border-border bg-white p-4 text-left shadow-sm transition-all hover:border-border-strong hover:shadow-md active:scale-[0.99]"
+      className="w-full rounded-2xl border border-border bg-bg-elevated p-4 text-left shadow-sm transition-all hover:border-border-strong hover:shadow-md active:scale-[0.99]"
     >
       <div className="flex items-start gap-3">
         <span className="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl bg-gray-50 text-lg">
@@ -430,7 +430,7 @@ export default function ScheduleTable({
           const categoryBreakdown = buildCategoryBreakdown(groupItems)
 
           return (
-            <div key={date} ref={isToday ? todayRef : undefined} className="overflow-hidden rounded-xl border border-border bg-white shadow-sm">
+            <div key={date} ref={isToday ? todayRef : undefined} className="overflow-hidden rounded-xl border border-border bg-bg-elevated shadow-sm">
               <DateGroupHeader
                 date={date}
                 dayOffset={dayOffset}
@@ -462,8 +462,8 @@ export default function ScheduleTable({
         })}
 
         {undatedItems.length > 0 && (
-          <div className="overflow-hidden rounded-xl border border-border bg-white shadow-sm">
-            <div className="flex items-center gap-2 px-3 py-3 bg-white border-b border-border sticky top-0 z-10">
+          <div className="overflow-hidden rounded-xl border border-border bg-bg-elevated shadow-sm">
+            <div className="flex items-center gap-2 px-3 py-3 bg-bg-elevated border-b border-border sticky top-0 z-10">
               <button
                 type="button"
                 onClick={() => setUndatedCollapsed(prev => !prev)}
@@ -501,11 +501,11 @@ export default function ScheduleTable({
       </div>
 
       <div className="hidden md:block">
-        <div className="overflow-hidden rounded-xl border border-border bg-white">
+        <div className="overflow-hidden rounded-xl border border-border bg-bg-elevated">
           <div className="overflow-x-auto">
             <div className={TABLE_MIN_WIDTH}>
               {/* 컬럼 헤더 */}
-              <div className="flex items-center gap-0 border-b border-border bg-white px-0">
+              <div className="flex items-center gap-0 border-b border-border bg-bg-elevated px-0">
                 <div className="w-16 flex-shrink-0 px-3 py-2.5">
                   <span className="text-xs font-semibold text-fg-muted whitespace-nowrap">시간</span>
                 </div>
@@ -567,7 +567,7 @@ export default function ScheduleTable({
               {/* 미배정 버킷 (최하단, 있을 때만) */}
               {undatedItems.length > 0 && (
                 <div>
-                  <div className="flex items-center gap-2 px-3 py-3 bg-white border-b border-border sticky top-0 z-10">
+                  <div className="flex items-center gap-2 px-3 py-3 bg-bg-elevated border-b border-border sticky top-0 z-10">
                     <button
                       type="button"
                       onClick={() => setUndatedCollapsed(prev => !prev)}

--- a/components/Schedule/cells/CategoryCell.tsx
+++ b/components/Schedule/cells/CategoryCell.tsx
@@ -80,7 +80,7 @@ export default function CategoryCell({
           <div
             ref={dropdownRef}
             data-portal="true"
-            className="fixed z-[1200] rounded-xl border border-border bg-white shadow-lg p-2"
+            className="fixed z-[1200] rounded-xl border border-border bg-bg-elevated shadow-lg p-2"
             style={{ top: position.top, left: position.left }}
           >
             <div className="grid grid-cols-4 gap-1">

--- a/components/Schedule/cells/PriorityCell.tsx
+++ b/components/Schedule/cells/PriorityCell.tsx
@@ -4,6 +4,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { TripPriority } from '@/types'
 import { TRIP_PRIORITY_META, TRIP_PRIORITY_OPTIONS } from '@/lib/itemOptions'
+import { cn } from '@/lib/cn'
 
 interface PriorityCellProps {
   value: TripPriority
@@ -36,7 +37,8 @@ export default function PriorityCell({
 
     function handleClickOutside(e: MouseEvent) {
       const target = e.target as Node
-      if (buttonRef.current?.contains(target) || dropdownRef.current?.contains(target)) return
+      if (buttonRef.current?.contains(target) || dropdownRef.current?.contains(target))
+        return
       onClose()
     }
 
@@ -55,8 +57,13 @@ export default function PriorityCell({
     if (!position || !dropdownRef.current) return
     const dropRect = dropdownRef.current.getBoundingClientRect()
     if (dropRect.right > window.innerWidth) {
-      setPosition(prev =>
-        prev ? { ...prev, left: Math.max(0, prev.left - (dropRect.right - window.innerWidth)) } : prev
+      setPosition((prev) =>
+        prev
+          ? {
+              ...prev,
+              left: Math.max(0, prev.left - (dropRect.right - window.innerWidth)),
+            }
+          : prev,
       )
     }
   }, [position])
@@ -67,14 +74,18 @@ export default function PriorityCell({
         ref={buttonRef}
         type="button"
         onClick={onClick}
-        className="flex items-center gap-1 cursor-pointer hover:opacity-70 transition-opacity select-none"
+        aria-label={`우선순위: ${value}, 클릭해서 변경`}
+        className="flex items-center gap-1 cursor-pointer hover:opacity-70 transition-opacity select-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent rounded"
         title={value}
       >
         <span
-          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border whitespace-nowrap"
-          style={meta.style as React.CSSProperties}
+          className={cn(
+            'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border whitespace-nowrap',
+            meta.className,
+          )}
         >
-          {meta.emoji} {value}
+          <span aria-hidden="true">{meta.emoji}</span>
+          {value}
         </span>
       </button>
 
@@ -83,33 +94,45 @@ export default function PriorityCell({
         createPortal(
           <div
             ref={dropdownRef}
+            role="menu"
             data-portal="true"
-            className="fixed z-[1200] rounded-xl border border-border bg-white shadow-lg p-1 w-52"
+            className="fixed z-[1200] rounded-lg border border-border bg-bg-elevated shadow-e16 p-1 w-52 animate-fade-in"
             style={{ top: position.top, left: position.left }}
           >
-            {TRIP_PRIORITY_OPTIONS.map(priority => {
+            {TRIP_PRIORITY_OPTIONS.map((priority) => {
               const m = TRIP_PRIORITY_META[priority]
+              const active = priority === value
               return (
                 <button
                   key={priority}
                   type="button"
+                  role="menuitemradio"
+                  aria-checked={active}
                   onClick={() => onSelect(priority)}
-                  className={`flex items-center gap-2 w-full rounded-lg px-3 py-2 text-left hover:bg-bg-subtle transition-colors ${
-                    priority === value ? 'bg-gray-50' : ''
-                  }`}
+                  className={cn(
+                    'flex items-center gap-2 w-full rounded px-3 py-2 text-left',
+                    'hover:bg-bg-subtle transition-colors',
+                    'focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent',
+                    active && 'bg-accent-subtle',
+                  )}
                 >
                   <span
-                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border whitespace-nowrap"
-                    style={m.style as React.CSSProperties}
+                    className={cn(
+                      'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border whitespace-nowrap',
+                      m.className,
+                    )}
                   >
-                    {m.emoji} {priority}
+                    <span aria-hidden="true">{m.emoji}</span>
+                    {priority}
                   </span>
-                  <span className="text-xs text-fg-subtle truncate">{m.description}</span>
+                  <span className="text-xs text-fg-subtle truncate">
+                    {m.description}
+                  </span>
                 </button>
               )
             })}
           </div>,
-          document.body
+          document.body,
         )}
     </>
   )

--- a/components/Schedule/cells/StatusCell.tsx
+++ b/components/Schedule/cells/StatusCell.tsx
@@ -4,6 +4,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { ReservationStatus } from '@/types'
 import { RESERVATION_STATUS_META, RESERVATION_STATUS_OPTIONS } from '@/lib/itemOptions'
+import { cn } from '@/lib/cn'
 
 interface StatusCellProps {
   value: ReservationStatus | null | undefined
@@ -14,10 +15,10 @@ interface StatusCellProps {
 }
 
 const STATUS_DOT: Record<ReservationStatus, string> = {
-  예약완료: 'bg-green-500',
-  '필요(미예약)': 'bg-orange-400',
-  불필요: 'bg-gray-300',
-  '확인 필요': 'bg-yellow-400',
+  예약완료: 'bg-success-fg',
+  '필요(미예약)': 'bg-warning-fg',
+  불필요: 'bg-fg-subtle',
+  '확인 필요': 'bg-warning-fg',
 }
 
 const STATUS_LABEL: Record<ReservationStatus, string> = {
@@ -49,7 +50,8 @@ export default function StatusCell({
 
     function handleClickOutside(e: MouseEvent) {
       const target = e.target as Node
-      if (buttonRef.current?.contains(target) || dropdownRef.current?.contains(target)) return
+      if (buttonRef.current?.contains(target) || dropdownRef.current?.contains(target))
+        return
       onClose()
     }
 
@@ -68,8 +70,13 @@ export default function StatusCell({
     if (!position || !dropdownRef.current) return
     const dropRect = dropdownRef.current.getBoundingClientRect()
     if (dropRect.right > window.innerWidth) {
-      setPosition(prev =>
-        prev ? { ...prev, left: Math.max(0, prev.left - (dropRect.right - window.innerWidth)) } : prev
+      setPosition((prev) =>
+        prev
+          ? {
+              ...prev,
+              left: Math.max(0, prev.left - (dropRect.right - window.innerWidth)),
+            }
+          : prev,
       )
     }
   }, [position])
@@ -80,15 +87,27 @@ export default function StatusCell({
         ref={buttonRef}
         type="button"
         onClick={onClick}
-        className="flex items-center gap-1.5 cursor-pointer hover:opacity-70 transition-opacity select-none"
+        aria-label={`예약상태: ${value ?? '없음'}, 클릭해서 변경`}
+        className="flex items-center gap-1.5 cursor-pointer hover:opacity-70 transition-opacity select-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent rounded"
       >
         {value ? (
           <>
-            <span className={`w-2 h-2 rounded-full flex-shrink-0 ${STATUS_DOT[value]}`} />
-            <span className="text-xs text-fg-muted whitespace-nowrap">{STATUS_LABEL[value]}</span>
+            <span
+              aria-hidden="true"
+              className={cn(
+                'w-2 h-2 rounded-full flex-shrink-0',
+                STATUS_DOT[value],
+              )}
+            />
+            <span className="text-xs text-fg-muted whitespace-nowrap">
+              {STATUS_LABEL[value]}
+            </span>
           </>
         ) : (
-          <span className="w-2 h-2 rounded-full bg-gray-200 flex-shrink-0" />
+          <span
+            aria-hidden="true"
+            className="w-2 h-2 rounded-full bg-border flex-shrink-0"
+          />
         )}
       </button>
 
@@ -97,41 +116,59 @@ export default function StatusCell({
         createPortal(
           <div
             ref={dropdownRef}
+            role="menu"
             data-portal="true"
-            className="fixed z-[1200] rounded-xl border border-border bg-white shadow-lg p-1 w-44"
+            className="fixed z-[1200] rounded-lg border border-border bg-bg-elevated shadow-e16 p-1 w-44 animate-fade-in"
             style={{ top: position.top, left: position.left }}
           >
-            {RESERVATION_STATUS_OPTIONS.map(status => {
+            {RESERVATION_STATUS_OPTIONS.map((status) => {
               const meta = RESERVATION_STATUS_META[status]
+              const active = status === value
               return (
                 <button
                   key={status}
                   type="button"
+                  role="menuitemradio"
+                  aria-checked={active}
                   onClick={() => onSelect(status)}
-                  className={`flex items-center gap-2 w-full rounded-lg px-3 py-2 text-left hover:bg-bg-subtle transition-colors ${
-                    status === value ? 'bg-gray-50' : ''
-                  }`}
+                  className={cn(
+                    'flex items-center gap-2 w-full rounded px-3 py-2 text-left',
+                    'hover:bg-bg-subtle transition-colors',
+                    'focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent',
+                    active && 'bg-accent-subtle',
+                  )}
                 >
                   <span
-                    className={`w-2 h-2 rounded-full flex-shrink-0 ${STATUS_DOT[status]}`}
+                    aria-hidden="true"
+                    className={cn(
+                      'w-2 h-2 rounded-full flex-shrink-0',
+                      STATUS_DOT[status],
+                    )}
                   />
-                  <div>
+                  <div className="min-w-0">
                     <div className="text-sm font-medium text-fg">{status}</div>
-                    <div className="text-xs text-fg-subtle">{meta.description}</div>
+                    <div className="text-xs text-fg-subtle truncate">
+                      {meta.description}
+                    </div>
                   </div>
                 </button>
               )
             })}
             <button
               type="button"
+              role="menuitemradio"
+              aria-checked={value == null}
               onClick={() => onSelect(null)}
-              className="flex items-center gap-2 w-full rounded-lg px-3 py-2 text-left hover:bg-bg-subtle transition-colors"
+              className="flex items-center gap-2 w-full rounded px-3 py-2 text-left hover:bg-bg-subtle transition-colors focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent"
             >
-              <span className="w-2 h-2 rounded-full bg-gray-200 flex-shrink-0" />
+              <span
+                aria-hidden="true"
+                className="w-2 h-2 rounded-full bg-border flex-shrink-0"
+              />
               <span className="text-sm text-fg-subtle">없음</span>
             </button>
           </div>,
-          document.body
+          document.body,
         )}
     </>
   )

--- a/components/Theme/ThemeProvider.tsx
+++ b/components/Theme/ThemeProvider.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+
+export type ThemeMode = 'light' | 'dark' | 'system'
+export type ResolvedTheme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  mode: ThemeMode
+  resolved: ResolvedTheme
+  setMode: (mode: ThemeMode) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  mode: 'system',
+  resolved: 'light',
+  setMode: () => {},
+})
+
+const STORAGE_KEY = 'trip-planner.theme'
+
+export function useTheme() {
+  return useContext(ThemeContext)
+}
+
+function resolveSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined') return 'light'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function applyResolved(resolved: ResolvedTheme) {
+  const root = document.documentElement
+  if (resolved === 'dark') {
+    root.classList.add('dark')
+  } else {
+    root.classList.remove('dark')
+  }
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [mode, setModeState] = useState<ThemeMode>('system')
+  const [resolved, setResolved] = useState<ResolvedTheme>('light')
+
+  // Hydration 단계: 저장된 mode 읽고 적용
+  useEffect(() => {
+    const saved = (localStorage.getItem(STORAGE_KEY) as ThemeMode | null) ?? 'system'
+    setModeState(saved)
+    const next: ResolvedTheme = saved === 'system' ? resolveSystemTheme() : saved
+    setResolved(next)
+    applyResolved(next)
+  }, [])
+
+  // mode가 'system'일 때 OS 변경 감지
+  useEffect(() => {
+    if (mode !== 'system') return
+    const media = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = () => {
+      const next: ResolvedTheme = media.matches ? 'dark' : 'light'
+      setResolved(next)
+      applyResolved(next)
+    }
+    media.addEventListener('change', handler)
+    return () => media.removeEventListener('change', handler)
+  }, [mode])
+
+  const setMode = useCallback((next: ThemeMode) => {
+    setModeState(next)
+    localStorage.setItem(STORAGE_KEY, next)
+    const resolvedNext: ResolvedTheme =
+      next === 'system' ? resolveSystemTheme() : next
+    setResolved(resolvedNext)
+    applyResolved(resolvedNext)
+  }, [])
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ mode, resolved, setMode }),
+    [mode, resolved, setMode],
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}

--- a/components/Theme/ThemeToggle.tsx
+++ b/components/Theme/ThemeToggle.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { Sun, Moon, Monitor } from 'lucide-react'
+import { useTheme, type ThemeMode } from './ThemeProvider'
+import { cn } from '@/lib/cn'
+
+const OPTIONS: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
+  { value: 'light', label: '라이트', icon: Sun },
+  { value: 'system', label: '시스템', icon: Monitor },
+  { value: 'dark', label: '다크', icon: Moon },
+]
+
+interface ThemeToggleProps {
+  /** 'compact' 는 아이콘만, 'full' 은 라벨 함께 */
+  variant?: 'compact' | 'full'
+  className?: string
+}
+
+export default function ThemeToggle({ variant = 'compact', className }: ThemeToggleProps) {
+  const { mode, setMode } = useTheme()
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="테마 모드"
+      className={cn(
+        'inline-flex items-center gap-0.5 p-0.5 rounded-lg bg-bg-subtle border border-border',
+        className,
+      )}
+    >
+      {OPTIONS.map(({ value, label, icon: Icon }) => {
+        const active = mode === value
+        return (
+          <button
+            key={value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={`${label} 모드`}
+            title={`${label} 모드`}
+            onClick={() => setMode(value)}
+            className={cn(
+              'inline-flex items-center justify-center gap-1 rounded',
+              'transition-colors duration-150 ease-out-soft',
+              'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+              variant === 'compact' ? 'size-7' : 'h-7 px-2 text-xs',
+              active
+                ? 'bg-bg-elevated text-fg shadow-e2'
+                : 'text-fg-muted hover:text-fg',
+            )}
+          >
+            <Icon className="size-3.5" aria-hidden="true" />
+            {variant === 'full' && <span>{label}</span>}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/UI/FAB.tsx
+++ b/components/UI/FAB.tsx
@@ -34,12 +34,15 @@ export default function FAB({
       onClick={handleClick}
       aria-label={label}
       className={cn(
-        'fixed bottom-20 right-4 z-40 size-14 rounded-full',
+        'fixed z-40 size-14 rounded-full',
         'bg-accent text-accent-fg shadow-e16',
         'flex items-center justify-center',
         'hover:bg-accent-hover active:bg-accent-hover',
         'transition-colors duration-150 ease-out-soft',
         'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+        // 기본 위치 (className 으로 override 가능)
+        !className?.includes('bottom-') && 'bottom-20',
+        !className?.includes('right-') && !className?.includes('left-') && 'right-4',
         className,
       )}
       style={{

--- a/lib/itemOptions.ts
+++ b/lib/itemOptions.ts
@@ -1,13 +1,5 @@
 import type { Category, ReservationStatus, TripItem, TripPriority } from '@/types'
 
-interface BadgeStyle {
-  background: string
-  color: string
-  borderColor: string
-  fontWeight?: number
-  textDecoration?: string
-}
-
 export const CATEGORY_OPTIONS: Category[] = [
   '교통',
   '숙박',
@@ -78,10 +70,8 @@ interface PriorityMeta {
   description: string
   order: number
   emoji: string
-  /** 신규 — Tailwind className 기반 톤 */
+  /** Tailwind className 기반 톤 — 라이트/다크 자동 적용 */
   className: string
-  /** legacy — 인라인 style 객체 (점진 마이그레이션 중) */
-  style: BadgeStyle
 }
 
 export const TRIP_PRIORITY_META: Record<TripPriority, PriorityMeta> = {
@@ -90,45 +80,30 @@ export const TRIP_PRIORITY_META: Record<TripPriority, PriorityMeta> = {
     order: 0,
     emoji: '🤔',
     className: 'bg-bg-subtle text-fg-subtle border-border',
-    style: { background: '#f8fafc', color: '#94a3b8', borderColor: '#e2e8f0' },
   },
   '시간 되면': {
     description: '여유가 있으면 가볼 곳',
     order: 1,
     emoji: '⏳',
     className: 'bg-info-bg text-info-fg border-info-border',
-    style: { background: '#eff6ff', color: '#3b82f6', borderColor: '#bfdbfe' },
   },
   '가고 싶음': {
     description: '꼭 가고 싶은 곳',
     order: 2,
     emoji: '⭐',
     className: 'bg-accent-subtle text-accent border-accent/30',
-    style: { background: '#f5f3ff', color: '#7c3aed', borderColor: '#ddd6fe' },
   },
   확정: {
     description: '일정에 넣기로 결정',
     order: 3,
     emoji: '✅',
     className: 'bg-success-bg text-success-fg border-success-border font-semibold',
-    style: {
-      background: '#f0fdf4',
-      color: '#16a34a',
-      borderColor: '#bbf7d0',
-      fontWeight: 600,
-    },
   },
   제외: {
     description: '이번 여행에서 제외',
     order: 4,
     emoji: '❌',
     className: 'bg-bg-subtle text-fg-subtle border-border line-through',
-    style: {
-      background: '#f8fafc',
-      color: '#cbd5e1',
-      borderColor: '#e2e8f0',
-      textDecoration: 'line-through',
-    },
   },
 }
 
@@ -136,7 +111,6 @@ interface ReservationMeta {
   description: string
   emoji: string
   className: string
-  style: BadgeStyle
 }
 
 export const RESERVATION_STATUS_META: Record<ReservationStatus, ReservationMeta> = {
@@ -144,30 +118,21 @@ export const RESERVATION_STATUS_META: Record<ReservationStatus, ReservationMeta>
     description: '예약 필요 여부 미확정',
     emoji: '🔍',
     className: 'bg-warning-bg text-warning-fg border-warning-border',
-    style: { background: '#fffbeb', color: '#d97706', borderColor: '#fde68a' },
   },
   불필요: {
     description: '예약 없이 진행 가능',
     emoji: '🆓',
     className: 'bg-bg-subtle text-fg-subtle border-border',
-    style: { background: '#f8fafc', color: '#94a3b8', borderColor: '#e2e8f0' },
   },
   '필요(미예약)': {
     description: '예약이 필요하지만 아직 안 함',
     emoji: '🔔',
     className: 'bg-warning-bg text-warning-fg border-warning-border font-semibold',
-    style: {
-      background: '#fff7ed',
-      color: '#ea580c',
-      borderColor: '#fed7aa',
-      fontWeight: 600,
-    },
   },
   예약완료: {
     description: '예약 완료',
     emoji: '✅',
     className: 'bg-success-bg text-success-fg border-success-border',
-    style: { background: '#f0fdf4', color: '#16a34a', borderColor: '#bbf7d0' },
   },
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
-  darkMode: 'media',
+  darkMode: 'class',
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## Summary

이전 디자인 시스템 도입 PR(#93) 의 후속 정비. 사용자 피드백 6 가지를 모두 반영.

## 변경

### 1. 일정 뷰 중복 제거 (질문 답변)
- `/research` 의 ViewToggle "일정" 모드 = 좌측 사이드바 "일정"(/schedule) 메뉴와 동일한 `ScheduleTable` 컴포넌트를 다른 진입점으로 보여주는 중복 화면이었음
- 해소: `/research` 는 목록 전용으로 단순화, ViewToggle 제거. 일정은 `/schedule` 만 유지

### 2. 다크모드 미완성 정비
- ScheduleTable 헤더, 카드, 드롭다운 등의 잔여 `bg-white` 11 곳 swap → `bg-bg-elevated`
- ItemPanel, PanelItemForm, ItemForm, GmapsImport, ResearchTable 등 동일 swap
- 우선순위·예약 칩의 인라인 `style: { background: '#...' }` 객체 제거 → `className` 만 사용 (다크 자동 적용)
- PriorityCell, StatusCell 의 인라인 hex → 시맨틱 토큰 className
- 잔여 hex (red/blue/green/yellow/orange/amber/sky/emerald) 일괄 swap → critical/info/success/warning/accent

### 3. 라이트/다크/시스템 3-way 테마 토글
- `darkMode: 'media' → 'class'` 전환
- `ThemeProvider` 컨텍스트: localStorage persist, OS 변경 감지
- `ThemeToggle` 컴포넌트: Sun/Monitor/Moon 라디오 그룹 (role=radiogroup/radio)
- `layout.tsx` head 에 inline script 로 hydration 전 dark 클래스 set (깜빡임 방지)
- 데스크톱 사이드바, 모바일 헤더 우측, /plan 모바일 지도 위 fixed 위치에 토글 노출

### 4. /plan 단일 통합 화면
- `components/Plan/PlanScreen.tsx` 추출: URL `?item=&day=` 동기, MapSidePanel + TripPlannerMap + ItemPanel 통합
- `/plan` 라우트 신설 (메인 작업 화면)
- `/map → /plan` 으로 redirect (search params 유지, 북마크 호환)
- `/` (홈) → `/plan` 으로 redirect
- Navigation 메뉴: 계획(/plan) / 목록(/research) / 일정(/schedule)

### 5. ItemPanel onSave/onDelete 데이터 연결
- ItemPanel 내부 `useItems.updateItem/deleteItem` 호출은 이전부터 작동 중. 호스트 페이지 콜백이 스텁(`() => {}`)이었음
- PlanScreen, /research, /schedule 모두 `onSave` 시 success toast("저장했어요"), `onDelete` 시 selection cleanup + toast("삭제했어요") 결선

### 6. 인라인 hex 다크 톤 매핑
- `itemOptions.ts`: `BadgeStyle` 인터페이스, `.style` 필드 완전 제거. `className` 만 노출 (다크 자동)
- 지도 마커 (TripPlannerMap, ResearchMap, ScheduleMap):
  - leaflet `divIcon` HTML 인라인 스타일 → CSS 클래스 (`tp-chip-marker`, `tp-number-marker`)
  - `globals.css` 에 `rgb(var(--bg-elevated))` 등으로 정의 → dark 토글 자동 반응
- Polyline `pathOptions.className: 'tp-day-route'` → CSS `stroke: rgb(var(--accent))`
- `globals.css`: leaflet tile 다크 보정 (`invert + hue-rotate filter`)
- leaflet 컨트롤 / attribution / popup 의 다크 톤 강제 적용

## 빌드

- `npm run build` ✅ 통과 (18 라우트, /plan 신규 6.98 kB)
- `tsc --noEmit` ✅ 통과

## Test plan

- [ ] `/` 진입 → /plan 으로 자동 리다이렉트
- [ ] `/plan` 데스크톱: 사이드패널 후보/일정 모드, 일자 칩, 카드 선택 → ItemPanel
- [ ] `/plan` 모바일: 지도 풀스크린 + 하단 패널, 우측 상단 ThemeToggle, FAB 위치
- [ ] `/map` 진입 → /plan 으로 redirect (search params 유지 확인)
- [ ] 테마 토글 — 라이트 / 시스템 / 다크 3-way, 새로고침 후 유지
- [ ] 다크 모드: ScheduleTable 헤더, 카드, 드롭다운, 우선순위 칩, 지도 tile, 마커 모두 어두운 톤
- [ ] OS 다크 모드 토글 시 'system' 모드에서 자동 전환
- [ ] ItemPanel 저장/삭제 → 토스트 노출
- [ ] `/research` 에 ViewToggle 사라지고 목록만