### PR TITLE
feat(mobile): 하단 패널 높이 드래그·스냅 조정 가능

### DIFF
--- a/components/Plan/PlanScreen.tsx
+++ b/components/Plan/PlanScreen.tsx
@@ -8,6 +8,10 @@ import MapSidePanel, { type DaySummary } from '@/components/Map/MapSidePanel'
 import ThemeToggle from '@/components/Theme/ThemeToggle'
 import FAB from '@/components/UI/FAB'
 import { useItems } from '@/lib/hooks/useItems'
+import {
+  PANEL_SNAP_POINTS_VH,
+  useMobilePanelHeight,
+} from '@/lib/hooks/useMobilePanelHeight'
 import { useToast } from '@/components/UI/Toast'
 import { CATEGORY_OPTIONS } from '@/lib/itemOptions'
 import type { Category, TripItem } from '@/types'
@@ -89,6 +93,7 @@ export default function PlanScreen({ basePath }: PlanScreenProps) {
 
   const selectedItem = items.find((i) => i.id === selectedItemId) ?? null
   const days = useMemo(() => buildDaySummaries(items), [items])
+  const mobilePanel = useMobilePanelHeight()
 
   // URL ↔ state 동기화 헬퍼
   function pushUrl(updates: { item?: string | null; day?: string | null }) {
@@ -169,7 +174,10 @@ export default function PlanScreen({ basePath }: PlanScreenProps) {
       </div>
 
       {/* Mobile: map fullscreen + bottom drawer with same panel */}
-      <div className="md:hidden flex h-[calc(100vh-56px)] flex-col relative">
+      <div
+        className="md:hidden flex h-[calc(100vh-56px)] flex-col relative"
+        style={{ '--mobile-panel-height': mobilePanel.heightStyle } as React.CSSProperties}
+      >
         <div className="relative min-h-0 flex-1">
           <TripPlannerMap
             items={items}
@@ -181,13 +189,33 @@ export default function PlanScreen({ basePath }: PlanScreenProps) {
           <div className="absolute top-3 right-3 z-[600]">
             <ThemeToggle />
           </div>
-          <FAB className="bottom-[calc(40vh+1rem)] right-4" />
+          <FAB className="bottom-[calc(var(--mobile-panel-height,40vh)+1rem)] right-4" />
         </div>
         <div
-          className="flex-shrink-0 border-t border-border bg-bg-elevated"
-          style={{ height: '40vh' }}
+          className={`flex-shrink-0 border-t border-border bg-bg-elevated flex flex-col ${
+            mobilePanel.isDragging ? '' : 'transition-[height] duration-200 ease-out'
+          }`}
+          style={{ height: mobilePanel.heightStyle }}
         >
-          {sidePanel}
+          <button
+            type="button"
+            role="slider"
+            aria-label="패널 높이 조정"
+            aria-valuemin={PANEL_SNAP_POINTS_VH[0]}
+            aria-valuemax={PANEL_SNAP_POINTS_VH[PANEL_SNAP_POINTS_VH.length - 1]}
+            aria-valuenow={PANEL_SNAP_POINTS_VH[mobilePanel.snapIndex]}
+            aria-valuetext={
+              ['축소', '기본', '확장'][mobilePanel.snapIndex] ?? '기본'
+            }
+            className="flex-shrink-0 flex items-center justify-center w-full py-2 cursor-row-resize touch-none focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent"
+            {...mobilePanel.handlers}
+          >
+            <span
+              aria-hidden="true"
+              className="block h-1 w-10 rounded-full bg-fg-subtle/40"
+            />
+          </button>
+          <div className="min-h-0 flex-1">{sidePanel}</div>
         </div>
       </div>
 

--- a/lib/hooks/useMobilePanelHeight.ts
+++ b/lib/hooks/useMobilePanelHeight.ts
@@ -1,0 +1,161 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const STORAGE_KEY = 'trip-planner.mobilePanelSnap'
+
+/** 패널 높이 스냅 지점 (vh 단위). 순서대로 축소·기본·확장. */
+export const PANEL_SNAP_POINTS_VH = [25, 40, 80] as const
+const DEFAULT_SNAP_INDEX = 1
+const DRAG_MIN_VH = 15
+const DRAG_MAX_VH = 90
+
+export type PanelSnapIndex = 0 | 1 | 2
+
+interface DragState {
+  pointerId: number
+  startY: number
+  startVh: number
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+function nearestSnapIndex(vh: number): PanelSnapIndex {
+  let best: PanelSnapIndex = 0
+  let bestDist = Infinity
+  PANEL_SNAP_POINTS_VH.forEach((point, i) => {
+    const d = Math.abs(point - vh)
+    if (d < bestDist) {
+      bestDist = d
+      best = i as PanelSnapIndex
+    }
+  })
+  return best
+}
+
+/**
+ * 모바일 하단 패널의 높이(vh)와 드래그 핸들러를 관리한다.
+ *
+ * - 3 개의 스냅 지점 사이를 핀치 없이 드래그/탭으로 이동할 수 있다.
+ * - 드래그 종료 시 가장 가까운 스냅으로 정렬되고, 인덱스가 localStorage 에 저장된다.
+ * - 핸들 단일 탭은 다음 스냅으로 순환 이동한다 (접근성·디스커버러빌리티).
+ */
+export function useMobilePanelHeight() {
+  const [snapIndex, setSnapIndex] = useState<PanelSnapIndex>(DEFAULT_SNAP_INDEX)
+  const [dragVh, setDragVh] = useState<number | null>(null)
+  const dragRef = useRef<DragState | null>(null)
+  const movedRef = useRef(false)
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved == null) return
+    const idx = Number(saved)
+    if (Number.isInteger(idx) && idx >= 0 && idx < PANEL_SNAP_POINTS_VH.length) {
+      setSnapIndex(idx as PanelSnapIndex)
+    }
+  }, [])
+
+  const persistSnap = useCallback((idx: PanelSnapIndex) => {
+    setSnapIndex(idx)
+    try {
+      localStorage.setItem(STORAGE_KEY, String(idx))
+    } catch {
+      // ignore quota / private mode
+    }
+  }, [])
+
+  const currentVh = dragVh ?? PANEL_SNAP_POINTS_VH[snapIndex]
+  const heightStyle = `${currentVh}vh`
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      // 마우스는 좌클릭만, 터치/펜은 모두 허용
+      if (e.pointerType === 'mouse' && e.button !== 0) return
+      e.preventDefault()
+      const startVh = currentVh
+      dragRef.current = { pointerId: e.pointerId, startY: e.clientY, startVh }
+      movedRef.current = false
+      e.currentTarget.setPointerCapture(e.pointerId)
+    },
+    [currentVh],
+  )
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    const drag = dragRef.current
+    if (!drag || drag.pointerId !== e.pointerId) return
+    const deltaPx = drag.startY - e.clientY // 위로 끌면 +
+    const deltaVh = (deltaPx / window.innerHeight) * 100
+    const next = clamp(drag.startVh + deltaVh, DRAG_MIN_VH, DRAG_MAX_VH)
+    if (Math.abs(next - drag.startVh) > 1) movedRef.current = true
+    setDragVh(next)
+  }, [])
+
+  const finishDrag = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      const drag = dragRef.current
+      if (!drag || drag.pointerId !== e.pointerId) return
+      const moved = movedRef.current
+      const finalVh = dragVh ?? drag.startVh
+      dragRef.current = null
+      setDragVh(null)
+      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+        e.currentTarget.releasePointerCapture(e.pointerId)
+      }
+      if (moved) {
+        persistSnap(nearestSnapIndex(finalVh))
+      } else {
+        // 탭 (이동 없음): 다음 스냅으로 순환
+        const next = ((snapIndex + 1) % PANEL_SNAP_POINTS_VH.length) as PanelSnapIndex
+        persistSnap(next)
+      }
+    },
+    [dragVh, persistSnap, snapIndex],
+  )
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLElement>) => {
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        const next = Math.min(
+          PANEL_SNAP_POINTS_VH.length - 1,
+          snapIndex + 1,
+        ) as PanelSnapIndex
+        persistSnap(next)
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        const next = Math.max(0, snapIndex - 1) as PanelSnapIndex
+        persistSnap(next)
+      } else if (e.key === 'Home') {
+        e.preventDefault()
+        persistSnap(0)
+      } else if (e.key === 'End') {
+        e.preventDefault()
+        persistSnap((PANEL_SNAP_POINTS_VH.length - 1) as PanelSnapIndex)
+      } else if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault()
+        const next = ((snapIndex + 1) % PANEL_SNAP_POINTS_VH.length) as PanelSnapIndex
+        persistSnap(next)
+      }
+    },
+    [snapIndex, persistSnap],
+  )
+
+  return {
+    /** 패널에 적용할 height 문자열 (예: "40vh"). 드래그 중에는 실시간 값. */
+    heightStyle,
+    /** 현재 스냅 인덱스 (0=축소, 1=기본, 2=확장). */
+    snapIndex,
+    /** 드래그 중 여부. transition 비활성화 등에 사용. */
+    isDragging: dragVh !== null,
+    /** 드래그 핸들에 바인딩할 포인터/키보드 핸들러. */
+    handlers: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: finishDrag,
+      onPointerCancel: finishDrag,
+      onKeyDown,
+    },
+  }
+}


### PR DESCRIPTION
## 배경

모바일 지도 화면(`/plan`, `/map`) 의 하단 후보·일정 패널 높이가 `40vh` 로 고정되어 있어 다음 두 시나리오에서 답답함이 컸다.

- 후보·일정 목록이 많아 패널을 더 펼쳐 보고 싶을 때
- 지도를 더 넓게 보고 싶어 패널을 임시로 축소하고 싶을 때

## 변경 사항

`components/Plan/PlanScreen.tsx` 의 모바일 분기에 드래그 가능한 핸들을 추가하고, 새 훅 `lib/hooks/useMobilePanelHeight.ts` 가 높이 상태·스냅·영속화를 담당한다.

- **3 단 스냅**: `25vh` (축소) / `40vh` (기본, 기존과 동일) / `80vh` (확장)
- **자유 드래그 후 스냅**: 핸들을 잡고 위·아래로 끌면 실시간으로 높이가 변하고, 손을 떼면 가장 가까운 스냅으로 정렬
- **단일 탭은 순환**: 핸들을 짧게 탭하면 다음 스냅으로 (디스커버러빌리티)
- **localStorage 영속화**: 선택한 스냅 인덱스를 `trip-planner.mobilePanelSnap` 으로 저장 → 세션 간 유지
- **CSS 변수 연동**: 컨테이너에 `--mobile-panel-height` 를 노출 → FAB 위치(`bottom-[calc(var(--mobile-panel-height,40vh)+1rem)]`) 가 패널 높이를 따라 자동으로 이동
- **접근성**: 핸들에 `role="slider"`, `aria-valuemin/max/now/text` 부여, 키보드 ↑/↓/Home/End/Space 로 스냅 이동
- **드래그 중 트랜지션 비활성화**: 드래그 중에는 `transition-[height]` 를 끄고, 스냅 후 다시 200ms 이즈아웃 적용

## 영향 범위

- 모바일(< 768px) 의 `/plan` 과 `/map` 화면만 영향. 데스크탑 사이드 패널은 변경 없음.
- 데이터 모델·API 변경 없음 (UI 전용).

## Test plan

- [ ] 모바일 뷰포트(375px) 에서 `/plan` 진입 시 하단 패널이 기본 높이(40vh) 로 표시
- [ ] 핸들을 잡고 위로 드래그 → 패널이 최대 90vh 까지 확장, 손 떼면 80vh 또는 40vh 로 스냅
- [ ] 핸들을 잡고 아래로 드래그 → 25vh 까지 축소
- [ ] 핸들 단일 탭 → 다음 스냅(예: 40vh → 80vh → 25vh → 40vh) 으로 순환
- [ ] 키보드 포커스 → ↑/↓ 로 스냅 이동, Home/End 로 양 끝
- [ ] 페이지 새로고침 후 직전에 선택한 스냅이 유지되는지 확인
- [ ] FAB 가 패널 높이 변화에 맞춰 항상 패널 위 1rem 에 위치
- [ ] 80vh 로 확장된 상태에서도 후보·일정 리스트가 내부에서 스크롤
- [ ] 데스크탑(≥ 768px) 에서는 드래그 핸들이 보이지 않고 사이드 패널 동작 동일

---
_Generated by [Claude Code](https://claude.ai/code/session_016BSqNbbtaAnNLjgpGTifGD)_