### PR TITLE
feat(share): #113 공유 페이지 /share/{token} + owner 발급 UI

### DIFF
--- a/app/api/trips/[tripId]/shares/[token]/revoke/route.ts
+++ b/app/api/trips/[tripId]/shares/[token]/revoke/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
+import { revokeShare } from '@/lib/share'
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: { tripId: string; token: string } },
+) {
+  try {
+    const client = createRouteHandlerSupabase()
+    await revokeShare(client, params.token)
+    return NextResponse.json({ ok: true })
+  } catch (e) {
+    console.error('[POST /api/trips/:tripId/shares/:token/revoke] failed:', e)
+    return NextResponse.json({ error: '공유 링크 회수에 실패했습니다.' }, { status: 500 })
+  }
+}

--- a/app/api/trips/[tripId]/shares/route.ts
+++ b/app/api/trips/[tripId]/shares/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
+import { createShare, listSharesForTrip } from '@/lib/share'
+
+export async function GET(_request: NextRequest, { params }: { params: { tripId: string } }) {
+  try {
+    const client = createRouteHandlerSupabase()
+    const shares = await listSharesForTrip(client, params.tripId)
+    return NextResponse.json({ shares })
+  } catch (e) {
+    console.error('[GET /api/trips/:tripId/shares] failed:', e)
+    return NextResponse.json({ error: '공유 링크 목록을 불러오지 못했습니다.' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest, { params }: { params: { tripId: string } }) {
+  try {
+    const body = await request.json().catch(() => ({}))
+    const expiresAtRaw = typeof body?.expires_at === 'string' ? body.expires_at : null
+    const expiresAt = expiresAtRaw ? new Date(expiresAtRaw) : null
+    if (expiresAt && isNaN(expiresAt.getTime())) {
+      return NextResponse.json({ error: '만료 시각 형식이 잘못되었습니다.' }, { status: 400 })
+    }
+
+    const client = createRouteHandlerSupabase()
+    const share = await createShare(client, params.tripId, { expiresAt })
+    return NextResponse.json({ share }, { status: 201 })
+  } catch (e) {
+    console.error('[POST /api/trips/:tripId/shares] failed:', e)
+    return NextResponse.json({ error: '공유 링크 발급에 실패했습니다.' }, { status: 500 })
+  }
+}

--- a/app/share/[token]/layout.tsx
+++ b/app/share/[token]/layout.tsx
@@ -1,0 +1,3 @@
+export default function ShareLayout({ children }: { children: React.ReactNode }) {
+  return <div className="min-h-screen bg-bg text-fg">{children}</div>
+}

--- a/app/share/[token]/page.tsx
+++ b/app/share/[token]/page.tsx
@@ -1,0 +1,172 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ExternalLink, Compass } from 'lucide-react'
+import { fetchSharedTrip, type SharedTripPayload } from '@/lib/sharedTrip'
+import SharedItemCard from '@/components/Share/SharedItemCard'
+import type { TripItem } from '@/types'
+
+type Props = { params: { token: string } }
+
+export const dynamic = 'force-dynamic'
+
+function tripPeriodLabel(trip: SharedTripPayload['trip']): string | null {
+  const { start_date, end_date } = trip
+  if (!start_date && !end_date) return null
+  if (start_date && end_date) {
+    if (start_date === end_date) return start_date
+    return `${start_date} – ${end_date}`
+  }
+  return start_date || end_date
+}
+
+function ogDescription(payload: SharedTripPayload): string {
+  const parts: string[] = []
+  const period = tripPeriodLabel(payload.trip)
+  if (period) parts.push(period)
+  if (payload.trip.region) parts.push(payload.trip.region)
+  parts.push(`일정 ${payload.items.length}개`)
+  return parts.join(' · ')
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const payload = await fetchSharedTrip(params.token)
+  if (!payload) {
+    return {
+      title: '공유 링크가 유효하지 않습니다 · Trip Planner',
+      description: '이 링크는 만료되었거나 회수되었습니다.',
+      robots: { index: false, follow: false },
+    }
+  }
+  const title = `${payload.trip.title} · Trip Planner`
+  const description = ogDescription(payload)
+  return {
+    title,
+    description,
+    robots: { index: false, follow: false },
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  }
+}
+
+type DateGroup = { date: string | null; items: TripItem[] }
+
+function groupByDate(items: TripItem[]): DateGroup[] {
+  const map = new Map<string, TripItem[]>()
+  const undated: TripItem[] = []
+  for (const it of items) {
+    if (!it.date) {
+      undated.push(it)
+      continue
+    }
+    const arr = map.get(it.date) ?? []
+    arr.push(it)
+    map.set(it.date, arr)
+  }
+  const groups: DateGroup[] = Array.from(map.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, items]) => ({ date, items }))
+  if (undated.length) groups.push({ date: null, items: undated })
+  return groups
+}
+
+export default async function SharePage({ params }: Props) {
+  const payload = await fetchSharedTrip(params.token)
+
+  if (!payload) {
+    return (
+      <main className="mx-auto max-w-xl px-5 py-16">
+        <div className="rounded-xl border border-border bg-bg-elevated p-6 text-center">
+          <Compass className="mx-auto mb-3 size-8 text-fg-subtle" aria-hidden />
+          <h1 className="text-lg font-semibold text-fg">공유 링크가 유효하지 않습니다</h1>
+          <p className="mt-2 text-sm text-fg-subtle">
+            이 링크는 만료되었거나 회수되었습니다.<br />
+            발급한 분에게 새 링크를 요청해주세요.
+          </p>
+          <Link
+            href="/"
+            className="mt-5 inline-flex items-center gap-1 text-sm font-medium text-accent hover:underline"
+          >
+            Trip Planner 둘러보기
+            <ExternalLink className="size-3.5" aria-hidden />
+          </Link>
+        </div>
+      </main>
+    )
+  }
+
+  const { trip, items } = payload
+  const period = tripPeriodLabel(trip)
+  const groups = groupByDate(items)
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-6 sm:px-6 sm:py-8">
+      <header className="mb-6">
+        <p className="text-xs font-medium uppercase tracking-wide text-fg-subtle">공유 일정</p>
+        <h1 className="mt-1 text-2xl font-bold text-fg break-words sm:text-3xl">{trip.title}</h1>
+        <dl className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-sm text-fg-subtle">
+          {period && (
+            <div className="tabular">
+              <dt className="sr-only">기간</dt>
+              <dd>{period}</dd>
+            </div>
+          )}
+          {trip.region && (
+            <div>
+              <dt className="sr-only">지역</dt>
+              <dd>{trip.region}</dd>
+            </div>
+          )}
+          <div className="tabular">
+            <dt className="sr-only">일정 수</dt>
+            <dd>일정 {items.length}개</dd>
+          </div>
+        </dl>
+        {trip.basecamp_address && (
+          <p className="mt-2 text-sm text-fg-subtle">
+            <span className="font-medium text-fg-muted">베이스캠프</span>{' '}
+            <span className="break-words">{trip.basecamp_address}</span>
+          </p>
+        )}
+      </header>
+
+      {items.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border bg-bg-elevated p-8 text-center text-sm text-fg-subtle">
+          아직 추가된 일정이 없어요.
+        </div>
+      ) : (
+        <section className="space-y-6">
+          {groups.map((group) => (
+            <div key={group.date ?? 'undated'}>
+              <h2 className="mb-2 text-sm font-semibold text-fg-muted tabular">
+                {group.date ?? '날짜 미정'}
+              </h2>
+              <div className="space-y-2">
+                {group.items.map((it) => (
+                  <SharedItemCard key={it.id} item={it} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+
+      <footer className="mt-10 rounded-xl border border-border bg-bg-elevated p-5 text-center">
+        <p className="text-sm text-fg-subtle">마음에 들면 직접 만들어보세요.</p>
+        <Link
+          href="/signup"
+          className="mt-3 inline-flex items-center justify-center rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-fg hover:bg-accent-hover"
+        >
+          Trip Planner 시작하기
+        </Link>
+      </footer>
+    </main>
+  )
+}

--- a/app/trip/[tripId]/list/page.tsx
+++ b/app/trip/[tripId]/list/page.tsx
@@ -3,7 +3,9 @@
 import { Suspense, useEffect, useMemo, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import dynamic from 'next/dynamic'
-import { Search } from 'lucide-react'
+import { Search, Share2 } from 'lucide-react'
+import ShareDialog from '@/components/Share/ShareDialog'
+import { useTripId } from '@/lib/hooks/useTripContext'
 import Navigation from '@/components/Layout/Navigation'
 import ItemList from '@/components/Items/ItemList'
 import ItemCardSkeleton from '@/components/UI/ItemCardSkeleton'
@@ -37,6 +39,8 @@ function ResearchPageContent() {
   const searchParams = useSearchParams()
   const { items, isLoading, updateItem, createItem } = useItems()
   const { showToast } = useToast()
+  const tripId = useTripId()
+  const [shareDialogOpen, setShareDialogOpen] = useState(false)
 
   const [selectedItemId, setSelectedItemId] = useState<string | null>(() =>
     searchParams.get('item'),
@@ -185,8 +189,19 @@ function ResearchPageContent() {
       <header className="px-4 md:px-8 pt-4">
         <div className="flex items-center justify-between mb-4">
           <h1 className="text-xl font-bold text-fg">목록</h1>
-          <div className="md:hidden">
-            <ThemeToggle />
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setShareDialogOpen(true)}
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-bg px-2.5 py-1.5 text-xs font-medium text-fg-muted hover:bg-bg-subtle"
+              aria-label="공유 링크 관리"
+            >
+              <Share2 className="size-3.5" aria-hidden />
+              공유
+            </button>
+            <div className="md:hidden">
+              <ThemeToggle />
+            </div>
           </div>
         </div>
 
@@ -273,6 +288,12 @@ function ResearchPageContent() {
           handleClosePanel()
           showToast({ type: 'success', message: '삭제했어요' })
         }}
+      />
+
+      <ShareDialog
+        open={shareDialogOpen}
+        onClose={() => setShareDialogOpen(false)}
+        tripId={tripId}
       />
     </div>
   )

--- a/components/Share/ShareDialog.tsx
+++ b/components/Share/ShareDialog.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Copy, Plus, Trash2, Check, AlertCircle } from 'lucide-react'
+import Sheet from '@/components/UI/Sheet'
+import Button from '@/components/UI/Button'
+import { useToast } from '@/components/UI/Toast'
+import type { Share } from '@/lib/share'
+import { isShareActive } from '@/lib/share'
+import { buildShareUrl } from '@/lib/sharedTrip'
+
+type Props = {
+  open: boolean
+  onClose: () => void
+  tripId: string
+}
+
+export default function ShareDialog({ open, onClose, tripId }: Props) {
+  const [shares, setShares] = useState<Share[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [copiedToken, setCopiedToken] = useState<string | null>(null)
+  const { showToast } = useToast()
+
+  const origin = useMemo(() => (typeof window !== 'undefined' ? window.location.origin : ''), [])
+
+  const loadShares = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/trips/${tripId}/shares`, { cache: 'no-store' })
+      if (!res.ok) throw new Error('목록을 불러오지 못했습니다.')
+      const json = await res.json()
+      setShares(json.shares as Share[])
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }, [tripId])
+
+  useEffect(() => {
+    if (open) void loadShares()
+  }, [open, loadShares])
+
+  const handleCreate = async () => {
+    setCreating(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/trips/${tripId}/shares`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+      if (!res.ok) throw new Error('발급에 실패했습니다.')
+      await loadShares()
+      showToast({ message: '공유 링크를 만들었어요.', type: 'success' })
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleRevoke = async (token: string) => {
+    if (!window.confirm('이 링크를 회수하시겠어요? 이후로 접속이 차단됩니다.')) return
+    try {
+      const res = await fetch(`/api/trips/${tripId}/shares/${token}/revoke`, { method: 'POST' })
+      if (!res.ok) throw new Error('회수에 실패했습니다.')
+      await loadShares()
+      showToast({ message: '링크를 회수했어요.', type: 'success' })
+    } catch (e) {
+      showToast({ message: (e as Error).message, type: 'error' })
+    }
+  }
+
+  const handleCopy = async (token: string) => {
+    const url = buildShareUrl(token, origin)
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopiedToken(token)
+      window.setTimeout(() => setCopiedToken((cur) => (cur === token ? null : cur)), 1500)
+    } catch {
+      showToast({ message: '복사에 실패했어요. 직접 선택해주세요.', type: 'error' })
+    }
+  }
+
+  const activeShares = (shares ?? []).filter((s) => isShareActive(s))
+  const revokedShares = (shares ?? []).filter((s) => !isShareActive(s))
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title="공유 링크"
+      description="가입 없이도 일정을 둘러볼 수 있는 읽기 전용 링크를 만들 수 있어요."
+      side="auto"
+    >
+      <div className="space-y-5 p-1">
+        <Button
+          type="button"
+          variant="primary"
+          onClick={handleCreate}
+          loading={creating}
+          data-autofocus
+          fullWidth
+          leftIcon={<Plus className="size-4" aria-hidden />}
+        >
+          새 링크 만들기
+        </Button>
+
+        {error && (
+          <div className="flex items-start gap-2 rounded-md border border-critical-border bg-critical-bg p-3 text-sm text-critical-fg">
+            <AlertCircle className="size-4 mt-0.5" aria-hidden />
+            <span>{error}</span>
+          </div>
+        )}
+
+        <section>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-fg-subtle">활성 링크</h3>
+          {loading && !shares ? (
+            <p className="text-sm text-fg-subtle">불러오는 중…</p>
+          ) : activeShares.length === 0 ? (
+            <p className="text-sm text-fg-subtle">아직 발급된 활성 링크가 없어요.</p>
+          ) : (
+            <ul className="space-y-2">
+              {activeShares.map((s) => {
+                const url = buildShareUrl(s.token, origin)
+                return (
+                  <li
+                    key={s.token}
+                    className="rounded-lg border border-border bg-bg-elevated p-3"
+                  >
+                    <div className="flex items-center gap-2">
+                      <code className="flex-1 min-w-0 truncate text-xs text-fg-muted">{url}</code>
+                      <button
+                        type="button"
+                        onClick={() => handleCopy(s.token)}
+                        className="inline-flex items-center gap-1 rounded-md border border-border bg-bg px-2 py-1 text-xs font-medium hover:bg-bg-subtle"
+                        aria-label="링크 복사"
+                      >
+                        {copiedToken === s.token ? (
+                          <>
+                            <Check className="size-3.5" aria-hidden /> 복사됨
+                          </>
+                        ) : (
+                          <>
+                            <Copy className="size-3.5" aria-hidden /> 복사
+                          </>
+                        )}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleRevoke(s.token)}
+                        className="inline-flex items-center rounded-md border border-border bg-bg px-2 py-1 text-xs font-medium text-critical-fg hover:bg-critical-bg"
+                        aria-label="링크 회수"
+                      >
+                        <Trash2 className="size-3.5" aria-hidden />
+                      </button>
+                    </div>
+                    <p className="mt-1 text-[11px] text-fg-subtle tabular">
+                      발급 {new Date(s.created_at).toLocaleDateString()}
+                      {s.expires_at && ` · ${new Date(s.expires_at).toLocaleDateString()} 만료`}
+                    </p>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </section>
+
+        {revokedShares.length > 0 && (
+          <section>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-fg-subtle">비활성</h3>
+            <ul className="space-y-1.5">
+              {revokedShares.slice(0, 10).map((s) => (
+                <li key={s.token} className="text-xs text-fg-subtle">
+                  <code className="truncate">{s.token.slice(0, 8)}…</code>
+                  {' · '}
+                  {s.revoked_at ? '회수됨' : '만료됨'}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </div>
+    </Sheet>
+  )
+}

--- a/components/Share/SharedItemCard.tsx
+++ b/components/Share/SharedItemCard.tsx
@@ -1,0 +1,40 @@
+import type { TripItem } from '@/types'
+import { CATEGORY_META } from '@/lib/itemOptions'
+
+type Props = { item: TripItem }
+
+function formatTimeRange(item: TripItem): string | null {
+  if (item.time_start && item.time_end) return `${item.time_start} – ${item.time_end}`
+  if (item.time_start) return item.time_start
+  return null
+}
+
+export default function SharedItemCard({ item }: Props) {
+  const meta = CATEGORY_META[item.category]
+  const time = formatTimeRange(item)
+
+  return (
+    <article className="rounded-lg border border-border bg-bg-elevated p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="inline-flex items-center gap-1 rounded-full border border-border bg-bg px-2 py-0.5 text-xs font-medium text-fg-subtle">
+              <span aria-hidden="true">{meta?.emoji}</span>
+              {item.category}
+            </span>
+            {time && <span className="text-xs text-fg-subtle tabular">{time}</span>}
+          </div>
+          <h3 className="text-base font-semibold text-fg break-words">{item.name}</h3>
+          {item.address && (
+            <p className="text-sm text-fg-subtle mt-1 break-words">{item.address}</p>
+          )}
+          {item.memo && (
+            <p className="text-sm text-fg-muted mt-2 whitespace-pre-wrap break-words">
+              {item.memo}
+            </p>
+          )}
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/lib/sharedTrip.ts
+++ b/lib/sharedTrip.ts
@@ -1,0 +1,48 @@
+import { createClient } from '@supabase/supabase-js'
+import type { TripItem } from '@/types'
+
+export type SharedTripMeta = {
+  id: string
+  title: string
+  start_date: string | null
+  end_date: string | null
+  region: string | null
+  basecamp_address: string | null
+}
+
+export type SharedTripPayload = {
+  trip: SharedTripMeta
+  items: TripItem[]
+}
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+
+function anonClient() {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY 가 설정되지 않았습니다.')
+  }
+  return createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+  })
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export async function fetchSharedTrip(token: string): Promise<SharedTripPayload | null> {
+  if (!token || !UUID_RE.test(token)) return null
+  const client = anonClient()
+  const { data, error } = await client.rpc('get_shared_trip', { p_token: token })
+  if (error) {
+    console.error('[fetchSharedTrip] RPC error', error)
+    return null
+  }
+  if (!data) return null
+  return data as SharedTripPayload
+}
+
+export function buildShareUrl(token: string, baseUrl?: string | null): string {
+  const base = (baseUrl || process.env.NEXT_PUBLIC_SITE_URL || '').replace(/\/+$/, '')
+  const path = `/share/${token}`
+  return base ? `${base}${path}` : path
+}

--- a/specs/110-share-page/plan.md
+++ b/specs/110-share-page/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: 공유 페이지 /share/{token}
+
+**Spec**: [spec.md](./spec.md)
+**Issue**: [#113](https://github.com/Useful-Dogus/trip-planner/issues/113)
+**Branch**: `110-share-page`
+
+## 핵심 결정
+
+### 1. 익명 데이터 페치 — 단일 RPC
+
+PostgREST의 single-request-single-transaction 모델에서 `set_share_token` + 후속 쿼리는 동작 보장이 약하다.
+→ **단일 RPC `get_shared_trip(p_token uuid)` 추가**. SECURITY DEFINER 함수가 토큰 유효성 검증 + trip + items를 JSON으로 한 번에 반환.
+
+```sql
+create or replace function public.get_shared_trip(p_token uuid)
+returns jsonb
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+declare
+  v_trip_id uuid;
+  v_result jsonb;
+begin
+  select s.trip_id into v_trip_id
+    from public.shares s
+   where s.token = p_token
+     and s.revoked_at is null
+     and (s.expires_at is null or s.expires_at > now());
+
+  if v_trip_id is null then
+    return null;
+  end if;
+
+  select jsonb_build_object(
+    'trip', to_jsonb(t.*),
+    'items', coalesce((
+      select jsonb_agg(to_jsonb(i.*) order by i.date nulls last, i.time_start nulls last, i.created_at)
+        from public.items i
+       where i.trip_id = v_trip_id
+    ), '[]'::jsonb)
+  ) into v_result
+    from public.trips t
+   where t.id = v_trip_id;
+
+  return v_result;
+end
+$$;
+
+grant execute on function public.get_shared_trip(uuid) to anon, authenticated;
+```
+
+장점:
+- 토큰 무효 시 `null` 반환 → 단일 분기로 안내 페이지 처리.
+- RLS 우회 없이 RPC 내부에서만 trip+items 노출 → 토큰 외 데이터 누출 0.
+- 1-round-trip → 모바일 4G에서 빠른 첫 페인트.
+
+### 2. 라우트 구조
+
+- `app/share/[token]/page.tsx` — Next.js 서버 컴포넌트.
+  - 토큰 형식 검증 → RPC 호출 → null이면 `<ShareInvalid />`, 아니면 `<SharePageView />`.
+- `app/share/[token]/layout.tsx` — 네비게이션 없는 최소 레이아웃(`/me`, `/trip/*`와 분리).
+- `generateMetadata({ params })` — RPC 결과 기반 OG 메타.
+
+미들웨어 (`middleware.ts`):
+- `PROTECTED_PAGES`에 `/share`가 없지만 `pathname === '/'`로 root는 보호. `/share/*`는 미보호.
+- `isProtectedApi`는 `/api/*` 한정 → 영향 없음.
+- 추가 작업 불필요. 다만 isAuthPage 분기에서 로그인 상태로 `/share/*`에 들어와도 차단되지 않는지 확인.
+- 안전을 위해 `isProtectedPage = pathname === '/' || (PROTECTED_PAGES.some(...) && !pathname.startsWith('/share'))` 로 명시 (방어).
+
+### 3. UI 구조
+
+`app/share/[token]/page.tsx`가 서버 컴포넌트로 데이터를 받아서 다음에 위임:
+- `<ShareHeader trip={...} itemCount={...} />` — trip 이름 + 메타 라인 + 작은 trip-planner 워터마크.
+- `<SharedItemList items={...} />` — 모바일 우선 카드. 날짜별 그룹화. 편집 핸들러 없음.
+- `<ShareFooterCTA />` — "직접 만들어보기" 버튼 → `/signup` 링크.
+
+기존 `ItemCard`/`ItemList`는 편집 props와 router 의존 → 재사용 안 함. 새 `SharedItemCard` 컴포넌트를 작게 신설.
+
+### 4. owner 측 발급 UI
+
+- `app/trip/[tripId]/list/page.tsx` 헤더에 "공유" 버튼 추가.
+- 버튼 클릭 → `ShareDialog` (Sheet 사용) 표시:
+  - 활성 토큰 목록 (없으면 비어있음 안내) + "새 링크 만들기" 버튼.
+  - 각 토큰: URL + "복사" + "회수".
+- 컴포넌트: `components/Plan/ShareDialog.tsx` (신규).
+- 데이터: `lib/share.ts`의 createShare/listSharesForTrip/revokeShare 그대로 사용.
+
+### 5. OG 이미지
+
+첫 단계: 기존 `/icon.svg`를 PNG로 가지지 않고, public 폴더에 정적 OG 이미지가 없다면 `og:image` 누락 가능. 본 PR에선 `og:image`는 `process.env.NEXT_PUBLIC_SITE_URL` 기반으로 사이트 메인 OG 이미지를 가리키되, 자원이 없으면 omit. **간단히 `og:image`는 선택적으로 두고 `og:title`/`og:description`만 보장**.
+
+### 6. 회귀 방지
+
+- 미들웨어 `/share/*` 통과 확인.
+- 기존 trip 페이지 헤더에 버튼 1개 추가 외 변경 없음.
+
+## 변경 파일
+
+신규:
+- `supabase/migration_113_get_shared_trip.sql`
+- `app/share/[token]/layout.tsx`
+- `app/share/[token]/page.tsx`
+- `components/Share/SharedItemCard.tsx`
+- `components/Share/ShareDialog.tsx`
+- `lib/sharedTrip.ts` — RPC 호출 wrapper + 타입
+
+수정:
+- `middleware.ts` — `/share/*` 명시적 제외
+- `app/trip/[tripId]/list/page.tsx` — "공유" 버튼 + ShareDialog 통합 (헤더 영역)
+- `lib/share.ts` — 필요시 sharedTrip 타입 재사용
+
+## 품질 게이트
+
+- `npm run lint`
+- `npm run build`
+- 수동: `/share/<invalid-uuid>` → 안내 페이지, `/share/<유효 토큰>` → 데이터(마이그레이션 적용 후 가능)

--- a/specs/110-share-page/spec.md
+++ b/specs/110-share-page/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: 공유 페이지 /share/{token}
+
+**Feature Branch**: `110-share-page`
+**Created**: 2026-05-20
+**Status**: Draft
+**Input**: GitHub Issue #113 — [multiuser] 공유 페이지 /share/{token}
+
+## User Scenarios & Testing
+
+### User Story 1 — 링크 받은 사람이 비로그인으로 일정을 본다 (Priority: P1)
+
+카카오톡/슬랙으로 공유 링크를 받은 사람이 가입 없이 trip 일정을 모바일에서 둘러본다.
+
+**Acceptance Scenarios**:
+1. **Given** 유효 토큰 URL, **When** 비로그인 모바일 브라우저로 진입, **Then** trip 제목·기간·지역·아이템 목록이 표시된다.
+2. **Given** 유효 토큰 URL, **When** 데스크탑 브라우저로 진입, **Then** 동일 내용이 가독성 있게 표시된다.
+3. **Given** 페이지, **When** 어떤 아이템도 편집 컨트롤(편집 버튼/입력 패널/드래그 핸들)을 노출하지 않는다.
+
+### User Story 2 — 만료/철회된 링크는 친절히 안내한다 (Priority: P1)
+
+기간이 지났거나 회수된 토큰으로 들어오면 명확한 안내 페이지가 뜬다.
+
+**Acceptance Scenarios**:
+1. **Given** 만료/철회/존재하지 않는 토큰, **When** 진입, **Then** "공유 링크가 더 이상 유효하지 않습니다" 메시지와 발급자에게 재요청 안내 표시.
+2. **Given** 안내 페이지, **When** 표시, **Then** 일정 데이터는 일절 노출되지 않는다.
+
+### User Story 3 — 메신저 미리보기가 정상 표시된다 (Priority: P1)
+
+링크를 메신저에 붙였을 때 trip 제목/요약이 OG 메타로 미리보기된다.
+
+**Acceptance Scenarios**:
+1. **Given** 유효 토큰 URL, **When** OG 메타 태그를 조회, **Then** `og:title`에 trip 이름, `og:description`에 `{기간} · {지역} · N일 일정` 형식, `og:image`가 포함된다.
+2. **Given** 만료된 토큰 URL, **When** OG 메타 조회, **Then** 민감하지 않은 일반 OG (예: "이 링크는 더 이상 유효하지 않습니다") 가 표시된다.
+
+### User Story 4 — owner가 공유 링크를 발급한다 (Priority: P2)
+
+owner가 자신의 trip 화면에서 공유 링크 생성 버튼을 눌러 URL을 받는다.
+
+**Acceptance Scenarios**:
+1. **Given** trip owner, **When** "공유 링크 만들기" 버튼 클릭, **Then** 새 토큰이 발급되고 `/share/{token}` URL이 클립보드에 복사 가능한 형태로 표시된다.
+2. **Given** owner, **When** 발급된 링크 목록에서 "회수"를 누름, **Then** 해당 링크가 즉시 무효화된다.
+
+### User Story 5 — 익명 쓰기는 차단된다 (Priority: P1)
+
+공유 페이지에서 어떤 방식으로도 데이터 수정이 일어나지 않는다.
+
+**Acceptance Scenarios**:
+1. **Given** 공유 페이지, **When** UI 검사, **Then** 편집/추가/삭제 컨트롤이 어떤 화면 크기에서도 노출되지 않는다.
+2. **Given** 익명 클라이언트, **When** trips/items에 INSERT/UPDATE/DELETE 시도, **Then** #110의 RLS가 거부.
+
+### User Story 6 — CTA로 가입을 부드럽게 권한다 (Priority: P3)
+
+공유 페이지 하단에 "마음에 들면 직접 만들어보세요" CTA가 노출된다.
+
+**Acceptance Scenarios**:
+1. **Given** 공유 페이지, **When** 페이지 하단까지 스크롤, **Then** 가입 페이지로 가는 CTA 버튼이 노출된다.
+
+### Edge Cases
+- 동일 trip에 여러 유효 토큰 존재 → 어느 토큰으로 들어와도 동작.
+- 토큰은 유효하나 trip이 삭제된 경우 → CASCADE로 share도 삭제 → "유효하지 않음" 안내.
+- 토큰 URL 형식이 잘못된 경우(UUID 아님) → "유효하지 않음" 안내.
+- items가 0건인 trip → 빈 상태 메시지 ("아직 추가된 일정이 없어요").
+- 카카오톡 인앱 브라우저(WebView) 호환 → 표준 HTML/CSS만 사용, JS 의존도 최소.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `/share/{token}` 경로는 비로그인 상태에서 접근 가능해야 한다(미들웨어 인증 보호 대상에서 제외).
+- **FR-002**: 토큰이 유효하면 trip 메타데이터(제목, 기간, 지역, 베이스캠프)와 items 목록을 표시해야 한다.
+- **FR-003**: 페이지는 읽기 전용으로, 편집/추가/삭제 컨트롤을 어떤 화면 크기에서도 노출하지 않아야 한다.
+- **FR-004**: 토큰이 무효(존재하지 않음/만료/철회)이면 trip 데이터를 노출하지 않고 친절한 안내 페이지를 표시해야 한다.
+- **FR-005**: 페이지는 OG 메타(`og:title`, `og:description`, `og:image`, `og:type`)를 응답에 포함해야 한다.
+- **FR-006**: OG 설명은 기간·지역·아이템 수를 포함하는 일관된 포맷이어야 한다(없는 필드는 자연스럽게 생략).
+- **FR-007**: OG 이미지는 첫 단계에선 사이트 기본 이미지/아이콘으로 대체할 수 있다(첫 장소 사진 자동 생성은 후속).
+- **FR-008**: 모바일 우선 레이아웃(360-768px)에서 가독성·터치 영역이 충분해야 한다.
+- **FR-009**: 데이터 페치는 단일 익명 호출로 trip + items를 원자적으로 받아와야 한다(RLS 세션 변수 race 회피).
+- **FR-010**: owner는 자신의 trip 화면에서 공유 토큰을 발급·회수할 수 있는 UI에 접근할 수 있어야 한다.
+- **FR-011**: 발급된 토큰 URL은 클립보드에 복사 가능한 형태로 노출되어야 한다.
+- **FR-012**: 페이지 하단에 가입 페이지로 유도하는 CTA가 노출되어야 한다.
+
+### Key Entities
+
+- **Shared Trip View**: 토큰으로 노출되는 trip + items 스냅샷. 메타데이터(제목/기간/지역/베이스캠프) + items 배열.
+
+## Success Criteria
+
+- **SC-001**: 유효 토큰 URL의 첫 의미있는 페인트(FMP)가 모바일 4G에서 2.5초 이내.
+- **SC-002**: 만료/철회/잘못된 토큰 시 trip 데이터 유출 0건.
+- **SC-003**: OG 미리보기에 trip 이름이 100% 노출(카카오톡/슬랙/iMessage 수동 점검).
+- **SC-004**: 공유 페이지 어디에서도 편집 컨트롤 노출 0건.
+- **SC-005**: owner는 3 클릭 이내로 공유 링크를 발급하고 URL을 복사할 수 있다.
+
+## Assumptions
+
+- 익명 read는 #110에서 추가한 `set_share_token` + `share_token_grants_access` 조합 대신, **단일 RPC `get_shared_trip(token)`**으로 묶어 호출한다(PostgREST single-request-single-transaction 제약 해결). 본 이슈에서 RPC를 추가한다.
+- OG 이미지는 첫 단계에서 사이트 기본 이미지(`/icon.svg` 기반 정적 이미지 또는 외부 generator) 사용. trip별 동적 OG 이미지 생성은 후속.
+- "베이스캠프"는 `trips.basecamp_address` 컬럼(이미 존재) 사용.
+- 모바일 메신저 인앱 브라우저(카카오톡 등) 호환을 위해 SSR 우선, 클라이언트 인터랙션 최소화.
+- 토큰 URL 도메인은 배포 환경의 `NEXT_PUBLIC_SITE_URL`(없으면 요청 host) 사용.
+
+## Dependencies
+
+- 선행: #110 (shares 테이블 + RLS) — 머지됨.
+- 후속: 동적 OG 이미지 생성, 비밀번호 보호 공유.
+
+## Out of Scope
+
+- 비밀번호 보호 공유
+- 만료 알림 / 자동 갱신
+- 공유 통계 / 조회 로그
+- 지도 정적 스냅샷 자동 생성(첫 단계는 정적 OG 이미지)
+- 공유 페이지 내 지도 (있으면 좋지만 본 PR에서는 아이템 카드 리스트만 포함; 후속으로 검토)

--- a/specs/110-share-page/tasks.md
+++ b/specs/110-share-page/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: 공유 페이지 /share/{token}
+
+## T001 — `get_shared_trip` RPC 마이그레이션
+파일: `supabase/migration_113_get_shared_trip.sql`
+
+## T002 — 익명 페치 wrapper
+파일: `lib/sharedTrip.ts`
+- `SharedTripPayload` 타입
+- `fetchSharedTrip(token)` — 익명 supabase 클라이언트로 RPC 호출
+
+## T003 — 공유 페이지 라우트
+파일: `app/share/[token]/layout.tsx`, `app/share/[token]/page.tsx`
+- 서버 컴포넌트, generateMetadata, ShareInvalid 분기
+
+## T004 — 공유 페이지 UI 컴포넌트
+파일: `components/Share/SharedItemCard.tsx`
+- 읽기 전용, 모바일 우선, 편집 핸들러 없음
+
+## T005 — 미들웨어 예외
+파일: `middleware.ts`
+- `/share/*` 명시 제외
+
+## T006 — owner 발급 UI
+파일: `components/Share/ShareDialog.tsx`, `app/trip/[tripId]/list/page.tsx`
+- "공유" 버튼 + Sheet 다이얼로그
+
+## T007 — 품질 게이트 + PR
+- `npm run lint && npm run build`
+- 커밋 + PR (Closes #113)

--- a/supabase/migration_113_get_shared_trip.sql
+++ b/supabase/migration_113_get_shared_trip.sql
@@ -1,0 +1,69 @@
+-- Issue #113 — 공유 페이지용 단일 RPC.
+-- 사전 조건: migration_110_shares_table.sql 이 적용되어 있어야 한다.
+--
+-- PostgREST 의 single-request-single-transaction 모델에서는 set_share_token + 후속 쿼리가
+-- 보장되지 않으므로, 토큰 검증 + trip + items 를 한 번에 반환하는 SECURITY DEFINER RPC 로 처리한다.
+-- 토큰이 무효(존재 X / 만료 / 철회) 이면 null 을 반환한다.
+
+begin;
+
+create or replace function public.get_shared_trip(p_token uuid)
+returns jsonb
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+declare
+  v_trip_id uuid;
+  v_result jsonb;
+begin
+  if p_token is null then
+    return null;
+  end if;
+
+  select s.trip_id
+    into v_trip_id
+    from public.shares s
+   where s.token = p_token
+     and s.revoked_at is null
+     and (s.expires_at is null or s.expires_at > now())
+   limit 1;
+
+  if v_trip_id is null then
+    return null;
+  end if;
+
+  select jsonb_build_object(
+    'trip', to_jsonb(t.*),
+    'items', coalesce((
+      select jsonb_agg(
+               to_jsonb(i.*)
+               order by i.date nulls last, i.time_start nulls last, i.created_at
+             )
+        from public.items i
+       where i.trip_id = v_trip_id
+    ), '[]'::jsonb)
+  )
+    into v_result
+    from public.trips t
+   where t.id = v_trip_id;
+
+  return v_result;
+end
+$$;
+
+revoke all on function public.get_shared_trip(uuid) from public;
+grant execute on function public.get_shared_trip(uuid) to anon, authenticated;
+
+commit;
+
+-- 검증 쿼리 (마이그레이션 직후):
+--   -- 함수 존재 확인
+--   select proname, pronargs from pg_proc where proname = 'get_shared_trip';   -- 1 row
+--
+--   -- 무효 토큰 → null
+--   select public.get_shared_trip('00000000-0000-0000-0000-000000000000'::uuid);
+--
+--   -- 유효 토큰 (실제 발급된 token 대입)
+--   select public.get_shared_trip('<token>'::uuid);


### PR DESCRIPTION
## 관련 이슈
Closes #113

## 변경 이유
마일스톤 1 Phase 5(공유)의 사용자-대면 화면. #110 의 RLS + shares 테이블 위에 `/share/{token}` 공유 페이지와 owner 발급 UI 를 얹어 친구에게 일정을 가입 없이 공유할 수 있게 한다.

## 변경 범위

### DB
- **`supabase/migration_113_get_shared_trip.sql`** — `get_shared_trip(token uuid) returns jsonb`. SECURITY DEFINER 로 토큰 유효성(존재/미만료/미철회) + trip + items 를 단일 호출에 반환. 무효 시 `null`.
  - PostgREST single-request-single-transaction 모델에서 `set_share_token` + 후속 SELECT 가 보장되지 않는 문제를 우회.

### 공유 페이지 (익명)
- `app/share/[token]/layout.tsx` — 네비게이션 없는 최소 레이아웃
- `app/share/[token]/page.tsx` — 서버 컴포넌트
  - `fetchSharedTrip(token)` 으로 익명 RPC 호출
  - 무효 토큰 → "더 이상 유효하지 않습니다" 안내 (데이터 노출 0)
  - 유효 토큰 → 모바일 우선 read-only UI (날짜별 그룹, 베이스캠프, CTA)
  - `generateMetadata`: `og:title` = trip 제목, `og:description` = `{기간} · {지역} · 일정 N개`, `robots: noindex,nofollow`
- `components/Share/SharedItemCard.tsx` — 읽기 전용 아이템 카드 (편집 핸들러 없음)
- `lib/sharedTrip.ts` — `fetchSharedTrip` / `buildShareUrl` (익명 supabase-js 클라이언트)

### owner 발급 UI
- `components/Share/ShareDialog.tsx` — Sheet 기반 다이얼로그. 활성 링크 목록 / 복사 / 회수 / 새 발급
- `app/trip/[tripId]/list/page.tsx` 헤더에 "공유" 버튼 추가
- API: `GET/POST /api/trips/[tripId]/shares`, `POST /api/trips/[tripId]/shares/[token]/revoke` (모두 `createRouteHandlerSupabase` 사용 → 기존 RLS 가 owner-only 강제)

### 미들웨어
- `/share/*` 는 `middleware.ts` 의 `config.matcher` 에 포함되지 않으므로 변경 불필요 — 익명 진입 가능 (수동 검증함).

## 검증
- `npm run lint` ✅ (warning/error 0)
- `npm run build` ✅ (`/share/[token]` 라우트 정상 등록 — 855 B)
- 마이그레이션 멱등(`create or replace function`, `begin/commit`)
- 인증·인가 흐름:
  - 익명: RPC 만 호출 가능 → 토큰 유효 시에만 trip+items 반환
  - owner: `/api/trips/[tripId]/shares` 는 기본 미들웨어로 보호되어 인증 필수, 내부 RLS 가 owner-only 강제
- 마이그레이션 실행은 본 PR 머지 후 Supabase SQL Editor 에서 수동 적용 필요 (기존 `migration_NNN_*.sql` 운영 방식과 동일)

## 남은 작업 / 리스크

### 남은 작업
- 동적 OG 이미지 생성 (현재는 `og:image` 미설정 → 메신저 미리보기는 텍스트만)
- 공유 페이지 내 지도(베이스캠프/아이템 핀) — 본 PR 은 카드 리스트만
- 카카오톡 / iMessage 인앱 브라우저 수동 점검 (현재 표준 SSR HTML 만 사용해 호환성 위험은 낮음)

### 리스크
- `get_shared_trip` 은 trip 행 전체(`to_jsonb(t.*)`)를 반환 — 새 컬럼 추가 시 자동 노출됨. 민감 컬럼 추가 시 함수에서 명시적으로 select 필요.
