### PR TITLE
docs(readme): Supabase Auth 전환·멀티유저 기능 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trip Planner
 
-개인 여행을 위한 리서치·일정 통합 플래너 웹앱. 후보 장소 조사부터 확정 일정 관리까지 하나의 인터페이스에서 처리한다.
+여행 리서치와 일정 관리를 하나의 인터페이스에서 처리하는 멀티유저 플래너 웹앱. 후보 장소 조사부터 확정 일정, 동행자와의 공동 편집까지 한 화면에서 다룬다.
 
 ## 주요 기능
 
@@ -9,7 +9,10 @@
 - **카테고리 / 우선순위 / 예약 상태 배지** — 이모지와 색상으로 한눈에 파악
 - **일정 뷰** — 날짜별 그룹, 시간순 정렬, 시작/종료 시간 표시
 - **Google Maps 가져오기** — 저장된 장소 목록을 앱에 일괄 임포트
-- **모바일 지원** — 맥북과 아이폰 브라우저 모두 동작
+- **멀티유저 / 트립 멤버십** — 여행별로 멤버를 초대해 공동 편집 (Supabase RLS + `trip_members`)
+- **이메일 인증** — 회원가입 / 로그인 / 비밀번호 재설정 (Supabase Auth, 이메일 enumeration 방지)
+- **모바일 최적화 UX** — 모바일 패널·필터·내비게이션 (맥북과 아이폰 브라우저 모두 동작)
+- **빠른 응답을 위한 SWR 캐싱** — 클라이언트 캐시 + 사용자 전환 시 자동 invalidate
 
 ## 기술 스택
 
@@ -18,10 +21,10 @@
 | 프레임워크 | Next.js 14 (App Router) |
 | UI | React 18, Tailwind CSS 3 |
 | 지도 | Leaflet, react-leaflet |
-| 데이터베이스 | Supabase (PostgreSQL) |
+| 데이터베이스 | Supabase (PostgreSQL + RLS) |
+| 인증 | Supabase Auth (`@supabase/ssr`, `@supabase/supabase-js`) |
 | 데이터 패칭 | SWR |
 | 검색 | fuse.js |
-| 인증 | JWT (jose) |
 
 ## 로컬 실행 방법
 
@@ -46,7 +49,15 @@ cp .env.example .env.local
 
 `.env.local` 파일을 열어 아래 값을 채운다 (환경 변수 섹션 참고).
 
-### 4. 개발 서버 실행
+### 4. Supabase 사전 설정
+
+Supabase 대시보드에서 다음을 활성화한다.
+
+- **Authentication → Providers → Email** 활성화
+- **Authentication → URL Configuration** 의 Site URL / Redirect URLs 에 `http://localhost:3000` 및 운영 도메인 등록
+- `supabase/` 디렉터리의 스키마 / 마이그레이션을 프로젝트에 반영 (RLS 정책 포함)
+
+### 5. 개발 서버 실행
 
 ```bash
 npm run dev
@@ -58,11 +69,9 @@ npm run dev
 
 | 변수명 | 설명 | 값 취득 방법 |
 |--------|------|-------------|
-| `AUTH_ID` | 로그인 아이디 | 직접 설정 (임의 문자열) |
-| `AUTH_PASSWORD` | 로그인 비밀번호 | 직접 설정 (임의 문자열) |
-| `JWT_SECRET` | JWT 서명 키 | 직접 생성 (충분히 긴 랜덤 문자열) |
-| `SUPABASE_URL` | Supabase 프로젝트 URL | [Supabase 대시보드](https://supabase.com) → Project Settings → API |
-| `SUPABASE_SERVICE_KEY` | Supabase service role key | [Supabase 대시보드](https://supabase.com) → Project Settings → API |
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase 프로젝트 URL (서버/클라이언트 공용) | Supabase Dashboard → Project Settings → API |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | anon public key (클라이언트/SSR Auth 용) | Supabase Dashboard → Project Settings → API |
+| `SUPABASE_SERVICE_KEY` | service role key (서버 전용, 비밀) | Supabase Dashboard → Project Settings → API |
 
 ## 스크립트
 
@@ -72,3 +81,7 @@ npm run build    # 프로덕션 빌드
 npm run start    # 프로덕션 서버 실행
 npm run lint     # 린트 실행
 ```
+
+## 디자인 가이드
+
+신규 화면·컴포넌트를 디자인하거나 기존 UI 를 수정할 때는 [docs/design-guidelines.md](docs/design-guidelines.md) 를 먼저 참고한다.


### PR DESCRIPTION
## Summary
- 인증 스택을 JWT/jose 에서 Supabase Auth 로 교체한 내용을 README 에 반영
- 환경 변수를 현재 .env.example 기준(NEXT_PUBLIC_SUPABASE_URL/ANON_KEY, SUPABASE_SERVICE_KEY)으로 정리
- 멀티유저(trip_members + RLS, #108), 회원가입/비밀번호 재설정 UI(#111), 모바일 UX, SWR 캐싱 등 최근 기능 추가
- Supabase 대시보드 사전 설정 단계와 docs/design-guidelines.md 링크 추가

## Test plan
- [ ] README 렌더링 확인 (GitHub 미리보기)
- [ ] .env.example 의 환경 변수명과 README 표의 일치 여부 재확인