### PR TITLE
feat(auth): RLS + trip_members — 다중 사용자 데이터 모델 (#108)

### DIFF
--- a/app/api/gmaps/import/route.ts
+++ b/app/api/gmaps/import/route.ts
@@ -1,15 +1,9 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { v4 as uuidv4 } from 'uuid'
 import { mapGoogleCategory } from '@/services/gmaps/categoryMap'
 import type { GooglePlace, TripItem } from '@/types'
-
-function getSupabaseClient() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-  if (!url || !key) throw new Error('NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY must be set')
-  return createClient(url, key)
-}
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
+import { ensureActiveTrip } from '@/lib/trip'
 
 function placeToItem(
   place: GooglePlace,
@@ -58,11 +52,15 @@ export async function POST(request: Request) {
       )
     }
 
+    const supabase = createRouteHandlerSupabase()
+    const tripId = await ensureActiveTrip(supabase)
+
     const rows = places.map(p => {
       const override = p.googlePlaceId ? categoryOverrides[p.googlePlaceId] : undefined
       const item = placeToItem(p, override)
       return {
         id: item.id,
+        trip_id: tripId,
         name: item.name,
         category: item.category,
         status: item.trip_priority,
@@ -84,7 +82,6 @@ export async function POST(request: Request) {
       }
     })
 
-    const supabase = getSupabaseClient()
     const { data: insertedRows, error } = await supabase.from('items').insert(rows).select('id')
 
     if (error) {

--- a/app/api/gmaps/preview/route.ts
+++ b/app/api/gmaps/preview/route.ts
@@ -4,6 +4,7 @@ import { fetchListPage, GmapsFetcherError } from '@/services/gmaps/fetcher'
 import { parseListPage, GmapsParserError } from '@/services/gmaps/parser'
 import { matchCandidates } from '@/services/gmaps/matcher'
 import { readItems } from '@/lib/data'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 import type { ImportCandidate } from '@/types'
 import { mapGoogleCategory } from '@/services/gmaps/categoryMap'
 
@@ -33,7 +34,7 @@ export async function POST(request: Request) {
     }
 
     // 4. 기존 items 조회 후 중복/유사 분류
-    const existingItems = await readItems()
+    const existingItems = await readItems(createRouteHandlerSupabase())
     const candidates: ImportCandidate[] = matchCandidates(places, existingItems).map(c => ({
       ...c,
       mappedCategory: c.mappedCategory ?? mapGoogleCategory(c.place.googleCategory),

--- a/app/api/items/[id]/route.ts
+++ b/app/api/items/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { readItems, writeItems } from '@/lib/data'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 import type { Category, TripPriority, ReservationStatus } from '@/types'
 import {
   CATEGORY_OPTIONS,
@@ -86,7 +87,8 @@ function validatePartial(body: Record<string, unknown>): string | null {
 type RouteContext = { params: { id: string } }
 
 export async function GET(_req: NextRequest, { params }: RouteContext) {
-  const items = await readItems()
+  const client = createRouteHandlerSupabase()
+  const items = await readItems(client)
   const item = items.find(i => i.id === params.id)
   if (!item) {
     return NextResponse.json({ error: '항목을 찾을 수 없습니다.' }, { status: 404 })
@@ -95,7 +97,8 @@ export async function GET(_req: NextRequest, { params }: RouteContext) {
 }
 
 export async function PUT(request: NextRequest, { params }: RouteContext) {
-  const items = await readItems()
+  const client = createRouteHandlerSupabase()
+  const items = await readItems(client)
   const idx = items.findIndex(i => i.id === params.id)
   if (idx === -1) {
     return NextResponse.json({ error: '항목을 찾을 수 없습니다.' }, { status: 404 })
@@ -121,20 +124,21 @@ export async function PUT(request: NextRequest, { params }: RouteContext) {
   }
 
   items[idx] = updated
-  await writeItems(items)
+  await writeItems(client, items)
 
   return NextResponse.json({ item: updated })
 }
 
 export async function DELETE(_req: NextRequest, { params }: RouteContext) {
-  const items = await readItems()
+  const client = createRouteHandlerSupabase()
+  const items = await readItems(client)
   const idx = items.findIndex(i => i.id === params.id)
   if (idx === -1) {
     return NextResponse.json({ error: '항목을 찾을 수 없습니다.' }, { status: 404 })
   }
 
   items.splice(idx, 1)
-  await writeItems(items)
+  await writeItems(client, items)
 
   return NextResponse.json({ ok: true })
 }

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { readItems, writeItems } from '@/lib/data'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 import { v4 as uuidv4 } from 'uuid'
 import type { TripItem, Category, TripPriority, Link, ReservationStatus } from '@/types'
 import {
@@ -89,7 +90,8 @@ function validateItem(body: Record<string, unknown>): string | null {
 }
 
 export async function GET() {
-  const items = await readItems()
+  const client = createRouteHandlerSupabase()
+  const items = await readItems(client)
   return NextResponse.json({ items })
 }
 
@@ -121,9 +123,10 @@ export async function POST(request: NextRequest) {
   if (body.time_start !== undefined) item.time_start = body.time_start as string
   if (body.time_end !== undefined && body.time_end !== null) item.time_end = body.time_end as string
 
-  const items = await readItems()
+  const client = createRouteHandlerSupabase()
+  const items = await readItems(client)
   items.push(item)
-  await writeItems(items)
+  await writeItems(client, items)
 
   return NextResponse.json({ item }, { status: 201 })
 }

--- a/app/items/[id]/edit/page.tsx
+++ b/app/items/[id]/edit/page.tsx
@@ -1,11 +1,12 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { readItems } from '@/lib/data'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 import Navigation from '@/components/Layout/Navigation'
 import ItemForm from '@/components/Items/ItemForm'
 
 export default async function EditItemPage({ params }: { params: { id: string } }) {
-  const items = await readItems()
+  const items = await readItems(createRouteHandlerSupabase())
   const item = items.find(i => i.id === params.id)
 
   if (!item) notFound()

--- a/app/items/[id]/page.tsx
+++ b/app/items/[id]/page.tsx
@@ -1,12 +1,13 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { readItems } from '@/lib/data'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 import Navigation from '@/components/Layout/Navigation'
 import ItemMetadataChips from '@/components/UI/ItemMetadataChips'
 import type { TripItem } from '@/types'
 
 export default async function ItemDetailPage({ params }: { params: { id: string } }) {
-  const items = await readItems()
+  const items = await readItems(createRouteHandlerSupabase())
   const item = items.find(i => i.id === params.id)
 
   if (!item) notFound()

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import type { TripItem } from '@/types'
 import {
   normalizeTripPriority,
@@ -6,59 +6,57 @@ import {
   normalizeTripItem,
   normalizeCategory,
 } from '@/lib/itemOptions'
+import { ensureActiveTrip } from '@/lib/trip'
 
-function getSupabaseClient() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const key = process.env.SUPABASE_SERVICE_KEY
-  if (!url || !key) {
-    throw new Error('NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_KEY must be set')
-  }
-  return createClient(url, key)
-}
+type Client = SupabaseClient
 
-export async function readItems(): Promise<TripItem[]> {
-  const supabase = getSupabaseClient()
-  const { data, error } = await supabase
+export async function readItems(client: Client): Promise<TripItem[]> {
+  const tripId = await ensureActiveTrip(client)
+  const { data, error } = await client
     .from('items')
     .select('*')
+    .eq('trip_id', tripId)
     .order('created_at', { ascending: true })
   if (error) throw error
   const normalized = (data ?? []).map(rowToItem).map(normalizeTripItem)
   const items = normalized.map(entry => entry.item)
   if (normalized.some(entry => entry.changed)) {
-    await writeItems(items)
+    await writeItems(client, items)
   }
   return items
 }
 
-export async function writeItems(items: TripItem[]): Promise<void> {
+export async function writeItems(client: Client, items: TripItem[]): Promise<void> {
   items.forEach(validateItem)
-  const supabase = getSupabaseClient()
+  const tripId = await ensureActiveTrip(client)
 
-  const { data: existing, error: fetchError } = await supabase.from('items').select('id')
+  const { data: existing, error: fetchError } = await client
+    .from('items')
+    .select('id')
+    .eq('trip_id', tripId)
   if (fetchError) throw fetchError
 
   const existingIds = new Set((existing ?? []).map((r: { id: string }) => r.id))
   const incomingIds = new Set(items.map(i => i.id))
 
   const toDelete = Array.from(existingIds).filter(id => !incomingIds.has(id))
-  const toUpsert = items.map(itemToRow)
+  const toUpsert = items.map(item => itemToRow(item, tripId))
 
   if (toDelete.length > 0) {
-    const { error } = await supabase.from('items').delete().in('id', toDelete)
+    const { error } = await client
+      .from('items')
+      .delete()
+      .eq('trip_id', tripId)
+      .in('id', toDelete)
     if (error) throw error
   }
 
   if (toUpsert.length > 0) {
-    const { error } = await supabase.from('items').upsert(toUpsert)
+    const { error } = await client.from('items').upsert(toUpsert)
     if (error) throw error
   }
 }
 
-// DB row → TripItem
-// DB의 status 컬럼에 trip_priority 값이 저장된다.
-// DB의 priority 컬럼은 deprecated (null로 유지).
-// 구 status/priority 값이 있는 경우 normalizeTripPriority가 마이그레이션 처리.
 function rowToItem(row: Record<string, unknown>): TripItem {
   return {
     id: row.id as string,
@@ -88,12 +86,10 @@ function validateItem(item: TripItem): void {
   }
 }
 
-// TripItem → DB row
-// trip_priority는 DB의 status 컬럼에 저장한다.
-// priority 컬럼은 null로 저장 (deprecated).
-function itemToRow(item: TripItem): Record<string, unknown> {
+function itemToRow(item: TripItem, tripId: string): Record<string, unknown> {
   return {
     id: item.id,
+    trip_id: tripId,
     name: item.name,
     category: item.category,
     status: item.trip_priority,

--- a/lib/trip.ts
+++ b/lib/trip.ts
@@ -1,0 +1,55 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type TripRole = 'owner' | 'editor' | 'viewer'
+
+export type TripSupabaseClient = SupabaseClient
+
+export async function getActiveTripId(client: TripSupabaseClient): Promise<string | null> {
+  const { data, error } = await client
+    .from('trip_members')
+    .select('trip_id, role, invited_at')
+    .order('role', { ascending: true }) // 'owner' < 'editor' < 'viewer' (사전순)
+    .order('invited_at', { ascending: true })
+    .limit(1)
+  if (error) throw error
+  if (!data || data.length === 0) return null
+  return data[0].trip_id as string
+}
+
+export async function ensureActiveTrip(client: TripSupabaseClient): Promise<string> {
+  const existing = await getActiveTripId(client)
+  if (existing) return existing
+
+  const { data: userData, error: userErr } = await client.auth.getUser()
+  if (userErr) throw userErr
+  const userId = userData.user?.id
+  if (!userId) throw new Error('로그인된 사용자가 없습니다.')
+
+  const { data: trip, error: tripErr } = await client
+    .from('trips')
+    .insert({ owner_user_id: userId, title: '내 여행' })
+    .select('id')
+    .single()
+  if (tripErr) throw tripErr
+  const tripId = trip.id as string
+
+  const { error: memberErr } = await client
+    .from('trip_members')
+    .insert({ trip_id: tripId, user_id: userId, role: 'owner' })
+  if (memberErr) throw memberErr
+
+  return tripId
+}
+
+export async function getUserRole(
+  client: TripSupabaseClient,
+  tripId: string,
+): Promise<TripRole | null> {
+  const { data, error } = await client
+    .from('trip_members')
+    .select('role')
+    .eq('trip_id', tripId)
+    .maybeSingle()
+  if (error) throw error
+  return (data?.role as TripRole | undefined) ?? null
+}

--- a/specs/108-rls-trip-members/checklists/requirements.md
+++ b/specs/108-rls-trip-members/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: RLS + trip_members
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+  - Note: "RLS", "auth.uid()", "Supabase Auth" 가 등장하지만 본 기능의 본질이 "DB 레벨 권한 강제"이므로 도메인 용어로 허용.
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders (with minimal unavoidable DB terminology)
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded (Out of Scope 명시)
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows (마이그레이션 / 격리 / 신규 가입자)
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification (필수 도메인 용어 외)
+
+## Notes
+
+- 사용자가 단일 사용자/단일 trip 환경임을 확인했으므로 마이그레이션 owner 결정에 모호함 없음.
+- RLS·auth.uid() 는 본 기능의 핵심 메커니즘이므로 기술 용어 사용을 허용함.

--- a/specs/108-rls-trip-members/data-model.md
+++ b/specs/108-rls-trip-members/data-model.md
@@ -1,0 +1,89 @@
+# Data Model — RLS + trip_members
+
+## Tables
+
+### `trips`
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|---|---|---|---|
+| `id` | `uuid` | PK, default `gen_random_uuid()` | trip 식별자 |
+| `owner_user_id` | `uuid` | NOT NULL, FK `auth.users(id) ON DELETE CASCADE` | trip 의 owner. 빠른 RLS 평가용 보조 컬럼. |
+| `title` | `text` | NOT NULL, default `'내 여행'` | trip 제목 |
+| `created_at` | `timestamptz` | NOT NULL, default `now()` | 생성 시각 |
+| `updated_at` | `timestamptz` | NOT NULL, default `now()` | 마지막 수정 시각 |
+
+Indexes: `idx_trips_owner` on `owner_user_id`.
+
+### `trip_members`
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|---|---|---|---|
+| `trip_id` | `uuid` | NOT NULL, FK `trips(id) ON DELETE CASCADE` | 소속 trip |
+| `user_id` | `uuid` | NOT NULL, FK `auth.users(id) ON DELETE CASCADE` | 멤버 |
+| `role` | `text` | NOT NULL, CHECK `in ('owner','editor','viewer')` | 역할 |
+| `invited_at` | `timestamptz` | NOT NULL, default `now()` | 초대(=레코드 생성) 시각 |
+
+PK: `(trip_id, user_id)`. Indexes: `idx_trip_members_user` on `user_id`.
+
+### `items` (기존 + 추가)
+
+추가 컬럼:
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|---|---|---|---|
+| `trip_id` | `uuid` | NOT NULL, FK `trips(id) ON DELETE CASCADE` | 소속 trip |
+
+Indexes: `idx_items_trip` on `trip_id`.
+
+기존 모든 컬럼은 그대로 유지.
+
+## Helper Functions
+
+### `public.is_trip_member(p_trip_id uuid) returns boolean`
+
+`SECURITY DEFINER`, `STABLE`. `trip_members` 에 `(p_trip_id, auth.uid())` 가 존재하는지 반환. RLS 재귀 회피용.
+
+### `public.user_role_in_trip(p_trip_id uuid) returns text`
+
+`SECURITY DEFINER`, `STABLE`. 현 사용자의 해당 trip 에서 역할을 반환. 멤버가 아니면 `null`.
+
+권한:
+- 함수는 `public` 스키마에 생성.
+- `grant execute ... to authenticated` (anon 에는 grant 하지 않는다).
+
+## RLS 정책 매트릭스
+
+| 테이블 | 작업 | USING / WITH CHECK |
+|---|---|---|
+| trips | SELECT | `is_trip_member(id)` |
+| trips | INSERT | with check: `owner_user_id = auth.uid()` |
+| trips | UPDATE | `owner_user_id = auth.uid()` (using + with check) |
+| trips | DELETE | `owner_user_id = auth.uid()` |
+| trip_members | SELECT | `is_trip_member(trip_id)` |
+| trip_members | INSERT | with check: `user_role_in_trip(trip_id) = 'owner'` 또는 `(select owner_user_id from trips where id = trip_id) = auth.uid()` (생성 직후 owner 자기 자신 INSERT 케이스 처리) |
+| trip_members | UPDATE | `user_role_in_trip(trip_id) = 'owner'` |
+| trip_members | DELETE | `user_role_in_trip(trip_id) = 'owner'` |
+| items | SELECT | `user_role_in_trip(trip_id) is not null` |
+| items | INSERT | with check: `user_role_in_trip(trip_id) in ('owner','editor')` |
+| items | UPDATE | `user_role_in_trip(trip_id) in ('owner','editor')` |
+| items | DELETE | `user_role_in_trip(trip_id) in ('owner','editor')` |
+
+## Bootstrap Edge Case — owner 자기 자신 INSERT
+
+`trips` 생성 직후 같은 트랜잭션에서 `trip_members(trip_id, owner, 'owner')` INSERT 가 필요하다. 이 시점에는 아직 멤버십이 없어 `user_role_in_trip(trip_id) = 'owner'` 가 거짓이 된다.
+
+**해결**: trip_members INSERT 정책의 with check 를 다음 OR 로 구성한다.
+
+```sql
+(
+  user_role_in_trip(trip_id) = 'owner'
+  or
+  (select owner_user_id from public.trips where id = trip_id) = auth.uid()
+)
+```
+
+`trips.owner_user_id` 는 RLS 정책 평가 시 동일 사용자 본인이 만든 행이므로 SELECT 가 가능하다. 두 번째 분기로 부트스트랩이 가능.
+
+## State Transitions
+
+본 스펙에는 상태 머신이 없다. 역할 변경/탈퇴 UX 는 후속 이슈에서 다룬다.

--- a/specs/108-rls-trip-members/plan.md
+++ b/specs/108-rls-trip-members/plan.md
@@ -1,0 +1,189 @@
+# Implementation Plan: RLS + trip_members
+
+**Branch**: `issue/108-rls-trip-members` | **Date**: 2026-05-19 | **Spec**: [spec.md](./spec.md)
+**Issue**: [#108](https://github.com/Useful-Dogus/trip-planner/issues/108)
+
+## Summary
+
+`trips`, `trip_members` 테이블을 도입하고 `items.trip_id` 를 추가해 다중 사용자 데이터 모델로 전환한다. 권한 강제는 애플리케이션이 아닌 DB(RLS) 가 담당한다. 기존 단일 사용자(chanhee13p@gmail.com)의 모든 items 는 일회성 마이그레이션 SQL 로 "내 여행" trip 한 개로 묶고 그 사용자를 owner 로 지정한다. RLS 가 실제로 평가되도록 `lib/data.ts` 의 자격증명을 service_role 키에서 사용자 세션 기반 anon 클라이언트로 전환한다.
+
+## Technical Context
+
+- **Language/Version**: TypeScript 5.x, Node.js 18+
+- **Primary Dependencies**: Next.js 14 (App Router), React 18, `@supabase/supabase-js` ^2.100, `@supabase/ssr`
+- **Storage**: Supabase PostgreSQL (project ID `onzkrbyokomdpjtuvbcy`)
+- **Testing**: 본 작업은 자동화 테스트 없음. 수동 검증(quickstart.md).
+- **Target Platform**: Vercel (Next.js Edge/Node)
+- **Project Type**: Web application (단일 Next.js 앱)
+- **Scale/Scope**: 단일 사용자/단일 trip 환경. 멀티 trip UX(#112)는 후속.
+
+## Constitution Check
+
+- **단일 Next.js + Supabase 네이티브 원칙(#121 결정)**: ✅ 유지. 추가 인프라 도입 없음.
+- **얇은 어댑터 레이어**: ✅ `lib/data.ts`, `lib/trip.ts` 에 격리. RLS 정책은 `supabase/schema.sql` 단일 파일에 집중.
+- **벤더 이전성**: ✅ RLS + 표준 Postgres 기능만 사용. SECURITY DEFINER 함수 1-2개는 일반 PostgreSQL.
+
+## Project Structure
+
+```text
+supabase/
+├── schema.sql                            # 신규 테이블/RLS/헬퍼 함수 전체 정의 (수정)
+└── migration_108_rls_trip_members.sql    # 운영 DB 적용용 일회성 마이그레이션 (신규)
+
+lib/
+├── data.ts          # service_role → 사용자 세션 클라이언트로 전환
+├── trip.ts          # 신규: ensureActiveTrip / getActiveTripId / getUserRole
+└── supabase-server.ts  # 이미 존재. 재사용.
+
+app/
+├── api/items/route.ts            # 호출부 갱신
+├── api/items/[id]/route.ts       # 호출부 갱신
+├── api/gmaps/preview/route.ts    # 호출부 갱신
+├── api/gmaps/import/route.ts     # 호출부 갱신
+├── items/[id]/page.tsx           # 호출부 갱신 (서버 컴포넌트)
+└── items/[id]/edit/page.tsx      # 호출부 갱신 (서버 컴포넌트)
+```
+
+## Phase 0 — Research
+
+### R1. RLS 무한 재귀 회피
+
+`trip_members` 의 RLS 정책이 "같은 trip 의 멤버" 를 확인하려고 `trip_members` 자체에 SELECT 를 거는 순간 무한 재귀에 빠진다. 검색해보면 표준 해결책은 `SECURITY DEFINER` 함수로 우회하는 것.
+
+**Decision**: 다음 두 헬퍼 함수를 `public` 스키마에 `SECURITY DEFINER` 로 만든다.
+
+```sql
+-- 현 사용자가 해당 trip 의 멤버인가
+create function public.is_trip_member(p_trip_id uuid) returns boolean
+  language sql security definer stable
+  as $$ select exists(select 1 from public.trip_members where trip_id = p_trip_id and user_id = auth.uid()) $$;
+
+-- 현 사용자의 해당 trip 에서의 역할 ('owner' | 'editor' | 'viewer' | null)
+create function public.user_role_in_trip(p_trip_id uuid) returns text
+  language sql security definer stable
+  as $$ select role from public.trip_members where trip_id = p_trip_id and user_id = auth.uid() $$;
+```
+
+이 함수들은 정의자 권한으로 실행되어 RLS 를 우회한다. 호출 입력은 `auth.uid()` 만 사용해 인젝션 위험 없음.
+
+**Rationale**: SQL 내장 재귀 회피의 정석. supabase 공식 문서가 권장하는 패턴.
+
+**Alternatives**: trips.owner_user_id 컬럼만 사용하는 단순 정책 (owner-only 모델) — viewer/editor 표현 불가, 향후 #110/#113 에서 깨짐.
+
+### R2. 신규 사용자의 기본 trip 생성 시점
+
+**Decision**: 앱 레벨 lazy 생성. `lib/trip.ts/ensureActiveTrip()` 가 서버 요청 진입 시 호출되어 멤버십 0개면 "내 여행" 1개를 생성.
+
+**Rationale**: DB 트리거는 (1) 마이그레이션 이전성이 떨어지고 (2) 디버깅이 어려우며 (3) 첫 로그인 콜백을 굳이 트리거에 묶을 이유가 없다.
+
+**Alternatives**: `auth.users` AFTER INSERT 트리거 — 위 단점.
+
+### R3. lib/data.ts 의 클라이언트 전환
+
+현재 `getSupabaseClient()` 가 `SUPABASE_SERVICE_KEY` 로 익명 service-role 클라이언트를 매 호출마다 생성. RLS 우회.
+
+**Decision**:
+- 라우트 핸들러: 기존 `createRouteHandlerSupabase()` (lib/supabase-server.ts) 사용 — 쿠키 기반 사용자 세션.
+- 서버 컴포넌트: 동일 SSR 패턴 사용. `cookies()` 가 RSC 에서 read-only 라 set 은 swallow.
+- `lib/data.ts` 의 `readItems()`, `writeItems()` 등 모든 함수가 **클라이언트를 인자로 받는** 시그니처로 바꾼다. 자동 스코프는 함수 내부에서 `getActiveTripId(client)` 로 결정.
+
+```ts
+// 새 시그니처
+export async function readItems(client: SupabaseServerClient): Promise<TripItem[]>
+export async function writeItems(client: SupabaseServerClient, items: TripItem[]): Promise<void>
+export async function getItem(client: SupabaseServerClient, id: string): Promise<TripItem | null>
+```
+
+호출부는 자기 컨텍스트(RouteHandler vs ServerComponent)에 맞는 클라이언트를 만들어 전달.
+
+**Rationale**: 클라이언트를 함수 내부에서 만들면 컨텍스트(쿠키 store 접근 모드)를 자동 추론할 수 없다. 명시 인자로 받는 게 깔끔.
+
+**Alternatives**: `lib/data.ts` 안에서 자동 추론 — `next/headers/cookies()` 가 RSC 와 라우트 핸들러 모두에서 동작하긴 함. 다만 명시적 의존성이 가독성에 유리.
+
+### R4. 마이그레이션 owner 식별
+
+**Decision**: 마이그레이션 SQL 내에서 `(select id from auth.users where email = 'chanhee13p@gmail.com')` 로 동적 조회. NOT FOUND 면 `RAISE EXCEPTION` 으로 트랜잭션 롤백.
+
+**Rationale**: SQL 파일에 user UUID 를 하드코딩하면 호스트 이전 시 깨진다. 이메일은 자연 식별자.
+
+**Alternatives**: env var 로 UUID 주입 — SQL 파일 재사용성 떨어짐.
+
+### R5. items.trip_id 추가 순서
+
+**Decision**: 단일 트랜잭션 내에서
+1. `trips`, `trip_members` 생성
+2. owner 트립 1건 INSERT, owner 멤버십 1건 INSERT
+3. `items.trip_id` nullable 컬럼 추가
+4. 모든 기존 items 의 trip_id 를 1번 트립으로 UPDATE
+5. `items.trip_id` NOT NULL + FK ON DELETE CASCADE 설정
+
+**Rationale**: 한 트랜잭션이면 부분 실패가 없다. items 가 N=수십~수백 단위라 LOCK 시간 무시 가능.
+
+## Phase 1 — Design
+
+### Data Model
+
+[`data-model.md`](./data-model.md) 참조.
+
+요약:
+- `trips(id uuid pk, owner_user_id uuid not null fk auth.users, title text, created_at, updated_at)`
+- `trip_members(trip_id uuid fk trips on delete cascade, user_id uuid fk auth.users, role text check in ('owner','editor','viewer'), invited_at, primary key (trip_id, user_id))`
+- `items.trip_id uuid not null fk trips on delete cascade` (신규 컬럼)
+
+### RLS 정책
+
+- **trips**
+  - SELECT: `is_trip_member(id)` 또는 `owner_user_id = auth.uid()`
+  - INSERT: `owner_user_id = auth.uid()` (with check)
+  - UPDATE: `owner_user_id = auth.uid()`
+  - DELETE: `owner_user_id = auth.uid()`
+
+- **trip_members**
+  - SELECT: `is_trip_member(trip_id)`
+  - INSERT/UPDATE/DELETE: 해당 trip 의 owner. `user_role_in_trip(trip_id) = 'owner'`
+
+- **items**
+  - SELECT: `user_role_in_trip(trip_id) is not null` (viewer 이상)
+  - INSERT: `user_role_in_trip(trip_id) in ('owner','editor')` (with check)
+  - UPDATE: `user_role_in_trip(trip_id) in ('owner','editor')`
+  - DELETE: `user_role_in_trip(trip_id) in ('owner','editor')`
+
+### Application Contracts
+
+`lib/trip.ts` 신규 API:
+
+```ts
+export async function getActiveTripId(client: SupabaseServerClient): Promise<string | null>
+export async function ensureActiveTrip(client: SupabaseServerClient): Promise<string>
+export async function getUserRole(client: SupabaseServerClient, tripId: string): Promise<TripRole | null>
+export type TripRole = 'owner' | 'editor' | 'viewer'
+```
+
+`lib/data.ts` 변경:
+- `getSupabaseClient()` 삭제
+- 모든 export 함수가 `client` 를 첫 인자로 받음
+- `readItems/writeItems/getItem/upsertItem/deleteItem` 내부에서 `ensureActiveTrip(client)` 호출해 활성 trip 으로 자동 스코프
+
+## Phase 2 — Implementation Order (commits)
+
+1. **DB 스키마 + RLS**: `supabase/schema.sql` 갱신, `supabase/migration_108_rls_trip_members.sql` 생성.
+2. **lib/trip.ts**: 활성 trip 헬퍼.
+3. **lib/data.ts 리팩터**: 사용자 세션 클라이언트 전환 + trip 자동 스코프.
+4. **호출부 갱신**: 7개 파일에서 client 주입.
+5. **수동 검증**: quickstart.md 시나리오.
+
+## Risks & Mitigations
+
+| 리스크 | 영향 | 완화 |
+|---|---|---|
+| RLS 정책 오류로 본인 데이터도 안 보임 | 운영 장애 | 마이그레이션 직후 quickstart.md 시나리오 1 즉시 실행 |
+| `service_role` 사용 누락된 곳이 안 보임 | 권한 우회 | grep `SUPABASE_SERVICE_KEY` 로 잔존 확인 |
+| 서버 컴포넌트에서 `cookies()` 가 read-only 라 세션 갱신 못함 | 토큰 만료 시 401 | middleware.ts 가 이미 갱신 담당, RSC 는 read 만 |
+| `auth.users` 에 chanhee13p@gmail.com 이 없는 환경에서 마이그레이션 실행 | 트랜잭션 롤백 | RAISE EXCEPTION 으로 보호. 데이터 변경 없음. |
+
+## Out of Scope
+
+- 멤버 초대/수락 UX (#112 후속)
+- 멀티 trip 전환 UI (#112)
+- 공유 토큰 / 익명 접근 (#110)
+- 권한 변경 UI / 역할 승격

--- a/specs/108-rls-trip-members/quickstart.md
+++ b/specs/108-rls-trip-members/quickstart.md
@@ -1,0 +1,82 @@
+# Quickstart — RLS + trip_members 적용/검증
+
+## 사전 조건
+
+- Supabase 프로젝트 `onzkrbyokomdpjtuvbcy` 가 active 상태
+- `auth.users` 에 `chanhee13p@gmail.com` 엔트리 존재 (#107 에서 가입 완료)
+- 로컬 `npm run dev` 가 동작
+
+## 1. 마이그레이션 적용 (운영 DB)
+
+1. Supabase 대시보드 → SQL Editor 열기
+2. `supabase/migration_108_rls_trip_members.sql` 전체 복사 → 실행
+3. 결과 확인:
+   ```sql
+   select count(*) from trips;          -- 1
+   select count(*) from trip_members;   -- 1
+   select count(*) from items where trip_id is null;  -- 0
+   ```
+
+마이그레이션 실패 시 (예: `auth.users` 에 이메일 없음) 트랜잭션이 롤백되어 데이터 변경 없음.
+
+## 2. 앱 동작 확인 (P1: 마이그레이션 회귀 없음)
+
+1. `npm run dev` 시작
+2. `chanhee13p@gmail.com` 으로 로그인
+3. 메인 화면에서 items 목록이 마이그레이션 전과 동일하게 보임을 확인
+4. 새 item 추가 → 정상 저장 → 새로고침 후에도 보임
+
+## 3. 격리 검증 (P1: 다른 사용자는 못 봄)
+
+SQL Editor 에서 시뮬레이션:
+
+```sql
+-- 다른 사용자 id 로 RLS 평가
+set local role authenticated;
+set local "request.jwt.claims" = '{"sub":"00000000-0000-0000-0000-000000000000","role":"authenticated"}';
+
+select count(*) from items;           -- 0 이어야 함
+select count(*) from trips;           -- 0 이어야 함
+select count(*) from trip_members;    -- 0 이어야 함
+```
+
+또는 두 번째 테스트 계정 가입 후 로그인해서 items 목록이 비어있는지 확인.
+
+## 4. 권한 강제 검증 (P1: 쓰기 거부)
+
+위 시뮬레이션 컨텍스트에서:
+
+```sql
+insert into items (id, name, category, status, trip_id, created_at, updated_at)
+  values ('test', 'test', '기타', '검토 필요',
+          (select id from trips limit 1),  -- chanhee13p 의 trip
+          now()::text, now()::text);
+-- → "new row violates row-level security policy" 에러
+```
+
+## 5. 신규 사용자 흐름 (P2)
+
+1. 새 이메일로 가입 (`/signup`)
+2. 인증 후 메인 화면 진입
+3. 자동으로 빈 trip "내 여행" 이 생성되어 빈 items 목록이 보임
+4. item 1개 추가 → 정상
+
+## 6. 롤백 계획
+
+문제 발생 시:
+
+```sql
+begin;
+alter table items drop column trip_id;
+drop policy if exists ... on items;
+drop policy if exists ... on trip_members;
+drop policy if exists ... on trips;
+drop table if exists trip_members;
+drop table if exists trips;
+drop function if exists user_role_in_trip;
+drop function if exists is_trip_member;
+alter table items enable row level security; -- 기존 상태로
+commit;
+```
+
+그 후 `lib/data.ts` 변경을 git revert 하고 `SUPABASE_SERVICE_KEY` 환경변수 확인.

--- a/specs/108-rls-trip-members/spec.md
+++ b/specs/108-rls-trip-members/spec.md
@@ -1,0 +1,114 @@
+# Feature Specification: RLS + trip_members — 다중 사용자 데이터 모델
+
+**Feature Branch**: `issue/108-rls-trip-members`
+**Created**: 2026-05-19
+**Status**: Draft
+**Input**: GitHub Issue #108 — [auth] RLS + trip_members — 다중 사용자 데이터 모델
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 기존 사용자가 마이그레이션 후에도 자신의 데이터를 그대로 본다 (Priority: P1)
+
+#107 으로 로그인 기능이 도입되었지만 현재 데이터는 사용자/여행 구분 없이 단일 풀에 들어있다. 다중 사용자 모델로 전환할 때 기존 단일 사용자(chanhee13p@gmail.com)의 모든 items 는 하나의 "내 여행" trip 으로 묶여 동일하게 보여야 한다.
+
+**Why this priority**: 데이터 손실/오인 노출은 신뢰를 즉시 깬다. 마이그레이션 회귀가 없어야 후속 Phase 가 의미를 가진다.
+
+**Independent Test**: 마이그레이션 SQL 실행 전후로 메인 화면 items 목록이 항목 수·내용 모두 동일하다는 것을 확인할 수 있다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 마이그레이션 전 N 개의 items 가 있고, **When** 마이그레이션 SQL 을 적용한 뒤 chanhee13p@gmail.com 으로 로그인하면, **Then** 동일한 N 개의 items 가 동일 순서로 보인다.
+2. **Given** 마이그레이션이 적용된 상태에서, **When** 사용자가 새 item 을 생성하면, **Then** 그 item 은 자동으로 "내 여행" trip 에 속한다.
+
+---
+
+### User Story 2 - 다른 사용자는 내 여행의 데이터를 볼 수 없다 (Priority: P1)
+
+다중 사용자 전환의 핵심은 격리다. 다른 계정으로 로그인한 사용자는 내 trip 의 items / trip 자체 / 멤버 목록을 모두 조회할 수 없어야 한다. 권한 체크는 애플리케이션이 아니라 DB(RLS)에서 강제된다.
+
+**Why this priority**: 격리 실패 = 보안 사고. 이 시점에 다른 모든 작업이 의미를 잃는다.
+
+**Independent Test**: 두 번째 테스트 계정으로 가입·로그인하고 첫 사용자의 trip / items / trip_members 를 직접 쿼리하면 빈 결과만 반환된다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 사용자 A 가 trip T 의 owner 이고, **When** 사용자 B 가 로그인해 items / trips / trip_members 를 조회하면, **Then** 결과에 T 와 T 의 items 는 포함되지 않는다.
+2. **Given** 사용자 B 가 trip T 의 ID 를 알고 직접 명시해 조회를 시도해도, **When** B 가 T 의 멤버가 아니면, **Then** B 의 조회는 빈 결과를 반환한다.
+3. **Given** 사용자 B 가 T 의 items 에 INSERT/UPDATE/DELETE 를 시도하면, **When** B 가 T 의 editor 이상 멤버가 아니면, **Then** DB 가 거부한다.
+
+---
+
+### User Story 3 - 새 가입자는 첫 로그인 시 빈 trip 을 갖는다 (Priority: P2)
+
+신규 가입한 사용자가 앱에 진입했을 때 "여행이 하나도 없어 아무것도 할 수 없는 상태" 가 되지 않도록, 첫 진입 시 기본 trip 1 개와 owner 멤버십이 자동 생성된다.
+
+**Why this priority**: 멀티-trip UX(#112) 가 도착하기 전까지의 단일-trip 사용성을 유지한다. P1 격리/마이그레이션이 깨지지 않는 한 후순위.
+
+**Independent Test**: 신규 계정으로 가입 후 첫 화면에서 빈 items 리스트가 보이고, 항목 추가가 정상 동작한다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 신규 가입자가 처음 로그인하면, **When** 메인 화면이 로드되면, **Then** 자동 생성된 기본 trip 이 활성화되어 있고 owner 멤버십이 존재한다.
+2. **Given** 신규 가입자가 첫 item 을 추가하면, **When** 저장이 완료되면, **Then** item 은 자신의 기본 trip 에 속한다.
+
+---
+
+### Edge Cases
+
+- 마이그레이션 시 chanhee13p@gmail.com 의 auth.users 엔트리가 아직 없는 환경(예: 새 Postgres 호스트로 이전)이라면 마이그레이션 스크립트는 **owner 후보가 없음을 보고하고 멈춰야** 한다. 임의 user 에 귀속시키지 않는다.
+- 비로그인 상태에서 데이터 API 를 호출하면 RLS 가 빈 결과를 반환하고, 앱은 로그인 화면으로 유도한다(이미 #107 미들웨어가 처리).
+- 한 사용자가 동시에 두 탭에서 다른 trip 으로 활성화를 시도하면, 마지막 활성화가 우선한다(서버 상태 기준).
+- viewer 권한 멤버가 items 를 수정/삭제 시도하면 DB 가 거부하고, 클라이언트는 권한 오류를 사용자 친화적 메시지로 표시한다.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST 모든 item 을 정확히 하나의 trip 에 귀속시킨다. trip_id 없는 item 은 존재할 수 없다.
+- **FR-002**: System MUST 각 trip 에 대해 멤버십 레코드를 owner / editor / viewer 역할로 표현한다.
+- **FR-003**: System MUST trip 에 속하지 않은 사용자가 그 trip 또는 trip 의 items / 멤버 목록을 읽지 못하도록 DB 레벨에서 강제한다.
+- **FR-004**: System MUST editor 이상의 권한을 가진 멤버만 해당 trip 의 items 를 생성/수정/삭제할 수 있도록 DB 레벨에서 강제한다.
+- **FR-005**: System MUST owner 만 trip 자체의 수정/삭제 및 멤버십 추가/수정/삭제를 할 수 있도록 DB 레벨에서 강제한다.
+- **FR-006**: System MUST 새로 가입한 사용자가 첫 진입 시 자동으로 1 개의 기본 trip 과 그 trip 의 owner 멤버십을 갖도록 한다.
+- **FR-007**: System MUST 기존 단일 사용자(chanhee13p@gmail.com)의 모든 items 를 단일 trip "내 여행" 으로 묶고 그 사용자를 owner 로 지정하는 일회성 마이그레이션을 제공한다.
+- **FR-008**: System MUST 애플리케이션 호출부가 명시적인 trip 식별 없이도 "현재 활성 trip" 의 items 에만 접근하도록 한다(편의 계층). 단, 권한 강제는 식별 계층이 아닌 DB 의 책임이다.
+- **FR-009**: System MUST 데이터 쿼리에 사용하는 자격증명을 사용자 세션 기반으로 바꿔, DB 의 RLS 가 실제로 평가되도록 한다. 권한 우회 자격증명(예: 서비스 키)으로 일반 CRUD 를 수행하지 않는다.
+- **FR-010**: System MUST `chanhee13p@gmail.com` 의 사용자 식별자를 마이그레이션 시점에 자동 조회해 사용한다. 식별자가 발견되지 않으면 마이그레이션은 실패하고 데이터는 변경되지 않은 상태로 남는다.
+
+### Non-Functional Requirements
+
+- **NFR-001**: RLS 정책 정의는 단일 SQL 파일(`supabase/schema.sql`) 에 명시되어, 다른 Postgres 호스트에서도 동일하게 적용 가능해야 한다.
+- **NFR-002**: 마이그레이션은 멱등하지 않아도 되지만(일회성), 부분 실패 시 데이터를 손상시키지 않는 트랜잭션 단위로 작성한다.
+- **NFR-003**: 기존 호출부 변경은 호출 시그니처가 가능하면 그대로 유지되도록 한다. 명시적 trip_id 인자가 새로 강제되면 모든 호출부를 수정해야 하므로 회귀 위험이 커진다.
+
+### Key Entities
+
+- **Trip**: 한 번의 여행 단위. 메타데이터(title, 생성/수정 시각, owner)를 가지며 items 와 멤버를 보유한다. owner 식별자를 보조 컬럼으로 가져 트리거 없이 빠른 권한 평가에 활용한다.
+- **TripMember**: (trip, user) 페어와 그 페어의 역할(owner/editor/viewer) 그리고 초대 시각. (trip_id, user_id) 가 자연 키.
+- **Item**: 기존 엔티티에 trip 소속을 표현하는 trip_id 가 추가된다. trip_id 는 필수.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 마이그레이션 후 기존 단일 사용자가 보는 item 의 개수와 내용은 마이그레이션 전과 100% 동일하다.
+- **SC-002**: 신규 가입자가 첫 로그인부터 item 1 개를 추가 완료하기까지 추가 설정 단계는 0 회다(기본 trip 자동 생성).
+- **SC-003**: 두 번째 사용자가 첫 번째 사용자의 trip / items / 멤버 목록을 어떤 방식으로 조회해도 DB 가 반환하는 행 수는 0 이다.
+- **SC-004**: 권한이 없는 멤버의 쓰기 시도(insert/update/delete)는 100% DB 레벨에서 거부된다.
+- **SC-005**: 마이그레이션과 RLS 적용은 동일한 SQL 파일을 다른 Supabase/Postgres 인스턴스에서 재실행했을 때도 동일한 결과를 만들어낸다.
+
+## Assumptions
+
+- 현재 운영 환경은 단일 사용자(chanhee13p@gmail.com), 단일 trip 상태이다(사용자 확인 완료).
+- 사용자 ID 발급은 Supabase Auth(`auth.users`) 에 위임한다(#107 에서 도입 완료). RLS 정책은 `auth.uid()` 를 신뢰한다.
+- 익명/공유 접근은 본 스펙의 범위가 아니다(#110 에서 별도 정책).
+- 초대/수락 UX·멀티 trip 전환 UX 는 본 스펙의 범위가 아니다(#112 에서 다룸). 본 스펙은 "기본 활성 trip" 개념만 도입한다.
+- 다른 사용자가 자신의 데이터를 입력할 때까지는 격리 검증을 운영 데이터로 직접 수행할 수 없다. 격리 검증은 SQL Editor 에서 다른 user_id 를 시뮬레이션하거나 두 번째 테스트 계정을 만들어 수행한다.
+
+## Out of Scope
+
+- 멤버 초대/수락 UX
+- 멀티 trip 전환 UX / 대시보드
+- 공유 토큰을 통한 익명 접근(#110)
+- 권한 변경 UI / 역할 승격
+- 멤버십 알림 / 이메일

--- a/specs/108-rls-trip-members/tasks.md
+++ b/specs/108-rls-trip-members/tasks.md
@@ -1,0 +1,64 @@
+# Tasks — RLS + trip_members
+
+순서대로 진행. 각 태스크는 가능하면 단일 커밋.
+
+## T1. DB: schema.sql + 마이그레이션 SQL 작성
+
+- [ ] `supabase/schema.sql` 갱신
+  - `trips`, `trip_members` 테이블 정의
+  - `items.trip_id` 컬럼 포함 (신규 호스트는 처음부터 적용)
+  - `is_trip_member`, `user_role_in_trip` SECURITY DEFINER 함수
+  - 전체 RLS 정책 (trips/trip_members/items)
+  - `grant execute ... to authenticated`
+- [ ] `supabase/migration_108_rls_trip_members.sql` 생성
+  - 단일 트랜잭션 (`begin; ... commit;`)
+  - chanhee13p@gmail.com 의 user_id 조회 + NOT FOUND 시 RAISE EXCEPTION
+  - 테이블/함수/정책 생성
+  - default trip "내 여행" 1건 INSERT
+  - owner 멤버십 1건 INSERT
+  - items.trip_id 추가 (nullable)
+  - 기존 items 전부 UPDATE
+  - items.trip_id NOT NULL + FK
+  - 기존 items 의 RLS (#107 이전엔 service_role 우회) 가 비활성 상태인지 확인 후 enable + 정책 적용
+
+## T2. lib/trip.ts 신규
+
+- [ ] `lib/trip.ts` 생성
+  - `TripRole` 타입
+  - `getActiveTripId(client)`: trip_members 에서 첫 번째 멤버십 trip_id 반환 (owner 우선, 그 다음 invited_at asc)
+  - `ensureActiveTrip(client)`: 멤버십이 0개면 새 trip 생성 + 자기 멤버십 INSERT, 그 trip_id 반환
+  - `getUserRole(client, tripId)`: trip_members 에서 role 조회
+
+## T3. lib/data.ts 리팩터
+
+- [ ] `getSupabaseClient()` 제거
+- [ ] 모든 export 함수 시그니처 변경: 첫 인자에 `SupabaseClient` 받음
+- [ ] `readItems(client)`, `writeItems(client, items)`, `getItem(client, id)` 등 내부에서 `ensureActiveTrip(client)` 호출 → 자동 trip_id 스코프
+- [ ] `writeItems` 의 upsert payload 에 `trip_id` 포함
+- [ ] `SUPABASE_SERVICE_KEY` 잔존 참조 제거
+
+## T4. 호출부 갱신 (7곳)
+
+각 호출부에서 컨텍스트에 맞는 클라이언트를 만들어 data 함수에 주입.
+
+- [ ] `app/api/items/route.ts` — `createRouteHandlerSupabase()`
+- [ ] `app/api/items/[id]/route.ts` — 동일
+- [ ] `app/api/gmaps/preview/route.ts` — 동일
+- [ ] `app/api/gmaps/import/route.ts` — 동일
+- [ ] `app/items/[id]/page.tsx` — 서버 컴포넌트용 클라이언트 (SSR cookies)
+- [ ] `app/items/[id]/edit/page.tsx` — 동일
+
+## T5. 인증 가드
+
+- [ ] 모든 데이터 라우트/페이지에서 `getSession()` 없으면 401/리다이렉트 (대부분 #107 미들웨어로 처리, 보강 필요한 곳만)
+
+## T6. 검증
+
+- [ ] `npm run build` 통과
+- [ ] (운영 DB 적용 후) quickstart.md 시나리오 1-5 수동 검증
+- [ ] `grep -r SUPABASE_SERVICE_KEY` 잔존 0건 확인 (env/문서 제외)
+
+## T7. PR
+
+- [ ] 커밋 분리 (T1 / T2-T3 / T4 / 검증 수정)
+- [ ] PR 본문에 마이그레이션 적용 안내, Closes #108

--- a/supabase/migration_108_rls_trip_members.sql
+++ b/supabase/migration_108_rls_trip_members.sql
@@ -1,10 +1,26 @@
--- Supabase SQL Editor 에서 실행하세요.
--- 신규 호스트(또는 빈 스키마)에 처음부터 적용할 때 사용하는 권위 있는 정의.
--- 운영 DB 에 이미 데이터가 있는 경우 migration_108_rls_trip_members.sql 을 대신 사용한다.
+-- 일회성 마이그레이션: 기존 단일 사용자/단일 trip 데이터 보존하며 RLS + trip_members 도입.
+-- Supabase SQL Editor 에서 한 번 실행. 트랜잭션 내에서 처리되어 부분 실패 시 롤백.
+-- 사전 조건: auth.users 에 chanhee13p@gmail.com 엔트리 존재.
 
--- ============================================================================
--- Tables
--- ============================================================================
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 1. owner 사용자 식별 (없으면 트랜잭션 중단)
+-- ---------------------------------------------------------------------------
+
+do $$
+declare
+  v_owner_id uuid;
+begin
+  select id into v_owner_id from auth.users where email = 'chanhee13p@gmail.com';
+  if v_owner_id is null then
+    raise exception 'auth.users 에 chanhee13p@gmail.com 이 없습니다. 마이그레이션 중단.';
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. 테이블 생성 (trips, trip_members)
+-- ---------------------------------------------------------------------------
 
 create table if not exists public.trips (
   id            uuid        primary key default gen_random_uuid(),
@@ -26,36 +42,43 @@ create table if not exists public.trip_members (
 
 create index if not exists idx_trip_members_user on public.trip_members(user_id);
 
-create table if not exists public.items (
-  id          text        primary key,
-  trip_id     uuid        not null references public.trips(id) on delete cascade,
-  name        text        not null,
-  category    text        not null default '기타',
-  status      text        not null default '검토 필요',
-  reservation_status text,
-  priority    text,
-  address     text,
-  lat         double precision,
-  lng         double precision,
-  links       jsonb       not null default '[]',
-  budget      integer,
-  memo        text,
-  date        text,
-  end_date    text,
-  time_start  text,
-  time_end    text,
-  is_franchise     boolean,
-  branches         jsonb,
-  google_place_id  text,
-  created_at       text        not null,
-  updated_at       text        not null
-);
+-- ---------------------------------------------------------------------------
+-- 3. default trip + owner 멤버십 시드
+-- ---------------------------------------------------------------------------
+
+with owner_lookup as (
+  select id as user_id from auth.users where email = 'chanhee13p@gmail.com'
+),
+new_trip as (
+  insert into public.trips (owner_user_id, title)
+  select user_id, '내 여행' from owner_lookup
+  returning id, owner_user_id
+)
+insert into public.trip_members (trip_id, user_id, role)
+select id, owner_user_id, 'owner' from new_trip;
+
+-- ---------------------------------------------------------------------------
+-- 4. items.trip_id 추가 + 기존 데이터 채움
+-- ---------------------------------------------------------------------------
+
+alter table public.items add column if not exists trip_id uuid references public.trips(id) on delete cascade;
+
+update public.items
+set trip_id = (
+  select t.id from public.trips t
+  join auth.users u on u.id = t.owner_user_id
+  where u.email = 'chanhee13p@gmail.com'
+  limit 1
+)
+where trip_id is null;
+
+alter table public.items alter column trip_id set not null;
 
 create index if not exists idx_items_trip on public.items(trip_id);
 
--- ============================================================================
--- RLS 재귀 회피용 헬퍼 함수 (SECURITY DEFINER)
--- ============================================================================
+-- ---------------------------------------------------------------------------
+-- 5. 헬퍼 함수 (RLS 재귀 회피)
+-- ---------------------------------------------------------------------------
 
 create or replace function public.is_trip_member(p_trip_id uuid)
 returns boolean
@@ -87,15 +110,14 @@ revoke all on function public.user_role_in_trip(uuid) from public, anon;
 grant execute on function public.is_trip_member(uuid) to authenticated;
 grant execute on function public.user_role_in_trip(uuid) to authenticated;
 
--- ============================================================================
--- Row Level Security
--- ============================================================================
+-- ---------------------------------------------------------------------------
+-- 6. RLS 정책 적용
+-- ---------------------------------------------------------------------------
 
 alter table public.trips         enable row level security;
 alter table public.trip_members  enable row level security;
 alter table public.items         enable row level security;
 
--- trips: 멤버만 SELECT, 본인이 owner 인 경우만 INSERT/UPDATE/DELETE
 drop policy if exists trips_select on public.trips;
 create policy trips_select on public.trips
   for select using (public.is_trip_member(id));
@@ -113,8 +135,6 @@ drop policy if exists trips_delete on public.trips;
 create policy trips_delete on public.trips
   for delete using (owner_user_id = auth.uid());
 
--- trip_members: 같은 trip 의 멤버만 SELECT, owner 만 INSERT/UPDATE/DELETE
--- INSERT 는 부트스트랩(owner 자기 자신을 막 생성한 trip 에 추가)을 위해 trips.owner_user_id OR 분기 포함
 drop policy if exists trip_members_select on public.trip_members;
 create policy trip_members_select on public.trip_members
   for select using (public.is_trip_member(trip_id));
@@ -135,7 +155,6 @@ drop policy if exists trip_members_delete on public.trip_members;
 create policy trip_members_delete on public.trip_members
   for delete using (public.user_role_in_trip(trip_id) = 'owner');
 
--- items: viewer 이상 SELECT, editor 이상 INSERT/UPDATE/DELETE
 drop policy if exists items_select on public.items;
 create policy items_select on public.items
   for select using (public.user_role_in_trip(trip_id) is not null);
@@ -152,3 +171,10 @@ create policy items_update on public.items
 drop policy if exists items_delete on public.items;
 create policy items_delete on public.items
   for delete using (public.user_role_in_trip(trip_id) in ('owner', 'editor'));
+
+commit;
+
+-- 검증 쿼리 (별도로 실행):
+--   select count(*) from public.trips;                            -- 1
+--   select count(*) from public.trip_members;                     -- 1
+--   select count(*) from public.items where trip_id is null;      -- 0


### PR DESCRIPTION
## 관련 이슈

Closes #108

## 변경 이유

다중 사용자 전환의 데이터 모델 도입. 한 trip 에 여러 멤버가 참여하고 owner/editor/viewer 권한을 표현한다. 자체 권한 미들웨어 대신 **Supabase RLS 네이티브**로 처리해, 애플리케이션은 `auth.uid()` 만 신뢰하고 권한 체크는 DB 가 강제하도록 한다. 이 변경은 #110(공유), #111(인증 UI), #112(멀티 trip 대시보드)의 선행 조건이다.

## 변경 범위

**DB**
- `trips`, `trip_members` 테이블 신설
- `items.trip_id` 컬럼 + FK + 인덱스
- RLS 재귀 회피용 `SECURITY DEFINER` 헬퍼 2개: `is_trip_member`, `user_role_in_trip`
- 전체 RLS 정책 (trips/trip_members/items)
- `supabase/migration_108_rls_trip_members.sql`: 운영 DB 일회성 마이그레이션
  - `chanhee13p@gmail.com` 의 user_id 를 SQL 내부에서 동적 조회 (NOT FOUND 시 트랜잭션 롤백)
  - 기존 items 전부를 단일 trip "내 여행" 으로 묶음

**앱**
- `lib/trip.ts` 신규: `getActiveTripId` / `ensureActiveTrip` / `getUserRole`
  - 신규 사용자는 첫 진입 시 default trip 1개 자동 생성 (lazy)
- `lib/data.ts` 리팩터: `SUPABASE_SERVICE_KEY` 의존 제거. 모든 export 가 client 를 첫 인자로 받음. 내부에서 활성 trip 으로 자동 스코프.
- 호출부 6곳 갱신: 각자 `createRouteHandlerSupabase()` 로 쿠키 기반 사용자 세션 클라이언트를 주입

**문서**
- `specs/108-rls-trip-members/`: spec / plan / data-model / quickstart / tasks

## 검증

- `npm run build` 통과 (22 페이지 정적/동적 빌드 OK)
- `npm run lint` 0 warnings
- `SUPABASE_SERVICE_KEY` 잔존 참조 0건 (`grep -r`)

## 적용 절차 (머지 후)

1. Supabase 대시보드 → SQL Editor 에서 `supabase/migration_108_rls_trip_members.sql` 전체 실행
2. `chanhee13p@gmail.com` 로그인하여 items 목록이 마이그레이션 전과 동일한지 확인 ([quickstart.md](../blob/issue/108-rls-trip-members/specs/108-rls-trip-members/quickstart.md))
3. (선택) 두 번째 테스트 계정으로 가입해 격리 검증

## 남은 작업 / 리스크

- **운영 DB 마이그레이션은 사람이 직접 실행**해야 함. 빌드/배포가 자동으로 적용하지 않는다.
- RLS 정책 오류 시 본인 데이터도 안 보일 수 있음 — 마이그레이션 직후 즉시 P1 시나리오 점검 필요.
- 멤버 초대/수락 UX, 멀티 trip 전환 UI 는 본 PR 범위 외 (#112).
- 공유 토큰을 통한 익명 접근은 본 PR 범위 외 (#110).
