### PR TITLE
feat(dashboard): #112(2/4) 대시보드 + 새 여행 만들기 버튼

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { exchangeCodeForSession } from '@/lib/auth'
 
 function safeNext(next: string | null): string {
-  if (!next) return '/'
-  if (!next.startsWith('/') || next.startsWith('//')) return '/'
+  if (!next) return '/dashboard'
+  if (!next.startsWith('/') || next.startsWith('//')) return '/dashboard'
   return next
 }
 

--- a/app/api/trips/route.ts
+++ b/app/api/trips/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}))
+    const rawTitle = typeof body?.title === 'string' ? body.title.trim() : ''
+    const title = rawTitle || '새 여행'
+
+    const client = createRouteHandlerSupabase()
+    const { data: tripId, error } = await client.rpc('create_user_trip', { p_title: title })
+    if (error) {
+      console.error('[POST /api/trips] create_user_trip failed:', error)
+      return NextResponse.json({ error: '여행 생성에 실패했습니다.' }, { status: 500 })
+    }
+    if (typeof tripId !== 'string') {
+      return NextResponse.json({ error: '여행 생성에 실패했습니다.' }, { status: 500 })
+    }
+    return NextResponse.json({ tripId, title }, { status: 201 })
+  } catch (e) {
+    console.error('[POST /api/trips] unexpected:', e)
+    return NextResponse.json({ error: '여행 생성에 실패했습니다.' }, { status: 500 })
+  }
+}

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { LogOut, Plus, Search } from 'lucide-react'
+import ThemeToggle from '@/components/Theme/ThemeToggle'
+import { Input } from '@/components/UI/Input'
+import Button from '@/components/UI/Button'
+import EmptyState from '@/components/UI/EmptyState'
+import { useToast } from '@/components/UI/Toast'
+import { clearAppCache } from '@/lib/clearAppCache'
+import type { TripSummary } from '@/lib/trips'
+
+type SortKey = 'created_desc' | 'created_asc' | 'name'
+
+const SORT_LABELS: Record<SortKey, string> = {
+  created_desc: '최근 생성순',
+  created_asc: '오래된 순',
+  name: '이름순',
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })
+  } catch {
+    return iso
+  }
+}
+
+async function handleLogout() {
+  await fetch('/api/auth/logout', { method: 'POST' })
+  clearAppCache()
+  window.location.href = '/login'
+}
+
+interface Props {
+  initialTrips: TripSummary[]
+  userEmail: string | null
+}
+
+export default function DashboardClient({ initialTrips, userEmail }: Props) {
+  const router = useRouter()
+  const { showToast } = useToast()
+  const [trips, setTrips] = useState<TripSummary[]>(initialTrips)
+  const [query, setQuery] = useState('')
+  const [sort, setSort] = useState<SortKey>('created_desc')
+  const [creating, setCreating] = useState(false)
+
+  const visibleTrips = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    const filtered = q
+      ? trips.filter(t => t.title.toLowerCase().includes(q))
+      : trips
+    const sorted = [...filtered].sort((a, b) => {
+      if (sort === 'name') return a.title.localeCompare(b.title, 'ko')
+      const cmp = a.created_at.localeCompare(b.created_at)
+      return sort === 'created_asc' ? cmp : -cmp
+    })
+    return sorted
+  }, [trips, query, sort])
+
+  async function handleCreate() {
+    if (creating) return
+    setCreating(true)
+    try {
+      const res = await fetch('/api/trips', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+      if (!res.ok) throw new Error('create failed')
+      const data = (await res.json()) as { tripId: string; title: string }
+      router.push(`/trip/${data.tripId}/map`)
+    } catch {
+      showToast({ type: 'error', message: '여행 생성에 실패했습니다.' })
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-bg text-fg">
+      <header className="border-b border-border bg-bg-elevated">
+        <div className="max-w-5xl mx-auto px-4 md:px-8 py-4 flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="text-lg md:text-xl font-bold text-fg">내 여행</h1>
+            {userEmail && (
+              <p className="text-xs text-fg-subtle mt-0.5 truncate">{userEmail}</p>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <ThemeToggle />
+            <button
+              type="button"
+              onClick={handleLogout}
+              aria-label="로그아웃"
+              className="p-2 rounded-lg text-fg-subtle hover:text-fg hover:bg-bg-subtle transition-colors"
+            >
+              <LogOut className="size-4" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-5xl mx-auto px-4 md:px-8 py-6">
+        {trips.length > 0 && (
+          <div className="flex flex-col md:flex-row gap-3 mb-6">
+            <div className="flex-1 min-w-0">
+              <Input
+                type="search"
+                hideLabel
+                label="여행 검색"
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                placeholder="여행 이름으로 검색"
+                leading={<Search className="size-4" aria-hidden="true" />}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="sr-only" htmlFor="sort-select">정렬</label>
+              <select
+                id="sort-select"
+                value={sort}
+                onChange={e => setSort(e.target.value as SortKey)}
+                className="bg-bg-elevated border border-border-strong rounded-lg px-3 py-2 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-border-strong"
+              >
+                {(Object.keys(SORT_LABELS) as SortKey[]).map(k => (
+                  <option key={k} value={k}>
+                    {SORT_LABELS[k]}
+                  </option>
+                ))}
+              </select>
+              <Button onClick={handleCreate} disabled={creating}>
+                <Plus className="size-4 mr-1" aria-hidden="true" />
+                {creating ? '생성 중…' : '새 여행'}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {trips.length === 0 ? (
+          <div className="py-12">
+            <EmptyState
+              title="아직 여행이 없어요"
+              description="첫 여행을 만들어 일정을 정리해 보세요."
+              action={
+                <Button onClick={handleCreate} disabled={creating}>
+                  <Plus className="size-4 mr-1" aria-hidden="true" />
+                  {creating ? '생성 중…' : '첫 여행 만들기'}
+                </Button>
+              }
+            />
+          </div>
+        ) : visibleTrips.length === 0 ? (
+          <div className="py-12">
+            <EmptyState
+              title="검색 결과가 없어요"
+              description="다른 키워드로 검색해 보세요."
+            />
+          </div>
+        ) : (
+          <ul className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {visibleTrips.map(trip => (
+              <li key={trip.id}>
+                <Link
+                  href={`/trip/${trip.id}/map`}
+                  className="block bg-bg-elevated border border-border rounded-xl p-4 hover:border-border-strong hover:shadow-sm transition-all duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                >
+                  <h2 className="text-base font-semibold text-fg mb-1 truncate">{trip.title}</h2>
+                  <p className="text-xs text-fg-subtle">
+                    {formatDate(trip.created_at)} · 항목 {trip.itemCount}개
+                  </p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from 'next/navigation'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
+import { listUserTrips } from '@/lib/trips'
+import DashboardClient from './DashboardClient'
+
+export const dynamic = 'force-dynamic'
+
+export default async function DashboardPage() {
+  const client = createRouteHandlerSupabase()
+  const { data: userData } = await client.auth.getUser()
+  if (!userData.user) {
+    redirect('/login?next=/dashboard')
+  }
+
+  const trips = await listUserTrips(client)
+  return <DashboardClient initialTrips={trips} userEmail={userData.user.email ?? null} />
+}

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -35,7 +35,7 @@ export default function LoginForm() {
       clearAppCache()
       // 로그인 후에는 풀 페이지 리로드: Next.js 라우터 캐시가 미인증 상태를
       // 캐시하고 있어서 router.push를 쓰면 쿠키가 설정돼도 기존 캐시를 재사용.
-      window.location.href = '/'
+      window.location.href = '/dashboard'
       return
     } else {
       const data = await res.json()

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
-import { redirectToActiveTrip } from '@/lib/activeTripRedirect'
+import { redirect } from 'next/navigation'
 
-export default async function Home() {
-  await redirectToActiveTrip('map')
+export default function Home() {
+  redirect('/dashboard')
 }

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -30,7 +30,7 @@ export default function SignupForm() {
         return
       }
       clearAppCache()
-      window.location.href = '/'
+      window.location.href = '/dashboard'
       return
     }
     setError(data.error || '회원가입에 실패했습니다.')

--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { List, Map, CalendarDays, Download, LogOut } from 'lucide-react'
+import { ArrowLeft, List, Map, CalendarDays, Download, LogOut } from 'lucide-react'
 import ThemeToggle from '@/components/Theme/ThemeToggle'
 import { cn } from '@/lib/cn'
 import { clearAppCache } from '@/lib/clearAppCache'
@@ -83,8 +83,13 @@ export default function Navigation() {
         aria-label="기본 네비게이션"
       >
         <div className="mb-6 px-3">
-          <p className="text-sm font-bold text-fg">NYC Trip</p>
-          <p className="text-xs text-fg-subtle mt-0.5">2026년 7월</p>
+          <Link
+            href="/dashboard"
+            className="inline-flex items-center gap-1.5 text-xs text-fg-subtle hover:text-fg transition-colors"
+          >
+            <ArrowLeft className="size-3.5" aria-hidden="true" />
+            내 여행 목록
+          </Link>
         </div>
         <ul className="flex-1 space-y-0.5">
           {NAV_ITEMS.map(({ sub, label, icon: Icon }) => {

--- a/lib/trips.ts
+++ b/lib/trips.ts
@@ -1,0 +1,38 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type TripSummary = {
+  id: string
+  title: string
+  created_at: string
+  itemCount: number
+}
+
+export async function listUserTrips(client: SupabaseClient): Promise<TripSummary[]> {
+  const { data: trips, error } = await client
+    .from('trips')
+    .select('id, title, created_at')
+    .order('created_at', { ascending: false })
+  if (error) throw error
+  const rows = (trips ?? []) as Array<{ id: string; title: string; created_at: string }>
+
+  if (rows.length === 0) return []
+
+  const ids = rows.map(t => t.id)
+  const { data: items, error: itemsErr } = await client
+    .from('items')
+    .select('trip_id')
+    .in('trip_id', ids)
+  if (itemsErr) throw itemsErr
+
+  const counts = new Map<string, number>()
+  for (const row of (items ?? []) as Array<{ trip_id: string }>) {
+    counts.set(row.trip_id, (counts.get(row.trip_id) ?? 0) + 1)
+  }
+
+  return rows.map(t => ({
+    id: t.id,
+    title: t.title,
+    created_at: t.created_at,
+    itemCount: counts.get(t.id) ?? 0,
+  }))
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,8 +2,8 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { getSessionFromMiddleware } from '@/lib/auth'
 
-const PROTECTED_PAGES = ['/list', '/map', '/schedule', '/items', '/gmaps-import', '/trip']
-const PROTECTED_API = ['/api/items', '/api/geocode', '/api/gmaps']
+const PROTECTED_PAGES = ['/list', '/map', '/schedule', '/items', '/gmaps-import', '/trip', '/dashboard']
+const PROTECTED_API = ['/api/items', '/api/geocode', '/api/gmaps', '/api/trips']
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
@@ -49,8 +49,10 @@ export const config = {
     '/items/:path*',
     '/gmaps-import/:path*',
     '/trip/:path*',
+    '/dashboard/:path*',
     '/api/items/:path*',
     '/api/geocode',
     '/api/gmaps/:path*',
+    '/api/trips/:path*',
   ],
 }


### PR DESCRIPTION
## 관련 이슈

#112 의 일부 (2/4) — **슬라이스 B: 대시보드**.
이 PR 은 #112 를 닫지 않습니다. 후속 슬라이스:
- C. 새 여행 마법사 + trip 메타데이터 컬럼
- D. `/me` 프로필

## 변경 이유

슬라이스 A 에서 `/trip/[tripId]/*` canonical 라우트를 만들었지만, 여러 trip 사이를 오갈 진입점이 없었다. 본 PR 은 사용자의 모든 trip 을 카드로 보여주는 `/dashboard` 와 "+ 새 여행" 버튼을 추가해 멀티 trip UX 의 핵심 진입점을 제공한다.

## 변경 범위

**대시보드**
- `app/dashboard/page.tsx` (server) + `DashboardClient.tsx` (client)
- 카드 그리드: 제목, 생성일, 항목 수
- 검색(제목), 정렬(최근/오래된/이름순)
- 빈 상태: "첫 여행 만들기" CTA
- 헤더에 이메일, 테마 토글, 로그아웃

**여행 생성**
- `POST /api/trips` — `create_user_trip(p_title)` RPC 호출
- 단순 버튼 형태 (다단계 마법사는 슬라이스 C)
- 생성 후 자동으로 `/trip/<id>/map` 진입

**진입점 전환**
- `/` → `/dashboard` (기존: 활성 trip 으로)
- 로그인/가입/auth callback 기본 목적지 `/dashboard`
- Navigation 사이드바 상단에 "← 내 여행 목록" 링크 (기존 "NYC Trip / 2026년 7월" 하드코딩 제거)
- 기존 `/map`, `/list`, ... 레거시 리디렉트는 슬라이스 A 그대로 유지

**기타**
- `lib/trips.ts` — `listUserTrips` (trip + item count)
- middleware: `/dashboard`, `/api/trips/*` 보호

## 검증

- [x] `npm run build` 성공
- [x] `npm run lint` 무경고
- [ ] **수동 검증 필요**: 가입 후 `/dashboard` 빈 상태 → "첫 여행 만들기" 정상 / 검색/정렬 / 카드 클릭 → `/trip/<id>/map` 진입 / 트립 내부에서 "← 내 여행 목록" 으로 복귀

## 남은 작업 / 리스크

- 카드에 기간/베이스캠프/표지 이미지가 없음 — DB 컬럼이 아직 없기 때문. 슬라이스 C 에서 `trips.start_date/end_date/region/basecamp_address` 추가 후 카드도 확장.
- 모바일에서 사이드바가 안 보이므로 trip 진입 후 대시보드 복귀 경로가 데스크톱 전용. 모바일은 `/` 또는 직접 URL 으로 복귀.
