### PR TITLE
feat(basics): #142 G-1 TripProvider 확장 + 모든 trip 페이지에 trip 이름 표시

### DIFF
--- a/app/trip/[tripId]/gmaps-import/page.tsx
+++ b/app/trip/[tripId]/gmaps-import/page.tsx
@@ -6,6 +6,7 @@ import Navigation from '@/components/Layout/Navigation'
 import UrlInput from '@/components/GmapsImport/UrlInput'
 import CandidateList from '@/components/GmapsImport/CandidateList'
 import { useTripPath } from '@/lib/hooks/useTripContext'
+import TripPageTitle from '@/components/UI/TripPageTitle'
 import type { ImportCandidate } from '@/types'
 
 type PageState = 'idle' | 'loading' | 'review' | 'importing' | 'done'
@@ -108,7 +109,7 @@ export default function GmapsImportPage() {
     <div className="md:pl-44 min-h-screen bg-bg-elevated">
       <div className="max-w-2xl mx-auto px-4 py-8 pb-24 md:pb-8">
         <div className="mb-6">
-          <h1 className="text-xl font-bold text-fg">구글맵 연동</h1>
+          <TripPageTitle section="구글맵 연동" />
           <p className="text-sm text-fg-muted mt-1">
             구글맵 공개 리스트에서 장소를 가져와 추가합니다.
           </p>

--- a/app/trip/[tripId]/items/[id]/edit/page.tsx
+++ b/app/trip/[tripId]/items/[id]/edit/page.tsx
@@ -5,6 +5,7 @@ import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 import Navigation from '@/components/Layout/Navigation'
 import ItemForm from '@/components/Items/ItemForm'
 import { buildTripPath } from '@/lib/hooks/useTripContext'
+import TripContextLabel from '@/components/UI/TripContextLabel'
 
 export default async function EditItemPage({
   params,
@@ -19,14 +20,17 @@ export default async function EditItemPage({
   return (
     <div className="md:pl-44">
       <div className="max-w-lg mx-auto px-4 py-6">
-        <div className="flex items-center gap-3 mb-6">
-          <Link
-            href={buildTripPath(params.tripId, `items/${item.id}`)}
-            className="text-sm text-fg-subtle hover:text-fg-muted transition-colors"
-          >
-            ← 상세보기
-          </Link>
-          <h1 className="text-xl font-bold text-fg">항목 수정</h1>
+        <div className="mb-6">
+          <TripContextLabel className="mb-1.5" />
+          <div className="flex items-center gap-3">
+            <Link
+              href={buildTripPath(params.tripId, `items/${item.id}`)}
+              className="text-sm text-fg-subtle hover:text-fg-muted transition-colors"
+            >
+              ← 상세보기
+            </Link>
+            <h1 className="text-xl font-bold text-fg">항목 수정</h1>
+          </div>
         </div>
         <ItemForm mode="edit" initialData={item} itemId={item.id} />
       </div>

--- a/app/trip/[tripId]/items/[id]/page.tsx
+++ b/app/trip/[tripId]/items/[id]/page.tsx
@@ -5,6 +5,7 @@ import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 import Navigation from '@/components/Layout/Navigation'
 import ItemMetadataChips from '@/components/UI/ItemMetadataChips'
 import { buildTripPath } from '@/lib/hooks/useTripContext'
+import TripContextLabel from '@/components/UI/TripContextLabel'
 import type { TripItem } from '@/types'
 
 export default async function ItemDetailPage({
@@ -37,6 +38,7 @@ export default async function ItemDetailPage({
         </div>
 
         <div className="mb-6">
+          <TripContextLabel className="mb-1.5" />
           <h1 className="text-2xl font-bold text-fg mb-2">{item.name}</h1>
           <ItemMetadataChips item={item} />
         </div>

--- a/app/trip/[tripId]/items/new/page.tsx
+++ b/app/trip/[tripId]/items/new/page.tsx
@@ -1,11 +1,14 @@
 import Navigation from '@/components/Layout/Navigation'
 import ItemForm from '@/components/Items/ItemForm'
+import TripPageTitle from '@/components/UI/TripPageTitle'
 
 export default function NewItemPage() {
   return (
     <div className="md:pl-44">
       <div className="max-w-lg mx-auto px-4 py-6">
-        <h1 className="text-xl font-bold text-fg mb-6">항목 추가</h1>
+        <div className="mb-6">
+          <TripPageTitle section="항목 추가" />
+        </div>
         <ItemForm mode="create" />
       </div>
       <Navigation />

--- a/app/trip/[tripId]/layout.tsx
+++ b/app/trip/[tripId]/layout.tsx
@@ -1,9 +1,19 @@
 import { redirect } from 'next/navigation'
-import { TripIdProvider } from '@/lib/hooks/useTripContext'
+import { TripProvider, type TripRole } from '@/lib/hooks/useTripContext'
 import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 import TripAccessDenied from '@/components/UI/TripAccessDenied'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+type TripRow = {
+  id: string
+  title: string
+  start_date: string | null
+  end_date: string | null
+  region: string | null
+  basecamp_address: string | null
+  trip_members: { role: TripRole }[]
+}
 
 export default async function TripLayout({
   children,
@@ -24,10 +34,37 @@ export default async function TripLayout({
     redirect(`/login?next=${encodeURIComponent(`/trip/${tripId}`)}`)
   }
 
-  const { data: isMember, error } = await client.rpc('is_trip_member', { p_trip_id: tripId })
-  if (error || !isMember) {
+  const { data, error } = await client
+    .from('trips')
+    .select(
+      'id, title, start_date, end_date, region, basecamp_address, trip_members!inner(role)',
+    )
+    .eq('id', tripId)
+    .eq('trip_members.user_id', userData.user.id)
+    .maybeSingle<TripRow>()
+
+  if (error || !data) {
     return <TripAccessDenied reason="forbidden" />
   }
 
-  return <TripIdProvider tripId={tripId}>{children}</TripIdProvider>
+  const role = data.trip_members[0]?.role
+  if (!role) {
+    return <TripAccessDenied reason="forbidden" />
+  }
+
+  return (
+    <TripProvider
+      value={{
+        id: data.id,
+        title: data.title,
+        startDate: data.start_date,
+        endDate: data.end_date,
+        region: data.region,
+        basecampAddress: data.basecamp_address,
+        role,
+      }}
+    >
+      {children}
+    </TripProvider>
+  )
 }

--- a/app/trip/[tripId]/list/page.tsx
+++ b/app/trip/[tripId]/list/page.tsx
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic'
 import { Search, Share2 } from 'lucide-react'
 import ShareDialog from '@/components/Share/ShareDialog'
 import { useTripId } from '@/lib/hooks/useTripContext'
+import TripPageTitle from '@/components/UI/TripPageTitle'
 import Navigation from '@/components/Layout/Navigation'
 import ItemList from '@/components/Items/ItemList'
 import ItemCardSkeleton from '@/components/UI/ItemCardSkeleton'
@@ -188,7 +189,7 @@ function ResearchPageContent() {
     <div className="md:pl-44 bg-bg text-fg min-h-screen">
       <header className="px-4 md:px-8 pt-4">
         <div className="flex items-center justify-between mb-4">
-          <h1 className="text-xl font-bold text-fg">목록</h1>
+          <TripPageTitle section="목록" />
           <div className="flex items-center gap-2">
             <button
               type="button"

--- a/app/trip/[tripId]/schedule/page.tsx
+++ b/app/trip/[tripId]/schedule/page.tsx
@@ -9,6 +9,7 @@ import ScheduleTable from '@/components/Schedule/ScheduleTable'
 import ThemeToggle from '@/components/Theme/ThemeToggle'
 import { useItems } from '@/lib/hooks/useItems'
 import { useToast } from '@/components/UI/Toast'
+import TripPageTitle from '@/components/UI/TripPageTitle'
 
 const ItemPanel = dynamic(() => import('@/components/Panel/ItemPanel'), { ssr: false })
 
@@ -66,7 +67,7 @@ function SchedulePageContent() {
     <div className="md:pl-44 bg-bg text-fg min-h-screen">
       <header className="max-w-3xl mx-auto px-4 pt-4">
         <div className="flex items-center justify-between mb-4">
-          <h1 className="text-xl font-bold text-fg">일정</h1>
+          <TripPageTitle section="일정" />
           <div className="md:hidden">
             <ThemeToggle />
           </div>

--- a/components/Plan/PlanScreen.tsx
+++ b/components/Plan/PlanScreen.tsx
@@ -13,6 +13,7 @@ import {
   useMobilePanelHeight,
 } from '@/lib/hooks/useMobilePanelHeight'
 import { useToast } from '@/components/UI/Toast'
+import TripContextLabel from '@/components/UI/TripContextLabel'
 import { CATEGORY_OPTIONS } from '@/lib/itemOptions'
 import type { Category, TripItem } from '@/types'
 
@@ -170,6 +171,9 @@ export default function PlanScreen({ basePath }: PlanScreenProps) {
             selectedItemId={selectedItemId}
             onSelectItem={handleSelectItem}
           />
+          <div className="pointer-events-none absolute top-3 left-3 z-[600] max-w-[60%] rounded-md bg-bg-elevated/90 px-2.5 py-1.5 shadow-sm backdrop-blur">
+            <TripContextLabel />
+          </div>
         </div>
       </div>
 
@@ -185,6 +189,10 @@ export default function PlanScreen({ basePath }: PlanScreenProps) {
             selectedItemId={selectedItemId}
             onSelectItem={handleSelectItem}
           />
+          {/* 모바일 좌측 상단 trip 컨텍스트 라벨 */}
+          <div className="pointer-events-none absolute top-3 left-3 z-[600] max-w-[60%] rounded-md bg-bg-elevated/90 px-2.5 py-1.5 shadow-sm backdrop-blur">
+            <TripContextLabel />
+          </div>
           {/* 모바일 우측 상단 떠있는 테마 토글 + FAB */}
           <div className="absolute top-3 right-3 z-[600]">
             <ThemeToggle />

--- a/components/UI/TripContextLabel.tsx
+++ b/components/UI/TripContextLabel.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useOptionalTrip } from '@/lib/hooks/useTripContext'
+
+export default function TripContextLabel({ className = '' }: { className?: string }) {
+  const trip = useOptionalTrip()
+  if (!trip) return null
+  const range =
+    trip.startDate && trip.endDate
+      ? `${trip.startDate} - ${trip.endDate}`
+      : trip.startDate ?? trip.endDate
+  return (
+    <div className={`truncate text-xs font-medium text-fg-subtle ${className}`}>
+      <span className="truncate">{trip.title}</span>
+      {range ? <span className="text-fg-subtle/70"> · {range}</span> : null}
+    </div>
+  )
+}

--- a/components/UI/TripPageTitle.tsx
+++ b/components/UI/TripPageTitle.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useOptionalTrip } from '@/lib/hooks/useTripContext'
+
+function formatRange(start: string | null, end: string | null): string | null {
+  if (!start && !end) return null
+  if (start && end) return `${start} - ${end}`
+  return start ?? end
+}
+
+export default function TripPageTitle({ section }: { section: string }) {
+  const trip = useOptionalTrip()
+  const range = trip ? formatRange(trip.startDate, trip.endDate) : null
+  return (
+    <div className="min-w-0">
+      {trip ? (
+        <div className="truncate text-xs font-medium text-fg-subtle">
+          <span className="truncate">{trip.title}</span>
+          {range ? <span className="text-fg-subtle/70"> · {range}</span> : null}
+        </div>
+      ) : null}
+      <h1 className="text-xl font-bold text-fg">{section}</h1>
+    </div>
+  )
+}

--- a/lib/hooks/useTripContext.tsx
+++ b/lib/hooks/useTripContext.tsx
@@ -2,28 +2,48 @@
 
 import { createContext, useContext, type ReactNode } from 'react'
 
-const TripIdContext = createContext<string | null>(null)
+export type TripRole = 'owner' | 'editor' | 'viewer'
 
-export function TripIdProvider({
-  tripId,
+export type TripContextValue = {
+  id: string
+  title: string
+  startDate: string | null
+  endDate: string | null
+  region: string | null
+  basecampAddress: string | null
+  role: TripRole
+}
+
+const TripContext = createContext<TripContextValue | null>(null)
+
+export function TripProvider({
+  value,
   children,
 }: {
-  tripId: string
+  value: TripContextValue
   children: ReactNode
 }) {
-  return <TripIdContext.Provider value={tripId}>{children}</TripIdContext.Provider>
+  return <TripContext.Provider value={value}>{children}</TripContext.Provider>
+}
+
+export function useTrip(): TripContextValue {
+  const value = useContext(TripContext)
+  if (!value) {
+    throw new Error('useTrip 은 TripProvider 내부에서만 사용할 수 있습니다.')
+  }
+  return value
+}
+
+export function useOptionalTrip(): TripContextValue | null {
+  return useContext(TripContext)
 }
 
 export function useTripId(): string {
-  const id = useContext(TripIdContext)
-  if (!id) {
-    throw new Error('useTripId 는 TripIdProvider 내부에서만 사용할 수 있습니다.')
-  }
-  return id
+  return useTrip().id
 }
 
 export function useOptionalTripId(): string | null {
-  return useContext(TripIdContext)
+  return useContext(TripContext)?.id ?? null
 }
 
 export function buildTripPath(tripId: string, sub: string): string {


### PR DESCRIPTION
## 관련 이슈
Closes #142

## 변경 이유
모든 `/trip/[tripId]/**` 페이지에서 "지금 보고 있는 여행이 무엇인지" 알 수 없어, 사용자가 컨텍스트를 잃어버리는 문제 해소. G-2/G-16 등 후속 게이트의 전제.

## 변경 범위
- `TripIdProvider` → `TripProvider` 확장. context 가 `{ id, title, startDate, endDate, region, basecampAddress, role }` 노출.
- `app/trip/[tripId]/layout.tsx`: `is_trip_member` RPC + 본체 fetch 를 `trips + trip_members!inner` 단일 query 로 통합 (N+1 없음).
- 공통 `TripPageTitle`, `TripContextLabel` 컴포넌트 신설 (G-16 공통 헤더 정착 전까지 최소 변경).
- list/schedule/gmaps-import 헤더: `TripPageTitle` 적용 → trip title + 기간 + 섹션명.
- map (PlanScreen): 데스크탑·모바일 좌측 상단에 `TripContextLabel` 오버레이.
- items/new/[id]/[id]/edit: `TripContextLabel` 로 trip 컨텍스트 표시.

## 검증
- `npm run lint` ✅
- `npm run build` ✅
- 멤버 아닌 경우 `TripAccessDenied` 유지 확인.
- 단일 query 로 trip + role 동시 fetch — N+1 없음.

## 기본기 5문항
- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? → 본 PR 의 목적
- [ ] 핵심 객체 C/R/U/D 모두 UI 가능? (해당 시) → trip U 는 G-2, D 는 G-9 에서
- [x] 모달·시트 콘텐츠 적응형? → 본 PR 범위 외 (G-6)
- [x] 마법사·카피 약속이 실제 가능? → 본 PR 범위 외
- [x] 모바일·데스크탑 동등? → 모든 페이지에서 양쪽 모두 trip 이름 보임

## 남은 작업 / 리스크
- G-16 에서 5개 trip 페이지 헤더를 공통 `TripPageHeader` 로 재정착 예정.
- map 페이지 trip 라벨은 떠있는 오버레이 형태 — G-16 에서 디자인 정렬 예정.