### PR TITLE
fix(theme): 다크 모드 미적용 잔여 영역 시맨틱 토큰화

### DIFF
--- a/app/gmaps-import/page.tsx
+++ b/app/gmaps-import/page.tsx
@@ -162,7 +162,7 @@ export default function GmapsImportPage() {
           <div className="bg-bg-elevated rounded-xl border border-border p-8 text-center">
             <div className="w-12 h-12 rounded-full bg-success-bg flex items-center justify-center mx-auto mb-4">
               <svg
-                className="w-6 h-6 text-green-600"
+                className="w-6 h-6 text-success-fg"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"

--- a/app/items/[id]/page.tsx
+++ b/app/items/[id]/page.tsx
@@ -25,7 +25,7 @@ export default async function ItemDetailPage({ params }: { params: { id: string 
           </Link>
           <Link
             href={`/items/${item.id}/edit`}
-            className="px-3 py-1.5 text-sm font-medium bg-accent text-white rounded-lg hover:bg-accent-hover transition-colors"
+            className="px-3 py-1.5 text-sm font-medium bg-accent text-accent-fg rounded-lg hover:bg-accent-hover transition-colors"
           >
             편집
           </Link>
@@ -40,7 +40,7 @@ export default async function ItemDetailPage({ params }: { params: { id: string 
         <div className="space-y-5">
           {/* 일정 & 예산 */}
           {(scheduleRows.length > 0 || item.budget !== undefined) && (
-            <section className="bg-gray-50 rounded-xl p-4 space-y-1.5">
+            <section className="bg-bg-subtle rounded-xl p-4 space-y-1.5">
               {scheduleRows.map(row => (
                 <Row key={row.label} label={row.label} value={row.value} />
               ))}

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -34,13 +34,13 @@ export default function LoginForm() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-gray-50 to-stone-100 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-bg via-bg-subtle to-bg flex items-center justify-center p-4">
       <div className="w-full max-w-sm">
         <div className="text-center mb-8">
           <div className="w-12 h-12 bg-accent rounded-2xl flex items-center justify-center mx-auto mb-4">
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              className="w-6 h-6 text-white"
+              className="w-6 h-6 text-accent-fg"
               viewBox="0 0 20 20"
               fill="currentColor"
             >
@@ -88,15 +88,15 @@ export default function LoginForm() {
           </div>
 
           {error && (
-            <div className="bg-rose-50 border border-rose-200 rounded-lg px-3 py-2">
-              <p className="text-rose-600 text-sm">{error}</p>
+            <div className="bg-critical-bg border border-critical-border rounded-lg px-3 py-2">
+              <p className="text-critical-fg text-sm">{error}</p>
             </div>
           )}
 
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-accent text-white rounded-xl px-4 py-2.5 text-sm font-semibold disabled:opacity-50 hover:bg-accent-hover active:bg-accent-hover transition-colors mt-2"
+            className="w-full bg-accent text-accent-fg rounded-xl px-4 py-2.5 text-sm font-semibold disabled:opacity-50 hover:bg-accent-hover active:bg-accent-hover transition-colors mt-2"
           >
             {loading ? '로그인 중...' : '로그인'}
           </button>

--- a/components/GmapsImport/CandidateList.tsx
+++ b/components/GmapsImport/CandidateList.tsx
@@ -62,7 +62,7 @@ export default function CandidateList({
         <button
           onClick={onImport}
           disabled={importing || selectedCount === 0}
-          className="px-4 py-2 text-sm font-medium bg-accent text-white rounded-lg hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="px-4 py-2 text-sm font-medium bg-accent text-accent-fg rounded-lg hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
           {importing ? '추가 중...' : `${selectedCount}개 추가`}
         </button>
@@ -88,10 +88,10 @@ export default function CandidateList({
             key={`${candidate.place.name}-${i}`}
             className={`flex items-start gap-3 p-3 rounded-lg border transition-colors ${
               candidate.status === 'duplicate'
-                ? 'border-border bg-gray-50 opacity-60'
+                ? 'border-border bg-bg-subtle opacity-60'
                 : candidate.selected
                 ? 'border-border bg-bg-elevated'
-                : 'border-border bg-gray-50'
+                : 'border-border bg-bg-subtle'
             }`}
           >
             <input
@@ -128,7 +128,7 @@ export default function CandidateList({
               )}
 
               {candidate.status === 'similar' && candidate.similarItem && (
-                <p className="text-xs text-yellow-600 mt-0.5">
+                <p className="text-xs text-warning-fg mt-0.5">
                   유사 장소: {candidate.similarItem.name}
                 </p>
               )}

--- a/components/GmapsImport/UrlInput.tsx
+++ b/components/GmapsImport/UrlInput.tsx
@@ -32,7 +32,7 @@ export default function UrlInput({ onSubmit, loading, error }: UrlInputProps) {
           type="url"
           placeholder="https://maps.app.goo.gl/..."
           disabled={loading}
-          className="flex-1 px-3 py-2 text-sm border border-border rounded-lg focus:outline-none focus:ring-2 focus-visible:outline-accent focus:border-transparent disabled:bg-gray-50 disabled:text-fg-subtle"
+          className="flex-1 px-3 py-2 text-sm border border-border rounded-lg bg-bg-elevated text-fg focus:outline-none focus:ring-2 focus-visible:outline-accent focus:border-transparent disabled:bg-bg-subtle disabled:text-fg-subtle"
           autoComplete="off"
           autoCorrect="off"
           autoCapitalize="off"
@@ -41,7 +41,7 @@ export default function UrlInput({ onSubmit, loading, error }: UrlInputProps) {
         <button
           type="submit"
           disabled={loading}
-          className="px-4 py-2 text-sm font-medium bg-accent text-white rounded-lg hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors whitespace-nowrap"
+          className="px-4 py-2 text-sm font-medium bg-accent text-accent-fg rounded-lg hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors whitespace-nowrap"
         >
           {loading ? '불러오는 중...' : '불러오기'}
         </button>

--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -200,7 +200,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
             type="text"
             value={form.name}
             onChange={e => setField('name', e.target.value)}
-            className={`${inputClass}${nameError ? ' border-red-400 focus:ring-red-200' : ''}`}
+            className={`${inputClass}${nameError ? ' border-critical-fg focus:ring-critical-border' : ''}`}
             placeholder="장소 또는 활동 이름"
           />
           {nameError && <p className="text-xs text-critical-fg mt-1">{nameError}</p>}
@@ -271,7 +271,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
           <label className={labelClass}>주소</label>
           <input type="text" value={form.address} onChange={e => setField('address', e.target.value)} onBlur={handleAddressBlur} className={inputClass} placeholder="주소 입력 후 포커스를 벗어나면 좌표 자동 입력" />
           {geocoding && <p className="text-xs text-fg-subtle mt-1">좌표 검색 중...</p>}
-          {!geocoding && geocodeError && <p className="text-xs text-amber-500 mt-1">{geocodeError}</p>}
+          {!geocoding && geocodeError && <p className="text-xs text-warning-fg mt-1">{geocodeError}</p>}
         </div>
 
         <div className="grid grid-cols-2 gap-3">
@@ -322,7 +322,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
           <button type="button" onClick={() => router.back()} className="px-4 py-2.5 rounded-lg text-sm font-medium text-fg-muted border border-border hover:bg-bg-subtle transition-colors">
             취소
           </button>
-          <button type="submit" disabled={loading} className="flex-1 bg-accent text-white rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-accent-hover transition-colors">
+          <button type="submit" disabled={loading} className="flex-1 bg-accent text-accent-fg rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-accent-hover transition-colors">
             {loading ? '저장 중...' : '저장'}
           </button>
         </div>

--- a/components/Map/ScheduleMap.tsx
+++ b/components/Map/ScheduleMap.tsx
@@ -60,7 +60,7 @@ export default function ScheduleMap({ items, onSelectItem }: ScheduleMapProps) {
               onClick={() => setSelectedDate(date)}
               className={`flex-shrink-0 px-3 py-1 rounded-full text-xs font-medium border shadow-sm transition-colors ${
                 selectedDate === date
-                  ? 'bg-accent text-white border-accent'
+                  ? 'bg-accent text-accent-fg border-accent'
                   : 'bg-bg-elevated text-fg border-border hover:border-border-strong'
               }`}
             >

--- a/components/Panel/ItemPanel.tsx
+++ b/components/Panel/ItemPanel.tsx
@@ -207,7 +207,7 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
           <div className="absolute bottom-0 left-0 right-0 bg-bg-elevated border-t-2 border-warning-border px-5 pt-4 pb-6 z-10">
             <p className="text-sm font-medium text-fg mb-3">변경사항이 있습니다. 저장하지 않고 나가시겠습니까?</p>
             <div className="flex gap-3">
-              <button onClick={handleDiscardAndClose} className="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium text-white bg-accent hover:bg-accent-hover transition-colors">나가기</button>
+              <button onClick={handleDiscardAndClose} className="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium text-accent-fg bg-accent hover:bg-accent-hover transition-colors">나가기</button>
               <button onClick={() => setConfirmingClose(false)} className="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium text-fg-muted border border-border hover:bg-bg-subtle transition-colors">계속 편집</button>
             </div>
           </div>
@@ -456,7 +456,7 @@ function ItemDetailView({
       </div>
 
       {/* 일정 + 예산 */}
-      <section className="bg-gray-50 rounded-xl p-4 space-y-2.5">
+      <section className="bg-bg-subtle rounded-xl p-4 space-y-2.5">
         <SectionTitle>일정 · 예산</SectionTitle>
 
         <InlineRow label="시작 날짜">

--- a/components/Panel/PanelItemForm.tsx
+++ b/components/Panel/PanelItemForm.tsx
@@ -169,7 +169,7 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
               type="text"
               value={form.name}
               onChange={e => setField('name', e.target.value)}
-              className={`${inputClass}${nameError ? ' border-red-400 focus:ring-red-200' : ''}`}
+              className={`${inputClass}${nameError ? ' border-critical-fg focus:ring-critical-border' : ''}`}
               placeholder="장소 또는 활동 이름"
             />
             {nameError && <p className="text-xs text-critical-fg mt-1">{nameError}</p>}
@@ -241,7 +241,7 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
             <input type="text" value={form.address} onChange={e => setField('address', e.target.value)} onBlur={handleAddressBlur} className={inputClass} placeholder="주소 입력 후 포커스를 벗어나면 좌표 자동 입력" />
           </Field>
           {geocoding && <p className="text-xs text-fg-subtle -mt-2">좌표 검색 중...</p>}
-          {!geocoding && geocodeError && <p className="text-xs text-amber-500 -mt-2">{geocodeError}</p>}
+          {!geocoding && geocodeError && <p className="text-xs text-warning-fg -mt-2">{geocodeError}</p>}
           <div className="grid grid-cols-2 gap-3">
             <Field label="위도 (lat)">
               <input type="number" step="any" value={form.lat} onChange={e => setField('lat', e.target.value)} className={inputClass} />
@@ -277,7 +277,7 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
           <button type="button" onClick={onCancel} className="px-4 py-2.5 rounded-lg text-sm font-medium text-fg-muted border border-border hover:bg-bg-subtle transition-colors">
             취소
           </button>
-          <button type="submit" className="flex-1 bg-accent text-white rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-accent-hover transition-colors">
+          <button type="submit" className="flex-1 bg-accent text-accent-fg rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-accent-hover transition-colors">
             저장
           </button>
         </div>

--- a/components/Research/ResearchTable.tsx
+++ b/components/Research/ResearchTable.tsx
@@ -252,7 +252,7 @@ export default function ResearchTable({
               onBlur={handleNewItemBlur}
               onKeyDown={handleNewItemKeyDown}
               placeholder="이름 입력 후 Enter…"
-              className="w-full bg-transparent border-b border-blue-300 focus:border-blue-500 outline-none text-sm text-fg py-0.5"
+              className="w-full bg-transparent border-b border-border-strong focus:border-accent outline-none text-sm text-fg py-0.5"
               style={{ fontSize: 16 }}
             />
           </div>

--- a/components/Schedule/ScheduleTable.tsx
+++ b/components/Schedule/ScheduleTable.tsx
@@ -112,7 +112,7 @@ function MobileScheduleItemCard({
       className="w-full rounded-2xl border border-border bg-bg-elevated p-4 text-left shadow-sm transition-all hover:border-border-strong hover:shadow-md active:scale-[0.99]"
     >
       <div className="flex items-start gap-3">
-        <span className="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl bg-gray-50 text-lg">
+        <span className="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl bg-bg-subtle text-lg">
           {emoji}
         </span>
         <div className="min-w-0 flex-1">
@@ -121,7 +121,7 @@ function MobileScheduleItemCard({
               <p className="truncate text-sm font-semibold text-fg">{item.name}</p>
               <p className="mt-0.5 text-xs text-fg-muted">{item.category}</p>
             </div>
-            <span className="inline-flex flex-shrink-0 items-center gap-1 rounded-full border border-border bg-gray-50 px-2 py-0.5 text-xs text-fg-muted">
+            <span className="inline-flex flex-shrink-0 items-center gap-1 rounded-full border border-border bg-bg-subtle px-2 py-0.5 text-xs text-fg-muted">
               <span className={`h-2 w-2 rounded-full ${status.dotClass}`} />
               {status.label}
             </span>
@@ -162,7 +162,7 @@ function MobileNewItemEditor({
         onBlur={onBlur}
         onKeyDown={e => onKeyDown(e, value)}
         placeholder="이름 입력 후 Enter…"
-        className="w-full bg-transparent border-b border-blue-300 focus:border-blue-500 outline-none text-sm text-fg py-1"
+        className="w-full bg-transparent border-b border-border-strong focus:border-accent outline-none text-sm text-fg py-1"
         style={{ fontSize: 16 }}
       />
     </div>
@@ -325,7 +325,7 @@ export default function ScheduleTable({
           )
         })}
         {addingToDate === date ? (
-          <div className="flex min-w-[720px] items-center border-b border-gray-50 bg-info-bg/30">
+          <div className="flex min-w-[720px] items-center border-b border-border bg-info-bg/30">
             <div className="w-16 flex-shrink-0 px-3 py-2.5" />
             <div className="min-w-[220px] flex-1 px-3 py-2.5">
               <input
@@ -335,7 +335,7 @@ export default function ScheduleTable({
                 onBlur={() => handleNewItemBlur(date)}
                 onKeyDown={e => handleNewItemKeyDown(e, date)}
                 placeholder="이름 입력 후 Enter…"
-                className="w-full bg-transparent border-b border-blue-300 focus:border-blue-500 outline-none text-sm text-fg py-0.5"
+                className="w-full bg-transparent border-b border-border-strong focus:border-accent outline-none text-sm text-fg py-0.5"
                 style={{ fontSize: 16 }}
               />
             </div>
@@ -392,7 +392,7 @@ export default function ScheduleTable({
               setAddingToDate(date)
               setNewItemName('')
             }}
-            className="flex w-full items-center justify-center gap-1.5 rounded-2xl border border-dashed border-border bg-gray-50 px-4 py-3 text-sm text-fg-muted transition-colors hover:border-border-strong hover:text-fg"
+            className="flex w-full items-center justify-center gap-1.5 rounded-2xl border border-dashed border-border bg-bg-subtle px-4 py-3 text-sm text-fg-muted transition-colors hover:border-border-strong hover:text-fg"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />

--- a/components/Schedule/cells/BudgetCell.tsx
+++ b/components/Schedule/cells/BudgetCell.tsx
@@ -63,7 +63,7 @@ export default function BudgetCell({ value, isEditing, onClick, onBlur, onKeyDow
       {value !== undefined ? (
         `$${value.toLocaleString()}`
       ) : (
-        <span className="text-gray-200">—</span>
+        <span className="text-fg-subtle">—</span>
       )}
     </span>
   )


### PR DESCRIPTION
## 배경

다크 모드가 적용되지 않은 잔여 영역 보완:
- **로그인 페이지** — 그라데이션 배경/에러 알림/아이콘 칩이 라이트 톤 고정
- **항목 추가 버튼** — 리서치·스케줄 인라인 "항목 추가" 입력 밑줄 (`border-blue-300/500`) 과 모바일 추가 카드 (`bg-gray-50`), 그리고 항목 카드의 카테고리 이모지 뒷배경
- **디테일 패널 정보 입력 영역** — `일정·예산` 섹션 (`bg-gray-50`), 이름 에러 보더 (`border-red-400`/`focus:ring-red-200`), 지오코드 경고 (`text-amber-500`), 저장/나가기 버튼 (`text-white`)

## 변경 내용

| 파일 | 교체 내용 |
| --- | --- |
| `app/login/LoginForm.tsx` | `from-slate-50 via-gray-50 to-stone-100` → `from-bg via-bg-subtle to-bg`, `bg-rose-50/border-rose-200/text-rose-600` → `bg-critical-bg/border-critical-border/text-critical-fg`, `text-white` → `text-accent-fg` |
| `components/Panel/ItemPanel.tsx` | `bg-gray-50` → `bg-bg-subtle`, `text-white` → `text-accent-fg` |
| `components/Items/ItemForm.tsx`, `components/Panel/PanelItemForm.tsx` | `border-red-400 focus:ring-red-200` → `border-critical-fg focus:ring-critical-border`, `text-amber-500` → `text-warning-fg`, `text-white` → `text-accent-fg` |
| `components/Research/ResearchTable.tsx`, `components/Schedule/ScheduleTable.tsx` | `border-blue-300 focus:border-blue-500` → `border-border-strong focus:border-accent`, `bg-gray-50` (이모지 칩·예약 칩·모바일 추가 카드) → `bg-bg-subtle`, `border-gray-50` → `border-border` |
| `app/items/[id]/page.tsx` | `bg-gray-50` → `bg-bg-subtle`, `text-white` → `text-accent-fg` |
| `components/GmapsImport/UrlInput.tsx`, `CandidateList.tsx`, `app/gmaps-import/page.tsx` | `disabled:bg-gray-50` → `disabled:bg-bg-subtle` (+ `bg-bg-elevated text-fg`), 카드 `bg-gray-50` → `bg-bg-subtle`, `text-white` → `text-accent-fg`, `text-yellow-600` → `text-warning-fg`, `text-green-600` → `text-success-fg` |
| `components/Map/ScheduleMap.tsx` | 일자 필터 칩 선택 상태 `text-white` → `text-accent-fg` |
| `components/Schedule/cells/BudgetCell.tsx` | 빈 값 대시 `text-gray-200` → `text-fg-subtle` |

## 검증

- `npx tsc --noEmit` 통과
- `npx next build` 통과 (모든 라우트 정상 빌드)
- 시각 회귀: `globals.css` 의 라이트/다크 토큰 정의는 변경하지 않았으므로 라이트 모드 외관은 동일
