### PR TITLE
fix(nav): 테마 레이블 줄바꿈 방지

### DIFF
--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -97,7 +97,7 @@ export default function Navigation() {
         </ul>
         <div className="border-t border-border pt-3 mt-2 space-y-0.5">
           <div className="px-3 py-2 flex items-center justify-between gap-2">
-            <span className="text-xs text-fg-subtle">테마</span>
+            <span className="text-xs text-fg-subtle whitespace-nowrap">테마</span>
             <ThemeToggle />
           </div>
           <Link


### PR DESCRIPTION
## Summary

- 사이드바가 좁을 때 `테마` 레이블이 두 줄로 깨지는 문제 수정
- `whitespace-nowrap` 추가로 항상 한 줄로 표시되도록 처리

## Changes

- `components/Layout/Navigation.tsx` — `테마` span에 `whitespace-nowrap` 추가