### PR TITLE
fix: 지도 마커에서 자정 크로스오버 일정 종료일 중복 표시 제거

### DIFF
--- a/components/Map/ScheduleMap.tsx
+++ b/components/Map/ScheduleMap.tsx
@@ -124,19 +124,27 @@ export default function ScheduleMap({ items, onSelectItem }: ScheduleMapProps) {
 
 function occursOnDate(item: TripItem, date: string) {
   if (!item.date) return false
-  if (!item.end_date) return item.date === date
-  return item.date <= date && date <= item.end_date
+  if (item.date === date) return true
+  // end_date 까지 확장하는 건 종일/다일 일정(time_start 없음)에만 적용.
+  // 자정을 넘기는 단일 일정이 종료일에 끼어들지 않도록.
+  if (item.end_date && !item.time_start) {
+    return item.date <= date && date <= item.end_date
+  }
+  return false
 }
 
 function collectScheduleDates(items: TripItem[]) {
   const dates = new Set<string>()
   items.forEach(item => {
     if (!item.date) return
-    const rangeEnd = item.end_date ?? item.date
-    let cursor = item.date
-    while (cursor <= rangeEnd) {
-      dates.add(cursor)
-      cursor = nextDate(cursor)
+    // 시작일은 항상 포함. end_date 확장은 종일/다일 일정에만.
+    dates.add(item.date)
+    if (item.end_date && !item.time_start) {
+      let cursor = nextDate(item.date)
+      while (cursor <= item.end_date) {
+        dates.add(cursor)
+        cursor = nextDate(cursor)
+      }
     }
   })
   return Array.from(dates).sort()

--- a/components/Map/TripPlannerMap.tsx
+++ b/components/Map/TripPlannerMap.tsx
@@ -41,8 +41,13 @@ function numberIcon(num: number, selected: boolean) {
 
 function occursOnDate(item: TripItem, date: string): boolean {
   if (!item.date) return false
-  if (!item.end_date) return item.date === date
-  return item.date <= date && date <= item.end_date
+  if (item.date === date) return true
+  // end_date 까지 확장하는 건 종일/다일 일정(time_start 없음)에만 적용.
+  // 자정을 넘기는 단일 일정이 종료일에 끼어들지 않도록.
+  if (item.end_date && !item.time_start) {
+    return item.date <= date && date <= item.end_date
+  }
+  return false
 }
 
 export default function TripPlannerMap({


### PR DESCRIPTION
## Summary

PR #92 의 후속 수정. 사이드 패널 리스트는 정상화됐지만 **지도 마커를 그리는 컴포넌트들**(TripPlannerMap, ScheduleMap)이 동일 함수를 자체 정의해두고 옛 로직을 유지하고 있어, 7/7 23:30 → 7/8 01:00 JFK 픽업 항목이 7/8 지도에 7번 마커로 계속 표시되던 문제를 해결.

- `components/Map/TripPlannerMap.tsx` — `occursOnDate` 새 규칙으로 통일
- `components/Map/ScheduleMap.tsx` — `occursOnDate` 새 규칙으로 통일
- `components/Map/ScheduleMap.tsx` — `collectScheduleDates` 도 동일 규칙 적용

## Test plan

- [ ] 7/8 지도 마커에 JFK 공항 -> Hard Rock 호텔 이동 항목이 표시되지 않는지 확인
- [ ] 7/7 지도 마커에는 정상 표시되는지 확인
- [ ] 다일 호텔 항목이 모든 숙박 날짜에 마커로 그려지는지 확인