### PR TITLE
fix(auth): 사용자 전환 시 데이터 격리 — RPC 원자화 + SWR 캐시 클리어

### DIFF
--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -90,9 +90,23 @@ function validateItem(body: Record<string, unknown>): string | null {
 }
 
 export async function GET() {
-  const client = createRouteHandlerSupabase()
-  const items = await readItems(client)
-  return NextResponse.json({ items })
+  try {
+    const client = createRouteHandlerSupabase()
+    const items = await readItems(client)
+    return NextResponse.json({ items })
+  } catch (e) {
+    const err = e as { message?: string; code?: string; details?: string; hint?: string }
+    console.error('[GET /api/items] failed:', {
+      message: err?.message,
+      code: err?.code,
+      details: err?.details,
+      hint: err?.hint,
+    })
+    return NextResponse.json(
+      { error: '항목을 불러오지 못했습니다.' },
+      { status: 500 },
+    )
+  }
 }
 
 export async function POST(request: NextRequest) {

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useState, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { clearAppCache } from '@/lib/clearAppCache'
 
 export default function LoginForm() {
   const router = useRouter()
@@ -31,6 +32,7 @@ export default function LoginForm() {
     })
 
     if (res.ok) {
+      clearAppCache()
       // 로그인 후에는 풀 페이지 리로드: Next.js 라우터 캐시가 미인증 상태를
       // 캐시하고 있어서 router.push를 쓰면 쿠키가 설정돼도 기존 캐시를 재사용.
       window.location.href = '/list'

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { useState } from 'react'
+import { clearAppCache } from '@/lib/clearAppCache'
 
 export default function SignupForm() {
   const [email, setEmail] = useState('')
@@ -28,6 +29,7 @@ export default function SignupForm() {
         setLoading(false)
         return
       }
+      clearAppCache()
       window.location.href = '/list'
       return
     }

--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation'
 import { List, Map, CalendarDays, Download, LogOut } from 'lucide-react'
 import ThemeToggle from '@/components/Theme/ThemeToggle'
 import { cn } from '@/lib/cn'
+import { clearAppCache } from '@/lib/clearAppCache'
 
 interface NavItem {
   href: string
@@ -20,6 +21,7 @@ const NAV_ITEMS: NavItem[] = [
 
 async function handleLogout() {
   await fetch('/api/auth/logout', { method: 'POST' })
+  clearAppCache()
   window.location.href = '/login'
 }
 

--- a/lib/clearAppCache.ts
+++ b/lib/clearAppCache.ts
@@ -1,0 +1,21 @@
+// 로그인/로그아웃/회원가입 시 호출. 이전 사용자의 SWR 캐시가
+// 다음 사용자에게 노출되는 것을 막는다.
+//
+// SWRProvider 의 beforeunload 핸들러는 페이지 떠날 때 in-memory 캐시를
+// localStorage 에 다시 써넣으므로, 단순히 localStorage.removeItem 만으로는
+// navigation 직후 다시 채워진다. window 플래그로 핸들러를 무력화한 뒤 제거한다.
+
+export const SWR_CACHE_KEY = 'trip-planner-swr-cache'
+export const SWR_TIMESTAMP_KEY = 'trip-planner-swr-timestamp'
+export const SKIP_PERSIST_FLAG = '__tripPlannerSkipSwrPersist'
+
+export function clearAppCache(): void {
+  if (typeof window === 'undefined') return
+  ;(window as unknown as Record<string, unknown>)[SKIP_PERSIST_FLAG] = true
+  try {
+    localStorage.removeItem(SWR_CACHE_KEY)
+    localStorage.removeItem(SWR_TIMESTAMP_KEY)
+  } catch {
+    // storage unavailable
+  }
+}

--- a/lib/providers/SWRProvider.tsx
+++ b/lib/providers/SWRProvider.tsx
@@ -2,9 +2,8 @@
 
 import { ReactNode } from 'react'
 import { SWRConfig } from 'swr'
+import { SKIP_PERSIST_FLAG, SWR_CACHE_KEY as CACHE_KEY, SWR_TIMESTAMP_KEY as TIMESTAMP_KEY } from '@/lib/clearAppCache'
 
-const CACHE_KEY = 'trip-planner-swr-cache'
-const TIMESTAMP_KEY = 'trip-planner-swr-timestamp'
 const TTL_MS = 24 * 60 * 60 * 1000
 
 function localStorageProvider() {
@@ -28,6 +27,18 @@ function localStorageProvider() {
   }
 
   window.addEventListener('beforeunload', () => {
+    // clearAppCache() 가 로그인/로그아웃 직전에 이 플래그를 세우면 write 건너뜀.
+    // (그러지 않으면 in-memory map 이 다시 localStorage 로 흘러나가 이전 사용자의
+    // 데이터가 다음 사용자에게 노출됨)
+    if ((window as unknown as Record<string, unknown>)[SKIP_PERSIST_FLAG]) {
+      try {
+        localStorage.removeItem(CACHE_KEY)
+        localStorage.removeItem(TIMESTAMP_KEY)
+      } catch {
+        // ignore
+      }
+      return
+    }
     try {
       localStorage.setItem(CACHE_KEY, JSON.stringify(Array.from(map.entries())))
       localStorage.setItem(TIMESTAMP_KEY, Date.now().toString())

--- a/lib/trip.ts
+++ b/lib/trip.ts
@@ -20,25 +20,23 @@ export async function ensureActiveTrip(client: TripSupabaseClient): Promise<stri
   const existing = await getActiveTripId(client)
   if (existing) return existing
 
-  const { data: userData, error: userErr } = await client.auth.getUser()
-  if (userErr) throw userErr
-  const userId = userData.user?.id
-  if (!userId) throw new Error('로그인된 사용자가 없습니다.')
-
-  const { data: trip, error: tripErr } = await client
-    .from('trips')
-    .insert({ owner_user_id: userId, title: '내 여행' })
-    .select('id')
-    .single()
-  if (tripErr) throw tripErr
-  const tripId = trip.id as string
-
-  const { error: memberErr } = await client
-    .from('trip_members')
-    .insert({ trip_id: tripId, user_id: userId, role: 'owner' })
-  if (memberErr) throw memberErr
-
-  return tripId
+  // SECURITY DEFINER RPC 로 trip + 멤버십을 원자 생성한다.
+  // 두 단계 insert 로 분리하면 trips_select RLS(is_trip_member 기반) 가
+  // INSERT..RETURNING 시점에 막아 403 을 반환할 수 있어 RPC 로 회피.
+  const { data, error } = await client.rpc('create_user_trip')
+  if (error) {
+    console.error('[ensureActiveTrip] create_user_trip RPC failed:', {
+      message: error.message,
+      code: error.code,
+      details: error.details,
+      hint: error.hint,
+    })
+    throw error
+  }
+  if (typeof data !== 'string') {
+    throw new Error('create_user_trip 가 trip id 를 반환하지 않았습니다.')
+  }
+  return data
 }
 
 export async function getUserRole(

--- a/supabase/migration_130_create_user_trip_rpc.sql
+++ b/supabase/migration_130_create_user_trip_rpc.sql
@@ -1,0 +1,48 @@
+-- 신규 사용자의 첫 trip 생성을 원자화. RLS 경합 회피.
+--
+-- 배경: ensureActiveTrip 이 trips.insert 후 trip_members.insert 를 별도로 수행하면
+-- trips_select RLS 정책(is_trip_member 기반)이 INSERT..RETURNING 단계에서 막혀
+-- PostgREST 가 403 을 반환하는 경우가 발생. RPC 한 번으로 처리하면 RLS 가 우회되고
+-- (SECURITY DEFINER), 두 insert 가 단일 트랜잭션에 묶인다.
+--
+-- Supabase SQL Editor 에서 1회 실행. 이미 적용된 환경에서 재실행해도 안전.
+
+begin;
+
+create or replace function public.create_user_trip(p_title text default '내 여행')
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_trip_id uuid;
+begin
+  if v_user_id is null then
+    raise exception 'not authenticated';
+  end if;
+
+  insert into public.trips (owner_user_id, title)
+  values (v_user_id, p_title)
+  returning id into v_trip_id;
+
+  insert into public.trip_members (trip_id, user_id, role)
+  values (v_trip_id, v_user_id, 'owner');
+
+  return v_trip_id;
+end;
+$$;
+
+revoke all on function public.create_user_trip(text) from public, anon;
+grant execute on function public.create_user_trip(text) to authenticated;
+
+-- RLS 위에 테이블 권한도 함께 보장 (Supabase 기본 default privilege 누락 대비)
+grant select, insert, update, delete on public.trips         to authenticated;
+grant select, insert, update, delete on public.trip_members  to authenticated;
+grant select, insert, update, delete on public.items         to authenticated;
+
+commit;
+
+-- 검증:
+--   select pg_get_functiondef('public.create_user_trip(text)'::regprocedure);


### PR DESCRIPTION
## 변경 이유
신규 계정으로 로그인했을 때 이전 사용자(chanhee)의 NY 데이터가 그대로 표시되는 회귀. 두 가지 원인이 결합:

1. **서버 (`/api/items` 500)** — Vercel 함수 로그에 `POST /rest/v1/trips → 403`. `ensureActiveTrip` 이 `trips.insert` 후 `trip_members.insert` 를 별도로 수행하는데, `trips_select` RLS 가 `is_trip_member(id)` 를 참조하기 때문에 첫 insert 의 `RETURNING` 시점에는 멤버십이 아직 없어 403 으로 떨어짐.
2. **클라이언트 (`localStorage` 누수)** — `SWRProvider` 의 `beforeunload` 핸들러가 페이지 이탈 시 in-memory SWR 캐시를 사용자 무관 키(`trip-planner-swr-cache`)로 localStorage 에 다시 써넣음. 로그아웃 시 localStorage 를 비워도 navigation 직전에 핸들러가 옛 데이터를 재기록 → 다음 사용자에게 노출. revalidation 이 500 이라 stale 캐시가 그대로 유지.

## 변경 범위

**서버**
- `supabase/migration_130_create_user_trip_rpc.sql` 신설: SECURITY DEFINER RPC `create_user_trip()` 가 trips + trip_members 를 단일 트랜잭션에 원자 생성. RLS race 회피. `trips`, `trip_members`, `items` 에 `authenticated` grant 명시(Supabase 기본 default privilege 누락 대비).
- `lib/trip.ts` 의 두 단계 insert → `client.rpc('create_user_trip')` 한 번. 에러 시 message/code/details/hint 를 함께 로깅.
- `app/api/items` GET 핸들러를 `try/catch` 로 감싸 500 시 에러 컨텍스트를 함수 로그에 남김(이전엔 사유 추적 불가).

**클라이언트**
- `lib/clearAppCache.ts` 신설: `window` 에 `SKIP_PERSIST_FLAG` 를 세팅하고 SWR 캐시 키 2개를 localStorage 에서 제거.
- `lib/providers/SWRProvider.tsx` 의 `beforeunload` 가 그 플래그를 보면 write 를 건너뛰고 캐시 키도 제거.
- `Navigation.handleLogout`, `LoginForm`, `SignupForm` 가 navigation 직전에 `clearAppCache()` 호출.

## 검증
- `npm run build` 통과.
- 운영 적용 절차:
  1. PR 머지 → Vercel 자동 배포 대기
  2. Supabase Dashboard → SQL Editor 에서 `supabase/migration_130_create_user_trip_rpc.sql` 1회 실행
  3. 시크릿창에서 신규 계정 가입 → `/list` 가 빈 상태로 표시되는지 확인
  4. 로그아웃 → 다른 계정 로그인 → 이전 계정 데이터 노출 없음 확인

## 남은 작업 / 리스크
- 마이그레이션 실행 누락 시 신규 가입자가 계속 500 을 받음. 머지 직후 SQL Editor 작업 필요.
- 장기적으로는 SWR 캐시 키 자체를 user_id 로 namespace 하는 게 더 견고. 현재는 명시적 clear 로 충분하지만, 사용자가 두 탭에서 다른 계정으로 로그인하는 엣지케이스는 여전히 노출 가능. 별도 이슈로 추적 가치 있음.
