### PR TITLE
feat(share): #110 shares 테이블 + 익명 RLS 정책

### DIFF
--- a/lib/share.ts
+++ b/lib/share.ts
@@ -1,0 +1,77 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type Share = {
+  token: string
+  trip_id: string
+  created_by_user_id: string
+  created_at: string
+  expires_at: string | null
+  revoked_at: string | null
+}
+
+export type CreateShareOptions = {
+  expiresAt?: Date | null
+}
+
+export async function createShare(
+  client: SupabaseClient,
+  tripId: string,
+  options?: CreateShareOptions,
+): Promise<Share> {
+  const { data: userData, error: userErr } = await client.auth.getUser()
+  if (userErr) throw userErr
+  const userId = userData.user?.id
+  if (!userId) throw new Error('로그인이 필요합니다.')
+
+  const { data, error } = await client
+    .from('shares')
+    .insert({
+      trip_id: tripId,
+      created_by_user_id: userId,
+      expires_at: options?.expiresAt ? options.expiresAt.toISOString() : null,
+    })
+    .select()
+    .single()
+  if (error) throw error
+  return data as Share
+}
+
+export async function listSharesForTrip(
+  client: SupabaseClient,
+  tripId: string,
+): Promise<Share[]> {
+  const { data, error } = await client
+    .from('shares')
+    .select('*')
+    .eq('trip_id', tripId)
+    .order('created_at', { ascending: false })
+  if (error) throw error
+  return (data ?? []) as Share[]
+}
+
+export async function revokeShare(
+  client: SupabaseClient,
+  token: string,
+): Promise<void> {
+  const { error } = await client
+    .from('shares')
+    .update({ revoked_at: new Date().toISOString() })
+    .eq('token', token)
+  if (error) throw error
+}
+
+export function isShareActive(share: Pick<Share, 'expires_at' | 'revoked_at'>, now: Date = new Date()): boolean {
+  if (share.revoked_at) return false
+  if (share.expires_at && new Date(share.expires_at) <= now) return false
+  return true
+}
+
+// PostgREST 의 단일-요청-단일-트랜잭션 모델 때문에 set_config 의 효과는 해당 트랜잭션 한정이다.
+// 익명 read 의 실제 호출 패턴(set_share_token RPC + 후속 쿼리 vs 단일 RPC 통합)은 #113 에서 확정한다.
+export async function applyShareTokenToSession(
+  client: SupabaseClient,
+  token: string,
+): Promise<void> {
+  const { error } = await client.rpc('set_share_token', { p_token: token })
+  if (error) throw error
+}

--- a/specs/109-shares-rls/checklists/requirements.md
+++ b/specs/109-shares-rls/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: shares 테이블 + 익명 RLS 정책
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)  ※ Supabase/RLS는 도메인 제약으로 명시
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- `lodgings` 테이블 존재 여부는 plan 단계에서 확인 (Assumptions에 기록).
+- 검증 통과. plan 단계 진행 가능.

--- a/specs/109-shares-rls/plan.md
+++ b/specs/109-shares-rls/plan.md
@@ -1,0 +1,311 @@
+# Implementation Plan: shares 테이블 + 익명 RLS 정책
+
+**Spec**: [spec.md](./spec.md)
+**Issue**: [#110](https://github.com/Useful-Dogus/trip-planner/issues/110)
+**Branch**: `109-shares-rls`
+
+## 기술 결정
+
+| 영역 | 결정 | 근거 |
+|---|---|---|
+| DB | Supabase Postgres | 기존 스택 |
+| 정책 | RLS (네이티브) | #108 패턴 일관성, NestJS 미들웨어 회피(#121 결정) |
+| 토큰 | UUID v4 (`gen_random_uuid()`) | 추측 불가, 기존 PK 컨벤션 |
+| 헬퍼 함수 | SECURITY DEFINER + `set search_path = public` | #108 패턴(`is_trip_member`)과 동일 |
+| 익명 컨텍스트 전달 | PostgreSQL `current_setting('request.jwt.claims', true)` 미사용. 대신 **헬퍼 함수가 `current_setting('request.headers', true)` 또는 `set_config` 기반 세션 변수**를 사용 — 그러나 Supabase에서는 익명 토큰을 쿼리 시 직접 전달하기 어려움. **선택안: 토큰을 별도 인자로 받는 RPC 함수(`get_shared_trip(p_token uuid)`)** | RLS만으로 익명 컨텍스트에 토큰을 안전히 전달하는 방법이 제한적. RPC 함수는 SECURITY DEFINER로 토큰 유효성 + 데이터 반환을 원자적으로 처리 |
+
+### RLS vs RPC 트레이드오프 (재검토)
+
+이슈 본문은 "RLS 네이티브 정책" 요청. 하지만 Supabase의 anon 클라이언트가 임의의 trip을 query 할 때 토큰을 어떻게 RLS 정책에 전달하느냐가 관건이다.
+
+**선택지 A: 순수 RLS + 세션 변수**
+- 클라이언트가 매 요청 전 `select set_config('app.share_token', '<token>', true)` 호출.
+- 정책: `EXISTS (SELECT 1 FROM shares WHERE shares.trip_id = trips.id AND shares.token = current_setting('app.share_token', true)::uuid AND shares.revoked_at IS NULL AND (shares.expires_at IS NULL OR shares.expires_at > now()))`.
+- 장점: 표준 SELECT 그대로. PostgREST/Supabase JS와 호환.
+- 단점: `set_config`를 매 요청 묶음마다 호출해야 함. anon 역할이 `set_config` 호출 가능해야 함.
+
+**선택지 B: RPC 함수 (`get_shared_trip`)**
+- 단일 RPC가 토큰 검증 + trip/items 반환.
+- 장점: 원자적, 토큰 검증 누락 불가.
+- 단점: 일반 SELECT API 패턴에서 벗어남. #113 페이지가 RPC 의존.
+
+**결정: A (순수 RLS + `set_config`)** — 이슈 본문 요청에 정확히 부합. `set_config(..., true)` 는 트랜잭션 로컬이므로 안전. anon 역할의 `set_config` 호출은 Supabase에서 기본 허용.
+
+### 헬퍼 함수
+
+```sql
+create or replace function public.share_token_grants_access(p_trip_id uuid)
+returns boolean
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select exists(
+    select 1 from public.shares s
+    where s.trip_id = p_trip_id
+      and s.token = nullif(current_setting('app.share_token', true), '')::uuid
+      and s.revoked_at is null
+      and (s.expires_at is null or s.expires_at > now())
+  )
+$$;
+```
+
+- `nullif(..., '')::uuid` — 토큰 미설정 시 안전하게 NULL.
+- `current_setting(..., true)` — 미설정 시 NULL 반환(예외 없음).
+- `SECURITY DEFINER` — shares 테이블의 RLS를 우회하여 정책 평가 자체는 항상 가능.
+
+## 스키마 변경 (`supabase/migration_110_shares_table.sql`)
+
+```sql
+begin;
+
+-- 1. shares 테이블
+create table if not exists public.shares (
+  token              uuid        primary key default gen_random_uuid(),
+  trip_id            uuid        not null references public.trips(id) on delete cascade,
+  created_by_user_id uuid        not null references auth.users(id) on delete cascade,
+  created_at         timestamptz not null default now(),
+  expires_at         timestamptz,
+  revoked_at         timestamptz
+);
+
+create index if not exists idx_shares_trip on public.shares(trip_id);
+
+-- 2. 헬퍼 함수
+create or replace function public.share_token_grants_access(p_trip_id uuid)
+returns boolean
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select exists(
+    select 1 from public.shares s
+    where s.trip_id = p_trip_id
+      and s.token = nullif(current_setting('app.share_token', true), '')::uuid
+      and s.revoked_at is null
+      and (s.expires_at is null or s.expires_at > now())
+  )
+$$;
+
+revoke all on function public.share_token_grants_access(uuid) from public;
+grant execute on function public.share_token_grants_access(uuid) to anon, authenticated;
+
+-- 3. shares RLS
+alter table public.shares enable row level security;
+
+drop policy if exists shares_select on public.shares;
+create policy shares_select on public.shares
+  for select to anon, authenticated
+  using (true);  -- token 은 추측 불가, 발급된 모든 share 의 메타 조회 허용
+                 -- (실제 trip 접근은 trips/items 정책에서 통제)
+
+drop policy if exists shares_insert on public.shares;
+create policy shares_insert on public.shares
+  for insert to authenticated
+  with check (
+    public.user_role_in_trip(trip_id) = 'owner'
+    and created_by_user_id = auth.uid()
+  );
+
+drop policy if exists shares_update on public.shares;
+create policy shares_update on public.shares
+  for update to authenticated
+  using (public.user_role_in_trip(trip_id) = 'owner')
+  with check (public.user_role_in_trip(trip_id) = 'owner');
+
+drop policy if exists shares_delete on public.shares;
+create policy shares_delete on public.shares
+  for delete to authenticated
+  using (public.user_role_in_trip(trip_id) = 'owner');
+
+-- 4. trips SELECT 정책 갱신 — 멤버이거나 유효한 share 가 있으면 허용
+drop policy if exists trips_select on public.trips;
+create policy trips_select on public.trips
+  for select
+  using (
+    public.is_trip_member(id)
+    or public.share_token_grants_access(id)
+  );
+
+-- 5. items SELECT 정책 갱신
+drop policy if exists items_select on public.items;
+create policy items_select on public.items
+  for select
+  using (
+    public.user_role_in_trip(trip_id) is not null
+    or public.share_token_grants_access(trip_id)
+  );
+
+-- INSERT/UPDATE/DELETE 정책은 변경 없음 — 멤버(owner/editor) 전용 유지.
+-- 익명 역할(anon)은 trips/items INSERT/UPDATE/DELETE 정책의 `using/with check`
+-- 평가에서 auth.uid() = null 이므로 자동 차단됨.
+
+commit;
+```
+
+**중요 — shares_select 정책 재고**: `using (true)` 는 익명이 모든 shares 행을 SELECT 가능하게 함. 토큰 자체가 PK 라 leak 위험. 보완:
+
+```sql
+drop policy if exists shares_select on public.shares;
+create policy shares_select on public.shares
+  for select to anon, authenticated
+  using (
+    -- 멤버는 자신의 trip 의 shares 메타 조회 가능
+    public.is_trip_member(trip_id)
+    -- 익명은 자신이 알고 있는 토큰 1건만 조회 가능
+    or token = nullif(current_setting('app.share_token', true), '')::uuid
+  );
+```
+
+이 정책으로 익명은 자신이 가진 토큰 한 건만 SELECT 가능, 멤버는 자기 trip 의 모든 토큰 메타 조회 가능. token enumeration 방지.
+
+## 애플리케이션 변경 (`lib/share.ts`)
+
+세 함수 + 클라이언트 헬퍼:
+
+```ts
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type Share = {
+  token: string
+  trip_id: string
+  created_by_user_id: string
+  created_at: string
+  expires_at: string | null
+  revoked_at: string | null
+}
+
+/** owner 가 trip 에 대해 새 share token 발급. */
+export async function createShare(
+  client: SupabaseClient,
+  tripId: string,
+  options?: { expiresAt?: Date | null },
+): Promise<Share> {
+  const { data: userData } = await client.auth.getUser()
+  const userId = userData.user?.id
+  if (!userId) throw new Error('로그인이 필요합니다.')
+
+  const { data, error } = await client
+    .from('shares')
+    .insert({
+      trip_id: tripId,
+      created_by_user_id: userId,
+      expires_at: options?.expiresAt ? options.expiresAt.toISOString() : null,
+    })
+    .select()
+    .single()
+  if (error) throw error
+  return data as Share
+}
+
+/** trip 의 활성/비활성 모든 share 목록 (owner 용). */
+export async function listSharesForTrip(
+  client: SupabaseClient,
+  tripId: string,
+): Promise<Share[]> {
+  const { data, error } = await client
+    .from('shares')
+    .select('*')
+    .eq('trip_id', tripId)
+    .order('created_at', { ascending: false })
+  if (error) throw error
+  return (data ?? []) as Share[]
+}
+
+/** share token 철회 (revoked_at 기록). */
+export async function revokeShare(
+  client: SupabaseClient,
+  token: string,
+): Promise<void> {
+  const { error } = await client
+    .from('shares')
+    .update({ revoked_at: new Date().toISOString() })
+    .eq('token', token)
+  if (error) throw error
+}
+
+/**
+ * 익명 클라이언트가 현재 세션에 share token 을 설정한다.
+ * 같은 트랜잭션 범위(=다음 단일 쿼리)에서만 유효.
+ * Supabase JS 는 각 .from(...) 호출이 별도 요청이므로, 호출 직전에 RPC 로 설정 필요.
+ * → 실용적으로는 share 페이지에서 RPC 헬퍼 `set_share_context(token)` 한 번 호출 후
+ *    바로 이어서 trips/items 쿼리. 본 이슈는 lib 만 제공.
+ */
+export async function applyShareTokenToSession(
+  client: SupabaseClient,
+  token: string,
+): Promise<void> {
+  // PostgREST 의 단일 트랜잭션 보장 — local set_config 는 그 트랜잭션 한정.
+  // 따라서 후속 쿼리와 RPC 묶음 호출이 필요. #113 에서 구체 패턴 결정.
+  const { error } = await client.rpc('set_share_token', { p_token: token })
+  if (error) throw error
+}
+```
+
+추가 RPC 함수(마이그레이션에 포함):
+
+```sql
+create or replace function public.set_share_token(p_token uuid)
+returns void
+language sql
+volatile
+security definer
+set search_path = public
+as $$
+  select set_config('app.share_token', p_token::text, false);
+$$;
+
+revoke all on function public.set_share_token(uuid) from public;
+grant execute on function public.set_share_token(uuid) to anon, authenticated;
+```
+
+**주의**: PostgREST 의 connection pooling 으로 인해 `set_config(..., false)`(세션 단위) 도 쿼리 간 보장이 약하다. **`true`(transaction 단위)**가 정석이지만 그러면 후속 쿼리에 적용 안 됨. 
+
+**대안 — 단일 RPC `get_shared_trip(p_token uuid)` 가 trip+items 한 번에 반환**: 본 이슈 범위에서는 `lib/share.ts` 의 read 헬퍼는 미구현으로 두고, 발급/조회/철회(owner 컨텍스트) 만 제공. 익명 read 경로는 #113 에서 RPC 또는 PostgREST 의 헤더 전달 방식을 확정.
+
+### 본 이슈 최종 범위 (Plan 확정)
+
+- ✅ `shares` 테이블 + 인덱스
+- ✅ `shares` RLS (멤버 INSERT/UPDATE/DELETE, 익명 SELECT는 본인 토큰만)
+- ✅ `trips`/`items` SELECT 정책에 익명 토큰 경로 추가
+- ✅ 헬퍼 함수 `share_token_grants_access(trip_id)`
+- ✅ 헬퍼 함수 `set_share_token(token)` (#113 에서 호출 예정)
+- ✅ `lib/share.ts` — owner 컨텍스트 헬퍼(create/list/revoke) + 익명 세션 설정 헬퍼 wrapper
+- ❌ 익명 read 호출 패턴 확정 (→ #113)
+- ❌ UI/페이지 (→ #113)
+
+## 검증 계획
+
+자동화된 통합 테스트는 본 저장소에 없음(기존 컨벤션). 수동 검증 SQL(`supabase/migration_110_shares_table.sql` 하단 주석):
+
+```sql
+-- 마이그레이션 직후 검증 (Supabase SQL Editor):
+-- 1. shares 테이블 존재
+select count(*) from information_schema.tables where table_schema='public' and table_name='shares';  -- 1
+-- 2. 헬퍼 함수 존재
+select count(*) from pg_proc where proname in ('share_token_grants_access','set_share_token');  -- 2
+-- 3. trips_select 정책에 share_token_grants_access 포함 여부
+select polname, pg_get_expr(polqual, polrelid) from pg_policy where polrelid='public.trips'::regclass;
+```
+
+빌드/타입 게이트:
+- `npm run build` (tsc + next build) — 성공 필수
+- `npm run lint` — 성공 필수
+
+## 회귀 위험
+
+- `trips_select`/`items_select` 정책을 `drop + create`로 교체. 멤버 접근 경로(`is_trip_member`, `user_role_in_trip`)는 유지하므로 기존 사용자 영향 없음.
+- `shares_select` 정책이 익명에게도 열려 있으나, `using` 조건이 본인 토큰으로 한정되어 enumeration 불가.
+- `set_share_token` RPC 가 `anon`에게 grant — 세션 변수 설정 외 다른 부수효과 없음.
+
+## Out of Scope (재확인)
+
+- `lodgings` 테이블 — 현재 스키마에 부재. 추가하지 않음.
+- 익명 read 호출 패턴 (#113 에서 RPC 단일 호출 vs `set_share_token` + 쿼리 패턴 확정).
+- 공유 페이지 UI.
+
+## 마이그레이션 파일명
+
+`supabase/migration_110_shares_table.sql` — 기존 `migration_NNN_*.sql` 컨벤션. 번호는 이슈 번호 그대로.

--- a/specs/109-shares-rls/spec.md
+++ b/specs/109-shares-rls/spec.md
@@ -1,0 +1,132 @@
+# Feature Specification: shares 테이블 + 익명 RLS 정책
+
+**Feature Branch**: `109-shares-rls`
+**Created**: 2026-05-20
+**Status**: Draft
+**Input**: GitHub Issue #110 — [share] shares 테이블 + 익명 RLS 정책
+
+## User Scenarios & Testing
+
+### User Story 1 — owner가 공유 토큰을 발급한다 (Priority: P1)
+
+여행 소유자가 자신의 trip에 대해 공유 토큰을 발급하여, 가입하지 않은 친구에게도 일정을 보여줄 수 있다.
+
+**Why this priority**: 마일스톤 1 Phase 5의 출발점. 토큰 발급 없이는 후속 공유 페이지(#113) 자체가 불가능하다.
+
+**Independent Test**: 로그인한 owner가 helper를 호출해 토큰을 받고, 토큰이 저장소에 기록되었음을 확인하면 검증 가능.
+
+**Acceptance Scenarios**:
+
+1. **Given** 로그인한 trip owner, **When** 해당 trip에 대해 공유 토큰 발급을 요청, **Then** 새 토큰이 생성되고 owner가 토큰 값을 받는다.
+2. **Given** owner가 아닌 멤버(editor/viewer), **When** 같은 trip에 대해 토큰 발급을 시도, **Then** 발급이 거부된다.
+3. **Given** owner가 자신이 멤버가 아닌 다른 trip, **When** 토큰 발급을 시도, **Then** 거부된다.
+
+---
+
+### User Story 2 — 익명 사용자가 토큰으로 read-only 조회한다 (Priority: P1)
+
+토큰을 가진 누구나(로그인 없이) 해당 trip의 일정·아이템·숙소를 읽을 수 있다.
+
+**Why this priority**: 공유 가치 자체. 익명 조회가 안 되면 토큰을 발급해도 의미가 없다.
+
+**Independent Test**: 익명 클라이언트로 token을 사용해 조회 → trip + items 데이터가 반환되는지 확인.
+
+**Acceptance Scenarios**:
+
+1. **Given** 유효한(만료/철회 안 됨) 토큰, **When** 익명 클라이언트가 토큰으로 trip을 조회, **Then** trip 메타데이터와 items 목록을 받는다.
+2. **Given** 익명 클라이언트, **When** 토큰 없이 임의의 trip을 조회, **Then** 결과가 비어 있다(RLS가 차단).
+3. **Given** 익명 클라이언트가 토큰을 가졌지만 다른 trip을 조회, **When** SELECT 요청, **Then** 결과가 비어 있다.
+
+---
+
+### User Story 3 — 만료/철회된 토큰은 거부된다 (Priority: P1)
+
+`expires_at`이 지났거나 `revoked_at`이 채워진 토큰으로는 더 이상 데이터에 접근할 수 없다.
+
+**Why this priority**: 공유 링크의 수명 제어가 없으면 사용자는 공유를 시작할 수 없다(되돌릴 수 없으므로).
+
+**Independent Test**: 만료된 토큰·철회된 토큰 각각으로 trip 조회 → 빈 결과.
+
+**Acceptance Scenarios**:
+
+1. **Given** `expires_at < now()`인 토큰, **When** 익명 조회, **Then** trip/items 결과 비어 있음.
+2. **Given** `revoked_at IS NOT NULL`인 토큰, **When** 익명 조회, **Then** 결과 비어 있음.
+3. **Given** owner, **When** 자신이 발급한 토큰의 `revoked_at`을 채움, **Then** 즉시 익명 접근 차단.
+
+---
+
+### User Story 4 — 익명 사용자는 쓰기 작업이 차단된다 (Priority: P1)
+
+토큰을 가진 익명 사용자라도 trip/items에 대한 INSERT/UPDATE/DELETE는 모두 거부된다.
+
+**Why this priority**: read-only 공유의 핵심 안전장치. 위반 시 데이터가 손상될 수 있다.
+
+**Independent Test**: 익명 클라이언트가 토큰을 들고 items에 INSERT/UPDATE/DELETE 시도 → 모두 거부.
+
+**Acceptance Scenarios**:
+
+1. **Given** 유효한 토큰을 가진 익명 클라이언트, **When** items INSERT 시도, **Then** RLS가 거부한다.
+2. **Given** 유효한 토큰을 가진 익명 클라이언트, **When** trips UPDATE 시도, **Then** 거부.
+3. **Given** 익명 클라이언트, **When** shares 테이블에 INSERT/DELETE 시도, **Then** 거부(owner만 가능).
+
+---
+
+### Edge Cases
+
+- 동일 trip에 여러 토큰이 발급되어 있고 일부만 만료된 경우 → 만료되지 않은 토큰 중 하나라도 유효하면 익명 조회 허용.
+- 토큰이 존재하지만 trip이 이미 삭제된 경우 → CASCADE로 shares도 함께 삭제되어 토큰이 자동 무효화.
+- `expires_at = NULL`인 토큰 → 만료 없음(영구). `revoked_at`으로만 무효화 가능.
+- owner가 trip의 owner 자격을 잃은(멤버에서 제거된) 경우 → 기존 토큰은 유효하게 유지(데이터 무결성 < 약속). 새 토큰 발급은 새 owner만 가능.
+- 같은 토큰 값이 충돌할 가능성 → UUID v4 사용으로 무시 가능한 수준.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: 시스템은 `shares` 저장소에 토큰(UUID), trip 참조, 생성자, 생성 시각, 만료 시각(optional), 철회 시각(optional)을 기록할 수 있어야 한다.
+- **FR-002**: trip의 owner 역할 멤버만 해당 trip에 대해 토큰을 발급할 수 있어야 한다.
+- **FR-003**: trip의 owner 역할 멤버만 자신이 발급한 토큰을 철회(`revoked_at` 기록)할 수 있어야 한다.
+- **FR-004**: 익명(비로그인) 요청도 토큰 값으로 정확히 1건을 lookup 할 수 있어야 한다(SELECT 허용).
+- **FR-005**: 익명 요청은 `shares` 테이블에 INSERT/UPDATE/DELETE를 수행할 수 없어야 한다.
+- **FR-006**: 유효한 토큰(만료 전 + 미철회)이 존재하는 trip은 익명 SELECT가 허용되어야 한다(trips, items, lodgings 존재 시).
+- **FR-007**: 익명 요청은 trips/items/lodgings에 대한 INSERT/UPDATE/DELETE가 모두 차단되어야 한다.
+- **FR-008**: 만료(`expires_at < now()`) 또는 철회(`revoked_at IS NOT NULL`)된 토큰은 익명 조회 자체를 더 이상 허용하지 않아야 한다.
+- **FR-009**: 토큰이 부여하는 익명 접근 범위는 해당 trip과 그 하위 데이터(items, lodgings)로 한정되어야 한다(다른 trip이 노출되어서는 안 됨).
+- **FR-010**: 기존 멤버(owner/editor/viewer)의 권한·정책은 본 변경으로 인해 영향받지 않아야 한다(회귀 금지).
+- **FR-011**: trip이 삭제되면 해당 trip의 모든 토큰은 자동으로 무효화되어야 한다.
+- **FR-012**: 애플리케이션은 토큰 발급 / 토큰으로 trip 조회 / 토큰 철회를 수행하는 헬퍼 인터페이스를 제공해야 한다.
+
+### Key Entities
+
+- **Share Token**: 익명 공유 접근을 부여하는 단일 자격증명.
+  - 토큰 값(추측 불가능한 식별자), 대상 trip 참조, 생성한 사용자, 생성/만료/철회 시각.
+  - 활성 조건: 철회되지 않았고, 만료 시각이 없거나 아직 도래하지 않음.
+
+## Success Criteria
+
+- **SC-001**: owner가 자신의 trip에 대해 토큰을 1회 발급하는 시도가 100% 성공한다.
+- **SC-002**: 비-owner 멤버 및 다른 trip의 owner가 토큰 발급을 시도하면 100% 거부된다.
+- **SC-003**: 유효한 토큰을 가진 익명 요청은 해당 trip의 메타데이터 + items 전체를 조회할 수 있다(빠짐 0건).
+- **SC-004**: 토큰 없는 익명 요청 또는 만료/철회된 토큰의 익명 요청은 trip/items 조회 결과가 항상 0건이다.
+- **SC-005**: 익명 요청의 INSERT/UPDATE/DELETE 시도는 trips, items, lodgings, shares 어디서도 성공하지 않는다(0건).
+- **SC-006**: 본 변경 전후로 로그인한 멤버의 기존 trip CRUD 동작에 회귀가 발생하지 않는다.
+
+## Assumptions
+
+- 토큰은 추측 불가능한 UUID로 충분하며 추가 비밀번호 보호는 본 이슈 범위 밖이다(#110 Out of Scope).
+- `lodgings` 테이블이 현재 스키마에 존재하지 않을 가능성이 있다. plan 단계에서 확인 후, 존재 시 items와 동일 패턴으로 RLS를 적용하고 부재 시 본 이슈에서 추가하지 않는다.
+- 토큰 발급 직후 즉시 활성으로 간주한다(별도 활성화 단계 없음).
+- 익명 SELECT는 Supabase의 `anon` 역할로 수행되며, 로그인 사용자(`authenticated`)와 자동 분리된다.
+- 마일스톤 1의 기존 RLS 패턴(`is_trip_member`, `user_role_in_trip` SECURITY DEFINER 헬퍼)과 일관성을 유지한다.
+
+## Dependencies
+
+- 선행: #107 Supabase Auth, #108 RLS + trip_members (완료됨).
+- 후속: #113 공유 페이지 `/share/{token}` — 본 이슈가 제공하는 토큰/RLS 위에서 UI 구현.
+
+## Out of Scope
+
+- 공유 페이지 UI / 라우트 (#113에서 처리)
+- 비밀번호 보호 공유
+- 만료 알림 / 자동 갱신
+- 공유 통계 / 조회 로그

--- a/specs/109-shares-rls/tasks.md
+++ b/specs/109-shares-rls/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: shares 테이블 + 익명 RLS 정책
+
+**Plan**: [plan.md](./plan.md)
+
+## T001 — 마이그레이션 작성
+
+파일: `supabase/migration_110_shares_table.sql`
+
+- [ ] `shares` 테이블 + `idx_shares_trip` 인덱스
+- [ ] `share_token_grants_access(uuid)` SECURITY DEFINER 함수
+- [ ] `set_share_token(uuid)` SECURITY DEFINER 함수 (anon 실행 가능)
+- [ ] `shares` 테이블 RLS 활성 + 4개 정책 (select/insert/update/delete)
+- [ ] `trips_select` 정책 갱신 (멤버 OR 토큰)
+- [ ] `items_select` 정책 갱신 (멤버 OR 토큰)
+- [ ] 파일 하단 검증 SQL 주석
+
+## T002 — `lib/share.ts` 구현
+
+파일: `lib/share.ts` (신규)
+
+- [ ] `Share` 타입 정의
+- [ ] `createShare(client, tripId, options?)` — owner only
+- [ ] `listSharesForTrip(client, tripId)` — owner 목록 조회
+- [ ] `revokeShare(client, token)` — `revoked_at` 기록
+- [ ] `applyShareTokenToSession(client, token)` — `set_share_token` RPC wrapper
+- [ ] JSDoc 한 줄씩만, 과한 주석 금지
+
+## T003 — 타입/빌드 검증
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+
+## T004 — 커밋 & PR
+
+- [ ] Conventional Commits 메시지(한국어)
+- [ ] PR 본문에 `Closes #110` + 검증 결과 + 남은 작업(#113 의존)

--- a/supabase/migration_110_shares_table.sql
+++ b/supabase/migration_110_shares_table.sql
@@ -1,0 +1,144 @@
+-- Issue #110 — shares 테이블 + 익명 RLS 정책
+-- 사전 조건: migration_108_rls_trip_members.sql 이 적용되어 있어야 한다
+--           (trips, trip_members, items, is_trip_member, user_role_in_trip 존재).
+-- Supabase SQL Editor 에서 한 번 실행. 트랜잭션 내에서 처리되어 부분 실패 시 롤백.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 1. shares 테이블
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.shares (
+  token              uuid        primary key default gen_random_uuid(),
+  trip_id            uuid        not null references public.trips(id) on delete cascade,
+  created_by_user_id uuid        not null references auth.users(id) on delete cascade,
+  created_at         timestamptz not null default now(),
+  expires_at         timestamptz,
+  revoked_at         timestamptz
+);
+
+create index if not exists idx_shares_trip on public.shares(trip_id);
+
+-- ---------------------------------------------------------------------------
+-- 2. 헬퍼 함수
+-- ---------------------------------------------------------------------------
+
+-- 익명 세션에 share token 을 주입한다 (#113 공유 페이지에서 매 요청 전 호출).
+-- set_config 의 세 번째 인자가 false 이면 세션 단위 — PostgREST 의 단일-요청-단일-트랜잭션
+-- 모델에서는 후속 쿼리에 영향을 주지 않으므로, 본 RPC 와 read 쿼리를 같은 요청에 묶거나
+-- (RPC 결과의 후처리), 단일 RPC 함수로 묶어 호출해야 한다. 자세한 패턴은 #113 에서 결정.
+create or replace function public.set_share_token(p_token uuid)
+returns void
+language sql
+volatile
+security definer
+set search_path = public
+as $$
+  select set_config('app.share_token', p_token::text, false);
+$$;
+
+revoke all on function public.set_share_token(uuid) from public;
+grant execute on function public.set_share_token(uuid) to anon, authenticated;
+
+-- 현재 세션 변수의 토큰이 해당 trip 에 대한 유효 share 인지 평가.
+-- 토큰 미설정 / 만료 / 철회 시 false.
+create or replace function public.share_token_grants_access(p_trip_id uuid)
+returns boolean
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select exists(
+    select 1 from public.shares s
+    where s.trip_id = p_trip_id
+      and s.token = nullif(current_setting('app.share_token', true), '')::uuid
+      and s.revoked_at is null
+      and (s.expires_at is null or s.expires_at > now())
+  )
+$$;
+
+revoke all on function public.share_token_grants_access(uuid) from public;
+grant execute on function public.share_token_grants_access(uuid) to anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 3. shares RLS
+-- ---------------------------------------------------------------------------
+
+alter table public.shares enable row level security;
+
+-- SELECT: 멤버는 자신이 속한 trip 의 모든 토큰 메타 조회 가능.
+-- 익명은 자신이 알고 있는(세션 변수에 설정한) 토큰 1건만 조회 가능 (enumeration 방지).
+drop policy if exists shares_select on public.shares;
+create policy shares_select on public.shares
+  for select
+  using (
+    public.is_trip_member(trip_id)
+    or token = nullif(current_setting('app.share_token', true), '')::uuid
+  );
+
+-- INSERT: 해당 trip 의 owner 만, created_by_user_id 는 본인으로 강제.
+drop policy if exists shares_insert on public.shares;
+create policy shares_insert on public.shares
+  for insert to authenticated
+  with check (
+    public.user_role_in_trip(trip_id) = 'owner'
+    and created_by_user_id = auth.uid()
+  );
+
+-- UPDATE: owner 만 (revoked_at 기록 용도).
+drop policy if exists shares_update on public.shares;
+create policy shares_update on public.shares
+  for update to authenticated
+  using (public.user_role_in_trip(trip_id) = 'owner')
+  with check (public.user_role_in_trip(trip_id) = 'owner');
+
+-- DELETE: owner 만.
+drop policy if exists shares_delete on public.shares;
+create policy shares_delete on public.shares
+  for delete to authenticated
+  using (public.user_role_in_trip(trip_id) = 'owner');
+
+-- ---------------------------------------------------------------------------
+-- 4. trips / items SELECT 정책 갱신 — 멤버이거나 유효한 share 토큰이 있으면 허용
+-- ---------------------------------------------------------------------------
+
+drop policy if exists trips_select on public.trips;
+create policy trips_select on public.trips
+  for select
+  using (
+    public.is_trip_member(id)
+    or public.share_token_grants_access(id)
+  );
+
+drop policy if exists items_select on public.items;
+create policy items_select on public.items
+  for select
+  using (
+    public.user_role_in_trip(trip_id) is not null
+    or public.share_token_grants_access(trip_id)
+  );
+
+-- INSERT/UPDATE/DELETE 정책 (trips, items, trip_members) 는 변경하지 않는다.
+-- 모두 auth.uid() / 멤버십 기반이므로 anon 역할은 자동으로 차단됨.
+
+commit;
+
+-- ---------------------------------------------------------------------------
+-- 검증 쿼리 (별도 실행):
+--   -- shares 테이블 존재 확인
+--   select count(*) from information_schema.tables
+--    where table_schema='public' and table_name='shares';            -- 1
+--
+--   -- 헬퍼 함수 존재 확인
+--   select proname from pg_proc
+--    where proname in ('share_token_grants_access','set_share_token')
+--    order by proname;                                               -- 2 rows
+--
+--   -- 정책 갱신 확인
+--   select polname, pg_get_expr(polqual, polrelid)
+--     from pg_policy
+--    where polrelid in ('public.trips'::regclass, 'public.items'::regclass)
+--      and polname in ('trips_select','items_select');
+-- ---------------------------------------------------------------------------


### PR DESCRIPTION
## 관련 이슈
Closes #110

## 변경 이유
마일스톤 1 Phase 5(공유)의 백엔드 토대. 후속 #113(공유 페이지 `/share/{token}`)이 이 위에서 동작한다. NestJS 토큰 미들웨어 대신 #121에서 결정된 "Supabase RLS 네이티브" 방향에 맞춰 RLS만으로 익명 공유를 표현.

## 변경 범위

### DB (`supabase/migration_110_shares_table.sql`)
- `shares` 테이블: `token uuid pk`, `trip_id`, `created_by_user_id`, `created_at`, `expires_at?`, `revoked_at?`
- 헬퍼 함수 (둘 다 `SECURITY DEFINER`)
  - `share_token_grants_access(trip_id)` — 현재 세션 변수의 토큰이 해당 trip 에 대해 유효한지 평가
  - `set_share_token(token)` — `anon`도 호출 가능, `set_config('app.share_token', ..., false)` 로 세션 주입
- RLS
  - `shares`: 멤버는 자기 trip 의 토큰 메타 전체 SELECT, 익명은 자신이 설정한 토큰 1건만 SELECT (enumeration 차단). INSERT/UPDATE/DELETE 는 `user_role_in_trip = 'owner'`
  - `trips_select`/`items_select`: 기존 멤버 조건 + `share_token_grants_access(...)` OR 추가
  - `trips`/`items` 의 INSERT/UPDATE/DELETE 정책은 변경하지 않음 → `anon` 자동 차단 유지

### 앱 (`lib/share.ts`)
- `createShare(client, tripId, { expiresAt? })` — owner 발급
- `listSharesForTrip(client, tripId)` — owner 컨텍스트 조회
- `revokeShare(client, token)` — `revoked_at` 기록
- `isShareActive(share)` — 만료/철회 판정 유틸
- `applyShareTokenToSession(client, token)` — `set_share_token` RPC wrapper (#113 에서 호출)

## 검증
- `npm run lint` ✅ (warning/error 0)
- `npm run build` ✅ (Next.js production build 성공)
- 마이그레이션은 `begin/commit` 트랜잭션 + `drop policy if exists` → 멱등, 부분 실패 시 롤백
- 파일 하단에 사후 확인용 검증 SQL 3종(테이블/함수/정책) 주석 포함
- DB 마이그레이션은 본 PR 머지 후 Supabase SQL Editor 에서 수동 실행 필요 (기존 `migration_108_*.sql` 운영 방식과 동일)

## 남은 작업 / 리스크

### 남은 작업 (#113 에서 처리)
- 익명 read 호출 패턴 확정: `set_share_token` RPC + 후속 쿼리 vs 단일 RPC 통합 — PostgREST 의 single-request-single-transaction 모델 때문에 `set_config` 의 유효 범위가 트랜잭션 한정인 점을 고려해야 함
- `/share/{token}` 라우트 + UI

### 리스크
- `shares_select` 정책이 익명에 열려 있지만 `token = nullif(current_setting('app.share_token', true), '')::uuid` 조건으로 본인 토큰 1건만 허용 → enumeration 불가
- `lodgings` 테이블은 현재 스키마에 부재 → 본 PR 에서 추가하지 않음. 추후 추가 시 같은 패턴으로 정책 갱신 필요
