### PR TITLE
feat(auth): #111 회원가입/비밀번호 재설정 UI + enumeration 차단

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -18,11 +18,14 @@ export async function POST(request: NextRequest) {
 
   const { data, error } = await signUpWithEmail(email, password, emailRedirectTo)
   if (error) {
-    const msg = /already/i.test(error.message)
-      ? '이미 사용 중인 이메일입니다.'
-      : '회원가입에 실패했습니다. 입력 정보를 확인해주세요.'
-    const status = /already/i.test(error.message) ? 409 : 400
-    return NextResponse.json({ error: msg }, { status })
+    // 이메일 enumeration 방지: 기존 가입 여부를 응답에 노출하지 않는다.
+    if (/already/i.test(error.message)) {
+      return NextResponse.json({ ok: true, needsEmailConfirmation: true })
+    }
+    return NextResponse.json(
+      { error: '회원가입에 실패했습니다. 입력 정보를 확인해주세요.' },
+      { status: 400 },
+    )
   }
 
   const needsEmailConfirmation = !data.session

--- a/app/forgot/ForgotForm.tsx
+++ b/app/forgot/ForgotForm.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export default function ForgotForm() {
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+
+    const res = await fetch('/api/auth/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    })
+
+    if (res.ok) {
+      setSubmitted(true)
+      setLoading(false)
+      return
+    }
+    const data = await res.json().catch(() => ({}))
+    setError(data.error || '요청에 실패했습니다.')
+    setLoading(false)
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-bg via-bg-subtle to-bg flex items-center justify-center p-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-bold text-fg">비밀번호 재설정</h1>
+          <p className="text-sm text-fg-subtle mt-1">가입 시 사용한 이메일을 입력하세요</p>
+        </div>
+
+        {submitted ? (
+          <div className="bg-bg-elevated rounded-2xl shadow-sm border border-border p-6 space-y-3">
+            <h2 className="text-base font-semibold text-fg">메일을 확인해주세요</h2>
+            <p className="text-sm text-fg-subtle">
+              입력하신 이메일이 가입된 주소라면 재설정 링크가 발송되었습니다. 받은 메일의 링크를 눌러 새 비밀번호를 설정해주세요.
+            </p>
+            <Link
+              href="/login"
+              className="block text-center w-full bg-accent text-accent-fg rounded-xl px-4 py-2.5 text-sm font-semibold hover:bg-accent-hover transition-colors"
+            >
+              로그인으로 돌아가기
+            </Link>
+          </div>
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            className="bg-bg-elevated rounded-2xl shadow-sm border border-border p-6 space-y-4"
+          >
+            <div>
+              <label className="block text-xs font-semibold text-fg-muted uppercase tracking-wide mb-1.5">
+                이메일
+              </label>
+              <input
+                type="email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                className="w-full border border-border rounded-xl px-3.5 py-2.5 text-fg text-sm focus:outline-none focus:ring-2 focus-visible:outline-accent focus:border-transparent transition-shadow"
+                autoComplete="email"
+                required
+              />
+            </div>
+
+            {error && (
+              <div className="bg-critical-bg border border-critical-border rounded-lg px-3 py-2">
+                <p className="text-critical-fg text-sm">{error}</p>
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-accent text-accent-fg rounded-xl px-4 py-2.5 text-sm font-semibold disabled:opacity-50 hover:bg-accent-hover active:bg-accent-hover transition-colors mt-2"
+            >
+              {loading ? '전송 중...' : '재설정 링크 받기'}
+            </button>
+
+            <div className="text-center text-sm text-fg-subtle pt-2">
+              <Link href="/login" className="text-accent font-semibold hover:underline">
+                로그인으로 돌아가기
+              </Link>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/forgot/page.tsx
+++ b/app/forgot/page.tsx
@@ -1,0 +1,5 @@
+import ForgotForm from './ForgotForm'
+
+export default function ForgotPage() {
+  return <ForgotForm />
+}

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -1,14 +1,23 @@
 'use client'
 
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useState, useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 
 export default function LoginForm() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const err = searchParams.get('error')
+    if (err === 'invalid_link') {
+      setError('만료되었거나 사용된 링크입니다. 재설정 링크를 다시 받아주세요.')
+    }
+  }, [searchParams])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -100,6 +109,15 @@ export default function LoginForm() {
           >
             {loading ? '로그인 중...' : '로그인'}
           </button>
+
+          <div className="flex items-center justify-between text-sm text-fg-subtle pt-2">
+            <Link href="/signup" className="text-accent font-semibold hover:underline">
+              가입하기
+            </Link>
+            <Link href="/forgot" className="hover:underline">
+              비밀번호를 잊으셨나요?
+            </Link>
+          </div>
         </form>
       </div>
     </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from 'react'
 import LoginForm from './LoginForm'
 
 export default function LoginPage() {
-  return <LoginForm />
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
+  )
 }

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export default function SignupForm() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [submitted, setSubmitted] = useState<null | { needsEmailConfirmation: boolean }>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+
+    const res = await fetch('/api/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    })
+    const data = await res.json().catch(() => ({}))
+
+    if (res.ok) {
+      if (data.needsEmailConfirmation) {
+        setSubmitted({ needsEmailConfirmation: true })
+        setLoading(false)
+        return
+      }
+      window.location.href = '/list'
+      return
+    }
+    setError(data.error || '회원가입에 실패했습니다.')
+    setLoading(false)
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-bg via-bg-subtle to-bg flex items-center justify-center p-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <div className="w-12 h-12 bg-accent rounded-2xl flex items-center justify-center mx-auto mb-4">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="w-6 h-6 text-accent-fg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </div>
+          <h1 className="text-2xl font-bold text-fg">계정 만들기</h1>
+          <p className="text-sm text-fg-subtle mt-1">trip-planner</p>
+        </div>
+
+        {submitted?.needsEmailConfirmation ? (
+          <div className="bg-bg-elevated rounded-2xl shadow-sm border border-border p-6 space-y-3">
+            <h2 className="text-base font-semibold text-fg">확인 메일을 보냈습니다</h2>
+            <p className="text-sm text-fg-subtle">
+              입력하신 이메일이 가입 가능한 주소라면 확인 링크가 발송되었습니다. 받은 메일의 링크를 눌러 가입을 완료해주세요.
+            </p>
+            <Link
+              href="/login"
+              className="block text-center w-full bg-accent text-accent-fg rounded-xl px-4 py-2.5 text-sm font-semibold hover:bg-accent-hover transition-colors"
+            >
+              로그인으로 이동
+            </Link>
+          </div>
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            className="bg-bg-elevated rounded-2xl shadow-sm border border-border p-6 space-y-4"
+          >
+            <div>
+              <label className="block text-xs font-semibold text-fg-muted uppercase tracking-wide mb-1.5">
+                이메일
+              </label>
+              <input
+                type="email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                className="w-full border border-border rounded-xl px-3.5 py-2.5 text-fg text-sm focus:outline-none focus:ring-2 focus-visible:outline-accent focus:border-transparent transition-shadow"
+                autoComplete="email"
+                required
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs font-semibold text-fg-muted uppercase tracking-wide mb-1.5">
+                비밀번호 (8자 이상)
+              </label>
+              <input
+                type="password"
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+                className="w-full border border-border rounded-xl px-3.5 py-2.5 text-fg text-sm focus:outline-none focus:ring-2 focus-visible:outline-accent focus:border-transparent transition-shadow"
+                autoComplete="new-password"
+                minLength={8}
+                required
+              />
+            </div>
+
+            {error && (
+              <div className="bg-critical-bg border border-critical-border rounded-lg px-3 py-2">
+                <p className="text-critical-fg text-sm">{error}</p>
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-accent text-accent-fg rounded-xl px-4 py-2.5 text-sm font-semibold disabled:opacity-50 hover:bg-accent-hover active:bg-accent-hover transition-colors mt-2"
+            >
+              {loading ? '가입 중...' : '가입하기'}
+            </button>
+
+            <div className="text-center text-sm text-fg-subtle pt-2">
+              이미 계정이 있나요?{' '}
+              <Link href="/login" className="text-accent font-semibold hover:underline">
+                로그인
+              </Link>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,5 @@
+import SignupForm from './SignupForm'
+
+export default function SignupPage() {
+  return <SignupForm />
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,13 +10,14 @@ export async function middleware(request: NextRequest) {
 
   const isProtectedPage = PROTECTED_PAGES.some(p => pathname.startsWith(p))
   const isProtectedApi = PROTECTED_API.some(p => pathname.startsWith(p))
-  const isLoginPage = pathname === '/login'
+  const isAuthPage =
+    pathname === '/login' || pathname === '/signup' || pathname === '/forgot'
 
   const response = NextResponse.next({ request })
   const session = await getSessionFromMiddleware(request, response)
   const isAuthenticated = session !== null
 
-  if (isLoginPage) {
+  if (isAuthPage) {
     if (isAuthenticated) {
       return NextResponse.redirect(new URL('/list', request.url))
     }
@@ -38,6 +39,8 @@ export async function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     '/login',
+    '/signup',
+    '/forgot',
     '/list/:path*',
     '/map/:path*',
     '/schedule/:path*',


### PR DESCRIPTION
## 관련 이슈
Closes #111

## 변경 이유
백엔드 인증 API(#107)는 갖춰져 있었지만 UI 측 진입점이 `/login` 한 페이지뿐이라 신규 사용자는 가입 경로가 없고 기존 사용자는 비밀번호를 잃으면 복구할 방법이 없었음. 다중 사용자(#112) 진입 전 인증 표면을 한 번에 정리.

## 변경 범위
- `/signup` 페이지 신설: 가입 폼, 메일 확인 안내 화면 분기
- `/forgot` 페이지 신설: 재설정 메일 요청, 결과는 가입 여부와 무관하게 동일 안내
- `/login`: `/signup`, `/forgot` 링크 추가, `?error=invalid_link` 콜백 만료 안내 처리 (Suspense 경계 포함)
- middleware: `/signup`, `/forgot` 도 인증 사용자 접근 시 `/list` 리다이렉트, matcher 갱신
- `app/api/auth/signup`: 이미 가입된 이메일에 대해서도 동일한 ok 응답을 반환해 이메일 enumeration 차단 (Supabase 가 미인증 가입자에는 확인 메일을 재발송)
- 디자인은 기존 로그인 페이지와 동일한 토큰(`bg-bg-elevated`, `border-border`, `bg-accent` 등) 사용, 모바일 뷰포트 우선

> 참고: 이슈 본문의 Apollo + JWT 흐름은 #121 의 2026-05-18 롤백 결정에 따라 Supabase Auth 네이티브로 대체. silent refresh / http-only cookie / 라우트 가드는 `@supabase/ssr` 과 기존 middleware 가 처리.

## 검증
- `npm run build` 통과 (lint + type check + prerender, 새 정적 페이지 `/signup`, `/forgot` 생성 확인)
- 인증 흐름 수동 검증 항목:
  - [x] `/signup` → 메일 확인 안내 화면 표시
  - [x] 이미 가입된 이메일 재가입 시도 → 동일 안내 (enumeration 차단)
  - [x] `/forgot` → 메일 확인 안내, 가입 여부 비노출
  - [x] 로그인 상태에서 `/login`, `/signup`, `/forgot` 진입 → `/list` 리다이렉트
  - [x] 만료된 콜백 링크 클릭 → `/login?error=invalid_link` 에서 안내 노출

## 남은 작업 / 리스크
- 자동 로그인 후 대시보드 진입은 #112 (대시보드/생성 마법사) 범위. 현재는 `/list` 로 진입.
- E2E 메일 수신 테스트는 Supabase SMTP 설정에 의존 — 운영 환경에서 별도 확인 필요.
