### PR TITLE
feat(basics): #143 G-2 PATCH /api/trips/[tripId] + 헤더 인라인 편집 + 여행 설정 시트

### DIFF
--- a/app/api/trips/[tripId]/route.ts
+++ b/app/api/trips/[tripId]/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function sanitizeText(v: unknown): string | null {
+  if (typeof v !== 'string') return null
+  const t = v.trim()
+  return t ? t : null
+}
+
+function sanitizeDate(v: unknown): string | null {
+  if (typeof v !== 'string') return null
+  return /^\d{4}-\d{2}-\d{2}$/.test(v) ? v : null
+}
+
+const FIELD_KEYS = ['title', 'start_date', 'end_date', 'region', 'basecamp_address'] as const
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { tripId: string } },
+) {
+  const { tripId } = params
+  if (!UUID_RE.test(tripId)) {
+    return NextResponse.json({ error: '잘못된 trip id' }, { status: 400 })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: '잘못된 요청 본문' }, { status: 400 })
+  }
+
+  const patch: Record<string, string | null> = {}
+  for (const key of FIELD_KEYS) {
+    if (!(key in body)) continue
+    const raw = body[key]
+    if (raw === null) {
+      patch[key] = null
+      continue
+    }
+    if (key === 'start_date' || key === 'end_date') {
+      const d = sanitizeDate(raw)
+      if (!d) {
+        return NextResponse.json(
+          { error: `${key} 는 YYYY-MM-DD 형식이어야 합니다.` },
+          { status: 400 },
+        )
+      }
+      patch[key] = d
+    } else {
+      const t = sanitizeText(raw)
+      if (key === 'title' && !t) {
+        return NextResponse.json({ error: '제목은 비울 수 없습니다.' }, { status: 400 })
+      }
+      patch[key] = t
+    }
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json({ error: '수정할 필드가 없습니다.' }, { status: 400 })
+  }
+
+  const start = patch.start_date ?? null
+  const end = patch.end_date ?? null
+  if (start && end && end < start) {
+    return NextResponse.json(
+      { error: '종료일은 시작일보다 빠를 수 없습니다.' },
+      { status: 400 },
+    )
+  }
+
+  const client = createRouteHandlerSupabase()
+  const { data: userData } = await client.auth.getUser()
+  if (!userData.user) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+  }
+
+  const { data, error } = await client
+    .from('trips')
+    .update(patch)
+    .eq('id', tripId)
+    .select('id, title, start_date, end_date, region, basecamp_address')
+    .maybeSingle()
+
+  if (error) {
+    console.error('[PATCH /api/trips/:id]', error)
+    return NextResponse.json({ error: '여행 수정에 실패했습니다.' }, { status: 500 })
+  }
+  if (!data) {
+    return NextResponse.json({ error: '권한이 없거나 trip 을 찾을 수 없습니다.' }, { status: 403 })
+  }
+
+  return NextResponse.json({ trip: data })
+}

--- a/components/Trip/EditableTripTitle.tsx
+++ b/components/Trip/EditableTripTitle.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { MoreHorizontal } from 'lucide-react'
+import { useTrip } from '@/lib/hooks/useTripContext'
+import { useToast } from '@/components/UI/Toast'
+import IconButton from '@/components/UI/IconButton'
+import TripSettingsSheet from './TripSettingsSheet'
+
+function canEdit(role: 'owner' | 'editor' | 'viewer'): boolean {
+  return role === 'owner' || role === 'editor'
+}
+
+function formatRange(start: string | null, end: string | null): string | null {
+  if (start && end) return `${start} - ${end}`
+  return start ?? end
+}
+
+/**
+ * Trip 페이지 공통 헤더 타이틀.
+ * - section: 현재 페이지명 (목록/지도/일정 등)
+ * - title 영역 클릭 → 인라인 편집 (owner/editor only)
+ * - ⋯ 버튼 → 여행 설정 시트
+ */
+export default function EditableTripTitle({ section }: { section: string }) {
+  const trip = useTrip()
+  const router = useRouter()
+  const { showToast } = useToast()
+  const editable = canEdit(trip.role)
+
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(trip.title)
+  const [saving, setSaving] = useState(false)
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    setDraft(trip.title)
+  }, [trip.title])
+
+  useEffect(() => {
+    if (editing) inputRef.current?.select()
+  }, [editing])
+
+  async function commit() {
+    const next = draft.trim()
+    if (!next || next === trip.title) {
+      setEditing(false)
+      setDraft(trip.title)
+      return
+    }
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/trips/${trip.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: next }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        showToast({ message: data?.error ?? '저장에 실패했습니다.', type: 'error' })
+        setDraft(trip.title)
+      } else {
+        showToast({ message: '제목을 저장했습니다.', type: 'success' })
+        router.refresh()
+      }
+    } catch {
+      showToast({ message: '네트워크 오류', type: 'error' })
+      setDraft(trip.title)
+    } finally {
+      setSaving(false)
+      setEditing(false)
+    }
+  }
+
+  const range = formatRange(trip.startDate, trip.endDate)
+
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-center gap-1.5 min-w-0">
+        {editing ? (
+          <input
+            ref={inputRef}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                commit()
+              } else if (e.key === 'Escape') {
+                setDraft(trip.title)
+                setEditing(false)
+              }
+            }}
+            disabled={saving}
+            className="min-w-0 flex-1 truncate text-xs font-medium text-fg bg-bg border border-border rounded px-1.5 py-0.5 focus:outline-none focus:border-accent"
+            aria-label="여행 제목"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => editable && setEditing(true)}
+            className={`truncate text-xs font-medium text-fg-subtle ${
+              editable ? 'cursor-text hover:text-fg' : 'cursor-default'
+            }`}
+            title={editable ? '클릭하여 제목 편집' : trip.title}
+            disabled={!editable}
+          >
+            <span className="truncate">{trip.title}</span>
+            {range ? <span className="text-fg-subtle/70"> · {range}</span> : null}
+          </button>
+        )}
+        {editable && !editing && (
+          <IconButton
+            aria-label="여행 설정"
+            onClick={() => setSheetOpen(true)}
+            size="sm"
+          >
+            <MoreHorizontal className="size-3.5" aria-hidden />
+          </IconButton>
+        )}
+      </div>
+      <h1 className="text-xl font-bold text-fg">{section}</h1>
+      {editable && <TripSettingsSheet open={sheetOpen} onClose={() => setSheetOpen(false)} />}
+    </div>
+  )
+}

--- a/components/Trip/TripSettingsSheet.tsx
+++ b/components/Trip/TripSettingsSheet.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Sheet, { SheetSection } from '@/components/UI/Sheet'
+import { Input } from '@/components/UI/Input'
+import Button from '@/components/UI/Button'
+import { useToast } from '@/components/UI/Toast'
+import { useTrip } from '@/lib/hooks/useTripContext'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+export default function TripSettingsSheet({ open, onClose }: Props) {
+  const trip = useTrip()
+  const router = useRouter()
+  const { showToast } = useToast()
+
+  const [title, setTitle] = useState(trip.title)
+  const [startDate, setStartDate] = useState(trip.startDate ?? '')
+  const [endDate, setEndDate] = useState(trip.endDate ?? '')
+  const [region, setRegion] = useState(trip.region ?? '')
+  const [basecamp, setBasecamp] = useState(trip.basecampAddress ?? '')
+  const [saving, setSaving] = useState(false)
+
+  async function handleSave() {
+    if (!title.trim()) {
+      showToast({ message: '제목은 비울 수 없습니다.', type: 'error' })
+      return
+    }
+    if (startDate && endDate && endDate < startDate) {
+      showToast({ message: '종료일은 시작일보다 빠를 수 없습니다.', type: 'error' })
+      return
+    }
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/trips/${trip.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: title.trim(),
+          start_date: startDate || null,
+          end_date: endDate || null,
+          region: region.trim() || null,
+          basecamp_address: basecamp.trim() || null,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        showToast({ message: data?.error ?? '저장에 실패했습니다.', type: 'error' })
+        return
+      }
+      showToast({ message: '여행 정보를 저장했습니다.', type: 'success' })
+      router.refresh()
+      onClose()
+    } catch {
+      showToast({ message: '네트워크 오류가 발생했습니다.', type: 'error' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title="여행 설정"
+      description="제목·기간·지역·베이스캠프를 수정합니다."
+      footer={
+        <>
+          <Button type="button" variant="ghost" onClick={onClose} disabled={saving}>
+            취소
+          </Button>
+          <Button type="button" onClick={handleSave} disabled={saving}>
+            {saving ? '저장 중...' : '저장'}
+          </Button>
+        </>
+      }
+    >
+      <SheetSection>
+        <div className="space-y-4">
+          <Input
+            label="제목"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+            data-autofocus
+          />
+          <div className="grid grid-cols-2 gap-3">
+            <Input
+              label="시작일"
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+            />
+            <Input
+              label="종료일"
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+            />
+          </div>
+          <Input
+            label="지역"
+            placeholder="예: 도쿄, 뉴욕"
+            value={region}
+            onChange={(e) => setRegion(e.target.value)}
+          />
+          <Input
+            label="베이스캠프 주소"
+            placeholder="숙소 등 동선의 기준점"
+            value={basecamp}
+            onChange={(e) => setBasecamp(e.target.value)}
+          />
+        </div>
+      </SheetSection>
+    </Sheet>
+  )
+}

--- a/components/UI/TripPageTitle.tsx
+++ b/components/UI/TripPageTitle.tsx
@@ -1,25 +1,7 @@
 'use client'
 
-import { useOptionalTrip } from '@/lib/hooks/useTripContext'
-
-function formatRange(start: string | null, end: string | null): string | null {
-  if (!start && !end) return null
-  if (start && end) return `${start} - ${end}`
-  return start ?? end
-}
+import EditableTripTitle from '@/components/Trip/EditableTripTitle'
 
 export default function TripPageTitle({ section }: { section: string }) {
-  const trip = useOptionalTrip()
-  const range = trip ? formatRange(trip.startDate, trip.endDate) : null
-  return (
-    <div className="min-w-0">
-      {trip ? (
-        <div className="truncate text-xs font-medium text-fg-subtle">
-          <span className="truncate">{trip.title}</span>
-          {range ? <span className="text-fg-subtle/70"> · {range}</span> : null}
-        </div>
-      ) : null}
-      <h1 className="text-xl font-bold text-fg">{section}</h1>
-    </div>
-  )
+  return <EditableTripTitle section={section} />
 }


### PR DESCRIPTION
## 관련 이슈
Closes #143

## 변경 이유
마법사가 "나중에 언제든 바꿀 수 있어요" 라고 약속하지만 trip 본체에 대한 수정 API/UI 가 없는 거짓말 상태 해소.

## 변경 범위
- `app/api/trips/[tripId]/route.ts` 신설: `PATCH` 로 `title`/`start_date`/`end_date`/`region`/`basecamp_address` 부분 수정. RLS `trips_update` 정책(owner/editor) 검증.
- `TripSettingsSheet`: 여행 설정 시트 — 제목·기간·지역·베이스캠프 일괄 편집.
- `EditableTripTitle`: 헤더 인라인 편집 (클릭 → input → Enter/blur 저장 / Esc 취소) + ⋯ 버튼으로 설정 시트 진입.
- `TripPageTitle` 이 `EditableTripTitle` 로 위임 → list/schedule/gmaps-import 헤더에 자동 적용.
- 비-owner/비-editor 는 편집 UI 가 보이지 않음 (role 기반).
- 저장 후 `router.refresh()` 로 즉시 헤더 반영 + toast.

## 검증
- `npm run lint` ✅
- `npm run build` ✅
- 빈 제목 / 종료일 < 시작일 / 비인증 / 권한 없음 케이스 모두 API 단에서 거부.

## 기본기 5문항
- [x] 여행 이름 보임
- [x] U 동작 UI 가능 (D 는 G-9, C 는 마법사)
- [x] 시트 콘텐츠 적응형 (G-6 후속에서 추가 정렬)
- [x] 카피 약속 4건 모두 실제 가능
- [x] 모바일·데스크탑 동등 (Sheet auto-side)

## 남은 작업 / 리스크
- map 페이지 overlay 라벨은 인라인 편집 진입점 미포함 (overlay UX). 편집은 list/schedule 헤더에서.
- G-9 에서 trip 삭제 추가 예정.