### PR TITLE
refactor(sort): 우선순위·예약상태 정렬 순위 일원화

### DIFF
--- a/components/Map/MapSidePanel.tsx
+++ b/components/Map/MapSidePanel.tsx
@@ -225,7 +225,7 @@ function CandidatesView({
       .sort((a, b) => {
         const oa = TRIP_PRIORITY_META[a.trip_priority]?.order ?? 99
         const ob = TRIP_PRIORITY_META[b.trip_priority]?.order ?? 99
-        if (oa !== ob) return ob - oa
+        if (oa !== ob) return oa - ob
         return a.name.localeCompare(b.name)
       })
   }, [items, categoryFilter, query])

--- a/components/Research/ResearchTable.tsx
+++ b/components/Research/ResearchTable.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { TripItem, TripPriority } from '@/types'
-import { TRIP_PRIORITY_META } from '@/lib/itemOptions'
+import { compareReservationStatus, compareTripPriority } from '@/lib/itemOptions'
 import NameCell from '@/components/Schedule/cells/NameCell'
 import CategoryCell from '@/components/Schedule/cells/CategoryCell'
 import PriorityCell from '@/components/Schedule/cells/PriorityCell'
@@ -26,14 +26,6 @@ interface ResearchTableProps {
   onCreateItem: (item: Omit<TripItem, 'id' | 'created_at' | 'updated_at'>) => void
   onOpenPanel: (id: string) => void
   hasActiveSearch?: boolean
-}
-
-const PRIORITY_ORDER: Record<TripPriority, number> = {
-  '확정': 0,
-  '가고 싶음': 1,
-  '시간 되면': 2,
-  '검토 필요': 3,
-  '제외': 4,
 }
 
 function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
@@ -80,16 +72,20 @@ export default function ResearchTable({
 
   const sortedItems = useMemo(() => {
     return [...items].sort((a, b) => {
+      if (sortKey === 'trip_priority') {
+        const cmp = compareTripPriority(a.trip_priority, b.trip_priority, sortDir)
+        if (cmp !== 0) return cmp
+        return a.name.localeCompare(b.name, 'ko')
+      }
+      if (sortKey === 'reservation_status') {
+        const cmp = compareReservationStatus(a.reservation_status, b.reservation_status, sortDir)
+        if (cmp !== 0) return cmp
+        return a.name.localeCompare(b.name, 'ko')
+      }
       let cmp = 0
       if (sortKey === 'budget') {
         cmp = (a.budget ?? 0) - (b.budget ?? 0)
-      } else if (sortKey === 'reservation_status') {
-        cmp = (a.reservation_status ?? 'zzz').localeCompare(b.reservation_status ?? 'zzz')
-      } else if (sortKey === 'trip_priority') {
-        cmp = (PRIORITY_ORDER[a.trip_priority] ?? 99) - (PRIORITY_ORDER[b.trip_priority] ?? 99)
-        if (cmp === 0) cmp = a.name.localeCompare(b.name, 'ko')
       } else {
-        // name
         cmp = a.name.localeCompare(b.name, 'ko')
       }
       return sortDir === 'asc' ? cmp : -cmp

--- a/lib/itemOptions.ts
+++ b/lib/itemOptions.ts
@@ -75,29 +75,29 @@ interface PriorityMeta {
 }
 
 export const TRIP_PRIORITY_META: Record<TripPriority, PriorityMeta> = {
-  '검토 필요': {
-    description: '아직 결정하지 않은 후보',
+  확정: {
+    description: '일정에 넣기로 결정',
     order: 0,
-    emoji: '🤔',
-    className: 'bg-bg-subtle text-fg-subtle border-border',
-  },
-  '시간 되면': {
-    description: '여유가 있으면 가볼 곳',
-    order: 1,
-    emoji: '⏳',
-    className: 'bg-info-bg text-info-fg border-info-border',
+    emoji: '✅',
+    className: 'bg-success-bg text-success-fg border-success-border font-semibold',
   },
   '가고 싶음': {
     description: '꼭 가고 싶은 곳',
-    order: 2,
+    order: 1,
     emoji: '⭐',
     className: 'bg-accent-subtle text-accent border-accent/30',
   },
-  확정: {
-    description: '일정에 넣기로 결정',
+  '시간 되면': {
+    description: '여유가 있으면 가볼 곳',
+    order: 2,
+    emoji: '⏳',
+    className: 'bg-info-bg text-info-fg border-info-border',
+  },
+  '검토 필요': {
+    description: '아직 결정하지 않은 후보',
     order: 3,
-    emoji: '✅',
-    className: 'bg-success-bg text-success-fg border-success-border font-semibold',
+    emoji: '🤔',
+    className: 'bg-bg-subtle text-fg-subtle border-border',
   },
   제외: {
     description: '이번 여행에서 제외',
@@ -109,31 +109,68 @@ export const TRIP_PRIORITY_META: Record<TripPriority, PriorityMeta> = {
 
 interface ReservationMeta {
   description: string
+  order: number
   emoji: string
   className: string
 }
 
 export const RESERVATION_STATUS_META: Record<ReservationStatus, ReservationMeta> = {
+  예약완료: {
+    description: '예약 완료',
+    order: 0,
+    emoji: '✅',
+    className: 'bg-success-bg text-success-fg border-success-border',
+  },
+  '필요(미예약)': {
+    description: '예약이 필요하지만 아직 안 함',
+    order: 1,
+    emoji: '🔔',
+    className: 'bg-warning-bg text-warning-fg border-warning-border font-semibold',
+  },
   '확인 필요': {
     description: '예약 필요 여부 미확정',
+    order: 2,
     emoji: '🔍',
     className: 'bg-warning-bg text-warning-fg border-warning-border',
   },
   불필요: {
     description: '예약 없이 진행 가능',
+    order: 3,
     emoji: '🆓',
     className: 'bg-bg-subtle text-fg-subtle border-border',
   },
-  '필요(미예약)': {
-    description: '예약이 필요하지만 아직 안 함',
-    emoji: '🔔',
-    className: 'bg-warning-bg text-warning-fg border-warning-border font-semibold',
-  },
-  예약완료: {
-    description: '예약 완료',
-    emoji: '✅',
-    className: 'bg-success-bg text-success-fg border-success-border',
-  },
+}
+
+/**
+ * trip_priority 비교 함수. null/undefined 는 dir 과 무관하게 항상 마지막.
+ * 동순위 tie-break 는 호출자 책임.
+ */
+export function compareTripPriority(
+  a: TripPriority | null | undefined,
+  b: TripPriority | null | undefined,
+  dir: 'asc' | 'desc',
+): number {
+  if (a == null && b == null) return 0
+  if (a == null) return 1
+  if (b == null) return -1
+  const cmp = TRIP_PRIORITY_META[a].order - TRIP_PRIORITY_META[b].order
+  return dir === 'asc' ? cmp : -cmp
+}
+
+/**
+ * reservation_status 비교 함수. null/undefined 는 dir 과 무관하게 항상 마지막.
+ * 동순위 tie-break 는 호출자 책임.
+ */
+export function compareReservationStatus(
+  a: ReservationStatus | null | undefined,
+  b: ReservationStatus | null | undefined,
+  dir: 'asc' | 'desc',
+): number {
+  if (a == null && b == null) return 0
+  if (a == null) return 1
+  if (b == null) return -1
+  const cmp = RESERVATION_STATUS_META[a].order - RESERVATION_STATUS_META[b].order
+  return dir === 'asc' ? cmp : -cmp
 }
 
 const LEGACY_CATEGORY_MAP: Record<string, Category> = {


### PR DESCRIPTION
## Summary
- `trip_priority` 정렬 순위를 단일 소스(`TRIP_PRIORITY_META.order`)로 통일하고 관심도 기준으로 재정의 (`확정 → 가고 싶음 → 시간 되면 → 검토 필요 → 제외`).
- `RESERVATION_STATUS_META`에 `order` 필드를 추가하고 워크플로 의미를 가지는 순서로 정의 (`예약완료 → 필요(미예약) → 확인 필요 → 불필요`). 기존 ResearchTable 의 `localeCompare` 가나다순 정렬을 대체.
- `compareTripPriority`/`compareReservationStatus` 헬퍼를 도입해 **null·undefined 항목은 정렬 방향(asc/desc)과 무관하게 항상 맨 아래** 로 고정.
- `MapSidePanel` 후보 정렬을 ascending 으로 정정 — 기존엔 `제외` 항목이 맨 위로 노출되던 비의도 동작이 있었음.

## 정렬 정책 변경 전/후

**우선순위 (asc)**
- Before(itemOptions): 검토 필요 → 시간 되면 → 가고 싶음 → 확정 → 제외
- Before(ResearchTable 로컬): 확정 → 가고 싶음 → 시간 되면 → 검토 필요 → 제외
- After (통일): **확정 → 가고 싶음 → 시간 되면 → 검토 필요 → 제외**

**예약상태 (asc)**
- Before(ResearchTable): 가나다순 (불필요 → 예약완료 → 필요(미예약) → 확인 필요)
- After: **예약완료 → 필요(미예약) → 확인 필요 → 불필요**

## 변경 파일
- `lib/itemOptions.ts` — META.order 갱신, 헬퍼 비교 함수 추가
- `components/Research/ResearchTable.tsx` — 로컬 `PRIORITY_ORDER` 제거, 헬퍼 사용
- `components/Map/MapSidePanel.tsx` — 정렬 부등호 정정

## Test plan
- [ ] `/research` 우선순위 컬럼 헤더 클릭 → asc 시 `✅ 확정` 부터, desc 시 `❌ 제외` 부터 노출
- [ ] `/research` 예약상태 컬럼 헤더 클릭 → asc 시 `예약완료 → 필요(미예약) → 확인 필요 → 불필요 → (정보 없음)` 순
- [ ] 정보 없음(null) 행이 asc/desc 양방향 모두 맨 아래에 위치
- [ ] 동순위 항목에서 이름 가나다순 tie-break 유지
- [ ] ItemList(모바일/리스트 뷰) 우선순위 정렬 옵션 결과가 새 정책과 일치
- [ ] MapSidePanel 후보 목록 첫 항목이 `확정` 우선순위로 노출