### PR TITLE
feat(trip-wizard): #112(3/4) 새 여행 마법사 + trip 메타데이터

### DIFF
--- a/app/api/trips/route.ts
+++ b/app/api/trips/route.ts
@@ -1,16 +1,43 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 
+function sanitizeText(v: unknown): string | null {
+  if (typeof v !== 'string') return null
+  const t = v.trim()
+  return t ? t : null
+}
+
+function sanitizeDate(v: unknown): string | null {
+  if (typeof v !== 'string') return null
+  return /^\d{4}-\d{2}-\d{2}$/.test(v) ? v : null
+}
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json().catch(() => ({}))
-    const rawTitle = typeof body?.title === 'string' ? body.title.trim() : ''
-    const title = rawTitle || '새 여행'
+    const title = sanitizeText(body?.title) ?? '새 여행'
+    const startDate = sanitizeDate(body?.start_date)
+    const endDate = sanitizeDate(body?.end_date)
+    const region = sanitizeText(body?.region)
+    const basecamp = sanitizeText(body?.basecamp_address)
+
+    if (startDate && endDate && endDate < startDate) {
+      return NextResponse.json(
+        { error: '종료일은 시작일보다 빠를 수 없습니다.' },
+        { status: 400 },
+      )
+    }
 
     const client = createRouteHandlerSupabase()
-    const { data: tripId, error } = await client.rpc('create_user_trip', { p_title: title })
+    const { data: tripId, error } = await client.rpc('create_trip_v2', {
+      p_title: title,
+      p_start_date: startDate,
+      p_end_date: endDate,
+      p_region: region,
+      p_basecamp_address: basecamp,
+    })
     if (error) {
-      console.error('[POST /api/trips] create_user_trip failed:', error)
+      console.error('[POST /api/trips] create_trip_v2 failed:', error)
       return NextResponse.json({ error: '여행 생성에 실패했습니다.' }, { status: 500 })
     }
     if (typeof tripId !== 'string') {

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -2,21 +2,19 @@
 
 import { useMemo, useState } from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
-import { LogOut, Plus, Search } from 'lucide-react'
+import { LogOut, MapPin, Plus, Search } from 'lucide-react'
 import ThemeToggle from '@/components/Theme/ThemeToggle'
 import { Input } from '@/components/UI/Input'
 import Button from '@/components/UI/Button'
 import EmptyState from '@/components/UI/EmptyState'
-import { useToast } from '@/components/UI/Toast'
 import { clearAppCache } from '@/lib/clearAppCache'
 import type { TripSummary } from '@/lib/trips'
 
-type SortKey = 'created_desc' | 'created_asc' | 'name'
+type SortKey = 'created_desc' | 'start_date' | 'name'
 
 const SORT_LABELS: Record<SortKey, string> = {
   created_desc: '최근 생성순',
-  created_asc: '오래된 순',
+  start_date: '기간 시작일순',
   name: '이름순',
 }
 
@@ -26,6 +24,21 @@ function formatDate(iso: string): string {
   } catch {
     return iso
   }
+}
+
+function formatDateShort(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })
+  } catch {
+    return iso
+  }
+}
+
+function formatRange(start: string | null, end: string | null): string | null {
+  if (!start && !end) return null
+  if (start && end) return `${formatDateShort(start)} – ${formatDateShort(end)}`
+  if (start) return `${formatDateShort(start)} 부터`
+  return `${formatDateShort(end!)} 까지`
 }
 
 async function handleLogout() {
@@ -40,43 +53,32 @@ interface Props {
 }
 
 export default function DashboardClient({ initialTrips, userEmail }: Props) {
-  const router = useRouter()
-  const { showToast } = useToast()
-  const [trips, setTrips] = useState<TripSummary[]>(initialTrips)
+  const [trips] = useState<TripSummary[]>(initialTrips)
   const [query, setQuery] = useState('')
   const [sort, setSort] = useState<SortKey>('created_desc')
-  const [creating, setCreating] = useState(false)
 
   const visibleTrips = useMemo(() => {
     const q = query.trim().toLowerCase()
     const filtered = q
-      ? trips.filter(t => t.title.toLowerCase().includes(q))
+      ? trips.filter(t =>
+          t.title.toLowerCase().includes(q) ||
+          (t.region ?? '').toLowerCase().includes(q),
+        )
       : trips
     const sorted = [...filtered].sort((a, b) => {
       if (sort === 'name') return a.title.localeCompare(b.title, 'ko')
-      const cmp = a.created_at.localeCompare(b.created_at)
-      return sort === 'created_asc' ? cmp : -cmp
+      if (sort === 'start_date') {
+        const av = a.start_date ?? ''
+        const bv = b.start_date ?? ''
+        if (av && bv) return av.localeCompare(bv)
+        if (av) return -1
+        if (bv) return 1
+        return b.created_at.localeCompare(a.created_at)
+      }
+      return b.created_at.localeCompare(a.created_at)
     })
     return sorted
   }, [trips, query, sort])
-
-  async function handleCreate() {
-    if (creating) return
-    setCreating(true)
-    try {
-      const res = await fetch('/api/trips', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      })
-      if (!res.ok) throw new Error('create failed')
-      const data = (await res.json()) as { tripId: string; title: string }
-      router.push(`/trip/${data.tripId}/map`)
-    } catch {
-      showToast({ type: 'error', message: '여행 생성에 실패했습니다.' })
-      setCreating(false)
-    }
-  }
 
   return (
     <div className="min-h-screen bg-bg text-fg">
@@ -112,7 +114,7 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
                 label="여행 검색"
                 value={query}
                 onChange={e => setQuery(e.target.value)}
-                placeholder="여행 이름으로 검색"
+                placeholder="이름·지역으로 검색"
                 leading={<Search className="size-4" aria-hidden="true" />}
               />
             </div>
@@ -130,10 +132,12 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
                   </option>
                 ))}
               </select>
-              <Button onClick={handleCreate} disabled={creating}>
-                <Plus className="size-4 mr-1" aria-hidden="true" />
-                {creating ? '생성 중…' : '새 여행'}
-              </Button>
+              <Link href="/dashboard/new">
+                <Button>
+                  <Plus className="size-4 mr-1" aria-hidden="true" />
+                  새 여행
+                </Button>
+              </Link>
             </div>
           </div>
         )}
@@ -144,10 +148,12 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
               title="아직 여행이 없어요"
               description="첫 여행을 만들어 일정을 정리해 보세요."
               action={
-                <Button onClick={handleCreate} disabled={creating}>
-                  <Plus className="size-4 mr-1" aria-hidden="true" />
-                  {creating ? '생성 중…' : '첫 여행 만들기'}
-                </Button>
+                <Link href="/dashboard/new">
+                  <Button>
+                    <Plus className="size-4 mr-1" aria-hidden="true" />
+                    첫 여행 만들기
+                  </Button>
+                </Link>
               }
             />
           </div>
@@ -160,19 +166,35 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
           </div>
         ) : (
           <ul className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-            {visibleTrips.map(trip => (
-              <li key={trip.id}>
-                <Link
-                  href={`/trip/${trip.id}/map`}
-                  className="block bg-bg-elevated border border-border rounded-xl p-4 hover:border-border-strong hover:shadow-sm transition-all duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-                >
-                  <h2 className="text-base font-semibold text-fg mb-1 truncate">{trip.title}</h2>
-                  <p className="text-xs text-fg-subtle">
-                    {formatDate(trip.created_at)} · 항목 {trip.itemCount}개
-                  </p>
-                </Link>
-              </li>
-            ))}
+            {visibleTrips.map(trip => {
+              const range = formatRange(trip.start_date, trip.end_date)
+              return (
+                <li key={trip.id}>
+                  <Link
+                    href={`/trip/${trip.id}/map`}
+                    className="block bg-bg-elevated border border-border rounded-xl p-4 hover:border-border-strong hover:shadow-sm transition-all duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                  >
+                    <h2 className="text-base font-semibold text-fg mb-2 truncate">{trip.title}</h2>
+                    <div className="space-y-1 text-xs text-fg-muted">
+                      {range ? (
+                        <p>{range}</p>
+                      ) : (
+                        <p className="text-fg-subtle">기간 미정</p>
+                      )}
+                      {trip.region && (
+                        <p className="flex items-center gap-1 truncate">
+                          <MapPin className="size-3 shrink-0" aria-hidden="true" />
+                          <span className="truncate">{trip.region}</span>
+                        </p>
+                      )}
+                      <p className="text-fg-subtle">
+                        {formatDate(trip.created_at)} 생성 · 항목 {trip.itemCount}개
+                      </p>
+                    </div>
+                  </Link>
+                </li>
+              )
+            })}
           </ul>
         )}
       </main>

--- a/app/dashboard/new/NewTripWizard.tsx
+++ b/app/dashboard/new/NewTripWizard.tsx
@@ -1,0 +1,296 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { ArrowLeft, Check } from 'lucide-react'
+import Button from '@/components/UI/Button'
+import { Input } from '@/components/UI/Input'
+import { useToast } from '@/components/UI/Toast'
+import { cn } from '@/lib/cn'
+
+type Step = 1 | 2 | 3 | 4
+
+const STEP_TITLES: Record<Step, string> = {
+  1: '여행 이름',
+  2: '기간',
+  3: '지역',
+  4: '베이스캠프',
+}
+
+export default function NewTripWizard() {
+  const router = useRouter()
+  const { showToast } = useToast()
+  const [step, setStep] = useState<Step>(1)
+  const [title, setTitle] = useState('')
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [region, setRegion] = useState('')
+  const [basecamp, setBasecamp] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const canProceed = useMemo(() => {
+    if (step === 1) return title.trim().length > 0
+    if (step === 2) {
+      if (startDate && endDate && endDate < startDate) return false
+      return true
+    }
+    return true
+  }, [step, title, startDate, endDate])
+
+  function next() {
+    if (!canProceed) return
+    if (step < 4) setStep((s) => (s + 1) as Step)
+  }
+
+  function prev() {
+    if (step > 1) setStep((s) => (s - 1) as Step)
+  }
+
+  async function handleSubmit() {
+    if (!title.trim() || submitting) return
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/trips', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: title.trim(),
+          start_date: startDate || null,
+          end_date: endDate || null,
+          region: region.trim() || null,
+          basecamp_address: basecamp.trim() || null,
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data?.error ?? '여행 생성에 실패했습니다.')
+      }
+      const data = (await res.json()) as { tripId: string }
+      router.push(`/trip/${data.tripId}/map`)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : '여행 생성에 실패했습니다.'
+      showToast({ type: 'error', message: msg })
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-bg text-fg">
+      <header className="border-b border-border bg-bg-elevated">
+        <div className="max-w-2xl mx-auto px-4 md:px-8 py-4 flex items-center gap-3">
+          <Link
+            href="/dashboard"
+            className="inline-flex items-center gap-1.5 text-sm text-fg-subtle hover:text-fg transition-colors"
+          >
+            <ArrowLeft className="size-4" aria-hidden="true" />
+            대시보드
+          </Link>
+          <h1 className="text-base font-bold text-fg ml-auto">새 여행 만들기</h1>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 md:px-8 py-6 pb-32">
+        <ol className="flex items-center gap-2 mb-8" aria-label="단계 표시">
+          {[1, 2, 3, 4].map((n) => {
+            const done = n < step
+            const current = n === step
+            return (
+              <li key={n} className="flex-1 flex items-center gap-2">
+                <div
+                  className={cn(
+                    'flex items-center justify-center size-7 rounded-full text-xs font-semibold transition-colors',
+                    done && 'bg-accent text-accent-fg',
+                    current && 'bg-accent text-accent-fg ring-2 ring-accent/30',
+                    !done && !current && 'bg-bg-subtle text-fg-subtle',
+                  )}
+                >
+                  {done ? <Check className="size-4" aria-hidden="true" /> : n}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className={cn('text-xs truncate', current ? 'text-fg font-medium' : 'text-fg-subtle')}>
+                    {STEP_TITLES[n as Step]}
+                  </p>
+                </div>
+              </li>
+            )
+          })}
+        </ol>
+
+        <section className="bg-bg-elevated border border-border rounded-xl p-6">
+          {step === 1 && (
+            <Step1
+              title={title}
+              setTitle={setTitle}
+            />
+          )}
+          {step === 2 && (
+            <Step2
+              startDate={startDate}
+              endDate={endDate}
+              setStartDate={setStartDate}
+              setEndDate={setEndDate}
+            />
+          )}
+          {step === 3 && (
+            <Step3 region={region} setRegion={setRegion} />
+          )}
+          {step === 4 && (
+            <Step4
+              basecamp={basecamp}
+              setBasecamp={setBasecamp}
+              summary={{ title, startDate, endDate, region }}
+            />
+          )}
+        </section>
+
+        <div className="flex items-center justify-between mt-6 gap-3">
+          <Button
+            variant="ghost"
+            onClick={prev}
+            disabled={step === 1 || submitting}
+          >
+            이전
+          </Button>
+          {step < 4 ? (
+            <Button onClick={next} disabled={!canProceed}>
+              다음
+            </Button>
+          ) : (
+            <Button onClick={handleSubmit} disabled={!title.trim() || submitting}>
+              {submitting ? '생성 중…' : '여행 만들기'}
+            </Button>
+          )}
+        </div>
+      </main>
+    </div>
+  )
+}
+
+function Step1({
+  title,
+  setTitle,
+}: {
+  title: string
+  setTitle: (v: string) => void
+}) {
+  return (
+    <div className="space-y-3">
+      <Input
+        label="여행 이름"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="예: 뉴욕 여름 휴가"
+        autoFocus
+        required
+      />
+      <p className="text-xs text-fg-subtle">
+        나중에 언제든 바꿀 수 있어요.
+      </p>
+    </div>
+  )
+}
+
+function Step2({
+  startDate,
+  endDate,
+  setStartDate,
+  setEndDate,
+}: {
+  startDate: string
+  endDate: string
+  setStartDate: (v: string) => void
+  setEndDate: (v: string) => void
+}) {
+  const invalid = startDate && endDate && endDate < startDate
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <Input
+          label="시작일"
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+        />
+        <Input
+          label="종료일"
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+        />
+      </div>
+      {invalid && (
+        <p className="text-xs text-critical-fg">종료일은 시작일과 같거나 이후여야 합니다.</p>
+      )}
+      <p className="text-xs text-fg-subtle">기간은 선택사항이에요. 비워두면 나중에 정할 수 있어요.</p>
+    </div>
+  )
+}
+
+function Step3({
+  region,
+  setRegion,
+}: {
+  region: string
+  setRegion: (v: string) => void
+}) {
+  return (
+    <div className="space-y-3">
+      <Input
+        label="지역"
+        value={region}
+        onChange={(e) => setRegion(e.target.value)}
+        placeholder="예: 미국 뉴욕"
+        autoFocus
+      />
+      <p className="text-xs text-fg-subtle">국가·도시·테마 등 자유롭게.</p>
+    </div>
+  )
+}
+
+function Step4({
+  basecamp,
+  setBasecamp,
+  summary,
+}: {
+  basecamp: string
+  setBasecamp: (v: string) => void
+  summary: { title: string; startDate: string; endDate: string; region: string }
+}) {
+  return (
+    <div className="space-y-4">
+      <Input
+        label="베이스캠프 (숙소)"
+        value={basecamp}
+        onChange={(e) => setBasecamp(e.target.value)}
+        placeholder="예: 맨해튼 미드타운 호텔"
+        autoFocus
+      />
+      <p className="text-xs text-fg-subtle">선택사항. 동선의 기준점이 돼요.</p>
+      <div className="border-t border-border pt-4">
+        <p className="text-xs font-semibold text-fg-subtle uppercase tracking-wider mb-2">미리 보기</p>
+        <dl className="text-sm space-y-1">
+          <SummaryRow label="이름" value={summary.title} />
+          <SummaryRow
+            label="기간"
+            value={
+              summary.startDate || summary.endDate
+                ? `${summary.startDate || '?'} – ${summary.endDate || '?'}`
+                : '미정'
+            }
+          />
+          <SummaryRow label="지역" value={summary.region || '미설정'} />
+        </dl>
+      </div>
+    </div>
+  )
+}
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <dt className="text-xs text-fg-muted">{label}</dt>
+      <dd className="text-sm text-fg truncate">{value}</dd>
+    </div>
+  )
+}

--- a/app/dashboard/new/page.tsx
+++ b/app/dashboard/new/page.tsx
@@ -1,0 +1,14 @@
+import { redirect } from 'next/navigation'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
+import NewTripWizard from './NewTripWizard'
+
+export const dynamic = 'force-dynamic'
+
+export default async function NewTripPage() {
+  const client = createRouteHandlerSupabase()
+  const { data: userData } = await client.auth.getUser()
+  if (!userData.user) {
+    redirect('/login?next=/dashboard/new')
+  }
+  return <NewTripWizard />
+}

--- a/lib/trips.ts
+++ b/lib/trips.ts
@@ -4,16 +4,28 @@ export type TripSummary = {
   id: string
   title: string
   created_at: string
+  start_date: string | null
+  end_date: string | null
+  region: string | null
+  basecamp_address: string | null
   itemCount: number
 }
 
 export async function listUserTrips(client: SupabaseClient): Promise<TripSummary[]> {
   const { data: trips, error } = await client
     .from('trips')
-    .select('id, title, created_at')
+    .select('id, title, created_at, start_date, end_date, region, basecamp_address')
     .order('created_at', { ascending: false })
   if (error) throw error
-  const rows = (trips ?? []) as Array<{ id: string; title: string; created_at: string }>
+  const rows = (trips ?? []) as Array<{
+    id: string
+    title: string
+    created_at: string
+    start_date: string | null
+    end_date: string | null
+    region: string | null
+    basecamp_address: string | null
+  }>
 
   if (rows.length === 0) return []
 
@@ -33,6 +45,10 @@ export async function listUserTrips(client: SupabaseClient): Promise<TripSummary
     id: t.id,
     title: t.title,
     created_at: t.created_at,
+    start_date: t.start_date,
+    end_date: t.end_date,
+    region: t.region,
+    basecamp_address: t.basecamp_address,
     itemCount: counts.get(t.id) ?? 0,
   }))
 }

--- a/supabase/migration_112c_trip_metadata.sql
+++ b/supabase/migration_112c_trip_metadata.sql
@@ -1,0 +1,61 @@
+-- #112 슬라이스 C: trip 메타데이터 컬럼 추가.
+-- 마법사가 채울 필드들. 모두 nullable — 기존 trip 은 그대로 두고
+-- 사용자가 편집 UI 에서 채우게 한다.
+--
+-- Supabase SQL Editor 에서 1회 실행. 이미 적용된 환경에서 재실행해도 안전.
+
+begin;
+
+alter table public.trips add column if not exists start_date       date;
+alter table public.trips add column if not exists end_date         date;
+alter table public.trips add column if not exists region           text;
+alter table public.trips add column if not exists basecamp_address text;
+
+-- 마법사 전용 RPC. SECURITY DEFINER 로 trips + trip_members 를 한 트랜잭션에 묶는다.
+-- 기존 create_user_trip 은 그대로 두고 (단일 trip 자동 생성용) 추가 RPC 를 도입.
+create or replace function public.create_trip_v2(
+  p_title            text,
+  p_start_date       date default null,
+  p_end_date         date default null,
+  p_region           text default null,
+  p_basecamp_address text default null
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_trip_id uuid;
+  v_title   text := coalesce(nullif(trim(p_title), ''), '새 여행');
+begin
+  if v_user_id is null then
+    raise exception 'not authenticated';
+  end if;
+
+  if p_start_date is not null and p_end_date is not null and p_end_date < p_start_date then
+    raise exception 'end_date must be on or after start_date';
+  end if;
+
+  insert into public.trips (
+    owner_user_id, title, start_date, end_date, region, basecamp_address
+  )
+  values (
+    v_user_id, v_title, p_start_date, p_end_date,
+    nullif(trim(coalesce(p_region, '')), ''),
+    nullif(trim(coalesce(p_basecamp_address, '')), '')
+  )
+  returning id into v_trip_id;
+
+  insert into public.trip_members (trip_id, user_id, role)
+  values (v_trip_id, v_user_id, 'owner');
+
+  return v_trip_id;
+end;
+$$;
+
+revoke all on function public.create_trip_v2(text, date, date, text, text) from public, anon;
+grant execute on function public.create_trip_v2(text, date, date, text, text) to authenticated;
+
+commit;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -7,11 +7,15 @@
 -- ============================================================================
 
 create table if not exists public.trips (
-  id            uuid        primary key default gen_random_uuid(),
-  owner_user_id uuid        not null references auth.users(id) on delete cascade,
-  title         text        not null default '내 여행',
-  created_at    timestamptz not null default now(),
-  updated_at    timestamptz not null default now()
+  id               uuid        primary key default gen_random_uuid(),
+  owner_user_id    uuid        not null references auth.users(id) on delete cascade,
+  title            text        not null default '내 여행',
+  start_date       date,
+  end_date         date,
+  region           text,
+  basecamp_address text,
+  created_at       timestamptz not null default now(),
+  updated_at       timestamptz not null default now()
 );
 
 create index if not exists idx_trips_owner on public.trips(owner_user_id);


### PR DESCRIPTION
## 관련 이슈

#112 의 일부 (3/4) — **슬라이스 C: 새 여행 마법사 + 메타데이터**.
이 PR 은 #112 를 닫지 않습니다. 후속 슬라이스:
- D. `/me` 프로필

## 변경 이유

슬라이스 B 의 "+ 새 여행" 버튼은 빈 trip 만 즉시 생성했다. 이슈 #112 는 마법사로 핵심 정보(이름·기간·지역·베이스캠프)를 한 번에 모아 "생성 즉시 의미 있는 첫 화면"을 보장하라고 명시한다. 그러려면 trips 테이블에 메타데이터 컬럼이 필요하다.

## 변경 범위

**DB**
- `supabase/migration_112c_trip_metadata.sql`:
  - `trips` 에 `start_date date`, `end_date date`, `region text`, `basecamp_address text` 컬럼 추가 (모두 nullable, 기존 trip 호환)
  - `create_trip_v2(title, start_date, end_date, region, basecamp_address)` RPC — SECURITY DEFINER, trips + trip_members 원자 생성, `end_date >= start_date` 검증
  - 기존 `create_user_trip` 은 유지 (legacy `ensureActiveTrip` 경로용)
- `supabase/schema.sql` 동기화

**API**
- `POST /api/trips`: `create_trip_v2` 호출. title sanitize, ISO 날짜 검증, region/basecamp trim & null 처리, end<start 거부.

**UI**
- `app/dashboard/new/page.tsx` (server: auth gate) + `NewTripWizard.tsx` (client)
- 4 단계 마법사 — 이름 → 기간 → 지역 → 베이스캠프
- 단계 인디케이터 (체크/현재/대기), 이전/다음 버튼, 마지막 단계에 미리보기
- 이름만 필수, 나머지는 선택 (skip 가능). 기간 잘못 입력 시 inline 에러.
- 생성 후 `/trip/<id>/map` 자동 진입
- DashboardClient: 카드에 기간(예: "5월 1일 – 5월 7일") + 지역 표시, 정렬 옵션에 "기간 시작일순" 추가
- "+ 새 여행" 버튼이 즉시 생성 대신 `/dashboard/new` 로 이동

## 검증

- [x] `npm run build` 성공
- [x] `npm run lint` 무경고
- [x] **DB 마이그레이션 필요**: 운영 Supabase 에서 `migration_112c_trip_metadata.sql` 실행해야 카드 메타데이터 / 마법사가 동작. 미실행 시 RPC 호출이 500 으로 실패.
- [ ] **수동 검증 필요**: 마법사 빈 이름 거부 / 기간 종료<시작 거부 / skip 후 생성 / 대시보드 카드에 메타 표시 / 정렬 동작

## 남은 작업 / 리스크

- 마법사는 자유 텍스트 입력 (지역/베이스캠프 자동완성 없음). 이슈 #112 는 "국가/도시 자동완성"을 언급하지만 후속 이슈에서 별도 분리 권장.
- 마법사에서 만든 trip 의 메타데이터를 trip 내부에서 편집하는 UI 가 아직 없음 — 별도 이슈 (#130 항목 추가 진입점 처럼)로 분리 권장.
