### PR TITLE
refactor: 일정 뷰 날짜 헤더의 카테고리 색상 바 제거

### DIFF
--- a/components/Schedule/DateGroupHeader.tsx
+++ b/components/Schedule/DateGroupHeader.tsx
@@ -1,15 +1,11 @@
 'use client'
 
-import type { Category } from '@/types'
-import CategoryStackBar from './CategoryStackBar'
-
 interface DateGroupHeaderProps {
   date: string
   dayOffset: number | null
   totalBudget: number
   isCollapsed: boolean
   isToday?: boolean
-  categoryBreakdown?: { category: Category; count: number }[]
   onToggleCollapse: () => void
   onAddItem: () => void
 }
@@ -29,12 +25,10 @@ export default function DateGroupHeader({
   totalBudget,
   isCollapsed,
   isToday = false,
-  categoryBreakdown,
   onToggleCollapse,
   onAddItem,
 }: DateGroupHeaderProps) {
   const isUndated = date === '__undated__'
-  const showBar = !isUndated && categoryBreakdown && categoryBreakdown.length > 0
 
   return (
     <div className="bg-bg-elevated border-b border-border sticky top-0 z-10">
@@ -96,11 +90,6 @@ export default function DateGroupHeader({
         </button>
       </div>
       </div>
-      {showBar && (
-        <div className="px-3 pb-2">
-          <CategoryStackBar breakdown={categoryBreakdown!} />
-        </div>
-      )}
     </div>
   )
 }

--- a/components/Schedule/ScheduleTable.tsx
+++ b/components/Schedule/ScheduleTable.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState, Fragment } from 'react'
-import type { Category, ReservationStatus, TripItem } from '@/types'
-import { CATEGORY_META, CATEGORY_OPTIONS, RESERVATION_STATUS_META } from '@/lib/itemOptions'
+import type { ReservationStatus, TripItem } from '@/types'
+import { CATEGORY_META, RESERVATION_STATUS_META } from '@/lib/itemOptions'
 import { haversineKm } from '@/lib/distance'
 import { EDITABLE_FIELDS, type EditableField } from './TableRow'
 import TableRow from './TableRow'
@@ -65,16 +65,6 @@ function getStatusMeta(value: ReservationStatus | null | undefined) {
     }[value],
     label: shortLabel[value],
   }
-}
-
-function buildCategoryBreakdown(items: TripItem[]): { category: Category; count: number }[] {
-  const counts = new Map<Category, number>()
-  for (const it of items) {
-    counts.set(it.category, (counts.get(it.category) ?? 0) + 1)
-  }
-  return CATEGORY_OPTIONS
-    .filter(c => counts.has(c))
-    .map(c => ({ category: c, count: counts.get(c)! }))
 }
 
 function distanceBetween(a: TripItem, b: TripItem): number | null {
@@ -427,7 +417,6 @@ export default function ScheduleTable({
           const isCollapsed = collapsedDates.has(date)
           const dayOffset = getDayOffset(date)
           const isToday = date === todayKey
-          const categoryBreakdown = buildCategoryBreakdown(groupItems)
 
           return (
             <div key={date} ref={isToday ? todayRef : undefined} className="overflow-hidden rounded-xl border border-border bg-bg-elevated shadow-sm">
@@ -437,7 +426,6 @@ export default function ScheduleTable({
                 totalBudget={totalBudget}
                 isCollapsed={isCollapsed}
                 isToday={isToday}
-                categoryBreakdown={categoryBreakdown}
                 onToggleCollapse={() =>
                   setCollapsedDates(prev => {
                     const next = new Set(prev)
@@ -530,7 +518,6 @@ export default function ScheduleTable({
                 const isCollapsed = collapsedDates.has(date)
                 const dayOffset = getDayOffset(date)
                 const isToday = date === todayKey
-                const categoryBreakdown = buildCategoryBreakdown(groupItems)
 
                 return (
                   <div key={date} ref={isToday ? todayRef : undefined}>
@@ -540,7 +527,6 @@ export default function ScheduleTable({
                       totalBudget={totalBudget}
                       isCollapsed={isCollapsed}
                       isToday={isToday}
-                      categoryBreakdown={categoryBreakdown}
                       onToggleCollapse={() =>
                         setCollapsedDates(prev => {
                           const next = new Set(prev)


### PR DESCRIPTION
## Summary

- 일정 뷰의 날짜 그룹 헤더(`DateGroupHeader`)에서 카테고리 분포를 표시하던 색상 바(`CategoryStackBar`) 렌더링을 제거
- `ScheduleTable` 에서 더 이상 사용되지 않는 `buildCategoryBreakdown` 헬퍼와 `categoryBreakdown` prop 전달 제거
- 사용되지 않게 된 `Category` / `CATEGORY_OPTIONS` import 도 함께 정리
- `CategoryStackBar` 컴포넌트 자체는 지도 사이드 패널(`MapSidePanel`)에서 여전히 사용되므로 파일은 유지

## 변경 이유

일정별 카드 헤더의 색상 바가 실사용에서 유용성이 낮다는 피드백에 따라 제거합니다.

## Test plan

- [ ] 일정 뷰(모바일/데스크톱 모두)에서 날짜 헤더 아래 색상 바가 더 이상 보이지 않는지 확인
- [ ] 날짜 헤더의 다른 정보(날짜 라벨, D+, 오늘 배지, 예산, 추가 버튼, 접기/펼치기) 가 정상 동작하는지 확인
- [ ] 지도 사이드 패널의 카테고리 분포 색상 바는 그대로 표시되는지 확인
- [ ] 빌드/타입 체크 통과 확인