### PR TITLE
fix(map): 일정 모드 지도 숫자 마커와 일정 목록 번호 불일치 수정

### DIFF
--- a/components/Map/TripPlannerMap.tsx
+++ b/components/Map/TripPlannerMap.tsx
@@ -67,7 +67,7 @@ export default function TripPlannerMap({
   const dayItems = useMemo(() => {
     if (!selectedDate) return [] as TripItem[]
     return visibleItems
-      .filter(i => occursOnDate(i, selectedDate))
+      .filter(i => i.trip_priority === '확정' && occursOnDate(i, selectedDate))
       .sort((a, b) => (a.time_start ?? '99:99').localeCompare(b.time_start ?? '99:99'))
   }, [visibleItems, selectedDate])
 


### PR DESCRIPTION
## 문제

지도 뷰의 **일정 모드**에서 지도 위에 표시되는 숫자 마커와 우측 일정 목록의 숫자가 일치하지 않아 사용자에게 혼동을 주는 문제가 있었습니다.

## 원인

같은 날짜에 표시되는 항목을 두 컴포넌트가 서로 다른 기준으로 필터링하고 번호를 매기고 있었습니다.

- `components/Map/TripPlannerMap.tsx:70` — `trip_priority !== '제외'` 인 모든 항목(즉, **확정 / 검토 필요 / 후보** 모두)을 시간순 정렬해 1, 2, 3… 번호 마커로 표시
- `components/Map/MapSidePanel.tsx:83` — `trip_priority === '확정'` 인 항목만 시간순 정렬해 1, 2, 3… 번호로 표시

후보(검토 필요/후보) 항목이 같은 날짜에 섞여 있으면 지도와 목록의 번호가 어긋났습니다.

예) Day 1 항목이 [A(확정), B(후보), C(확정)] 일 때
- 지도: ① A, ② B, ③ C
- 목록: ① A, ② C

## 변경

`TripPlannerMap` 의 `dayItems` 필터에 `trip_priority === '확정'` 조건을 추가해 번호 마커 대상을 사이드패널 일정 목록과 동일하게 맞췄습니다. 후보 항목(`'후보'`, `'검토 필요'`)은 이전과 동일하게 카테고리 이모지 마커로 dim 처리되어 표시됩니다.

## Test plan

- [ ] 일정 모드에서 같은 날짜에 확정 + 후보가 섞여 있을 때 지도 숫자 마커 ①②③… 와 우측 일정 목록의 ①②③… 가 같은 항목을 가리키는지 확인
- [ ] 후보/검토 필요 항목은 여전히 카테고리 이모지 마커로 보이는지 확인
- [ ] 시간(`time_start`) 미입력 항목이 있을 때 정렬 순서가 둘 다 동일하게 끝으로 가는지 확인
- [ ] 자정 크로스오버 / 다일 종일 일정에서도 둘의 표시가 일관되는지 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_011VrJyQbnizNB26vHH6oGuF)_