### PR TITLE
feat(basics): #144 G-3 TRIP_DATE_MIN/MAX 하드코딩 제거 — trip 기간 기반 동적 검증

### DIFF
--- a/app/api/items/[id]/route.ts
+++ b/app/api/items/[id]/route.ts
@@ -6,11 +6,15 @@ import {
   CATEGORY_OPTIONS,
   RESERVATION_STATUS_OPTIONS,
   TRIP_PRIORITY_OPTIONS,
-  TRIP_DATE_MAX,
-  TRIP_DATE_MIN,
 } from '@/lib/itemOptions'
+import {
+  fetchTripBounds,
+  formatBoundsLabel,
+  isDateWithinBounds,
+  type TripBounds,
+} from '@/lib/trips'
 
-function validatePartial(body: Record<string, unknown>): string | null {
+function validatePartial(body: Record<string, unknown>, bounds: TripBounds | null): string | null {
   if (body.name !== undefined && (typeof body.name !== 'string' || !body.name.trim())) {
     return 'name은 비워둘 수 없습니다.'
   }
@@ -40,9 +44,9 @@ function validatePartial(body: Record<string, unknown>): string | null {
   if (
     body.date !== undefined &&
     body.date !== null &&
-    ((body.date as string) < TRIP_DATE_MIN || (body.date as string) > TRIP_DATE_MAX)
+    !isDateWithinBounds(body.date as string, bounds)
   ) {
-    return 'date는 2026-07-01부터 2026-07-31 사이여야 합니다.'
+    return `date는 여행 기간(${formatBoundsLabel(bounds)}) 내여야 합니다.`
   }
   if (
     body.end_date !== undefined &&
@@ -54,9 +58,9 @@ function validatePartial(body: Record<string, unknown>): string | null {
   if (
     body.end_date !== undefined &&
     body.end_date !== null &&
-    ((body.end_date as string) < TRIP_DATE_MIN || (body.end_date as string) > TRIP_DATE_MAX)
+    !isDateWithinBounds(body.end_date as string, bounds)
   ) {
-    return 'end_date는 2026-07-01부터 2026-07-31 사이여야 합니다.'
+    return `end_date는 여행 기간(${formatBoundsLabel(bounds)}) 내여야 합니다.`
   }
   if (
     body.date !== undefined &&
@@ -111,8 +115,9 @@ export async function PUT(request: NextRequest, { params }: RouteContext) {
     return NextResponse.json({ error: '항목을 찾을 수 없습니다.' }, { status: 404 })
   }
 
+  const bounds = tripId ? await fetchTripBounds(client, tripId) : null
   const body = await request.json()
-  const error = validatePartial(body)
+  const error = validatePartial(body, bounds)
   if (error) return NextResponse.json({ error }, { status: 400 })
 
   const updated = {

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -7,11 +7,15 @@ import {
   CATEGORY_OPTIONS,
   RESERVATION_STATUS_OPTIONS,
   TRIP_PRIORITY_OPTIONS,
-  TRIP_DATE_MAX,
-  TRIP_DATE_MIN,
 } from '@/lib/itemOptions'
+import {
+  fetchTripBounds,
+  formatBoundsLabel,
+  isDateWithinBounds,
+  type TripBounds,
+} from '@/lib/trips'
 
-function validateItem(body: Record<string, unknown>): string | null {
+function validateItem(body: Record<string, unknown>, bounds: TripBounds | null): string | null {
   if (!body.name || typeof body.name !== 'string' || !body.name.trim()) {
     return 'name은 필수입니다.'
   }
@@ -31,15 +35,15 @@ function validateItem(body: Record<string, unknown>): string | null {
   if (body.budget !== undefined && body.budget !== null && (typeof body.budget !== 'number' || body.budget < 0)) {
     return 'budget은 0 이상의 숫자여야 합니다.'
   }
-  if (body.date !== undefined && !/^\d{4}-\d{2}-\d{2}$/.test(body.date as string)) {
+  if (body.date !== undefined && body.date !== null && !/^\d{4}-\d{2}-\d{2}$/.test(body.date as string)) {
     return 'date는 YYYY-MM-DD 형식이어야 합니다.'
   }
   if (
     body.date !== undefined &&
     body.date !== null &&
-    ((body.date as string) < TRIP_DATE_MIN || (body.date as string) > TRIP_DATE_MAX)
+    !isDateWithinBounds(body.date as string, bounds)
   ) {
-    return 'date는 2026-07-01부터 2026-07-31 사이여야 합니다.'
+    return `date는 여행 기간(${formatBoundsLabel(bounds)}) 내여야 합니다.`
   }
   if (
     body.end_date !== undefined &&
@@ -51,9 +55,9 @@ function validateItem(body: Record<string, unknown>): string | null {
   if (
     body.end_date !== undefined &&
     body.end_date !== null &&
-    ((body.end_date as string) < TRIP_DATE_MIN || (body.end_date as string) > TRIP_DATE_MAX)
+    !isDateWithinBounds(body.end_date as string, bounds)
   ) {
-    return 'end_date는 2026-07-01부터 2026-07-31 사이여야 합니다.'
+    return `end_date는 여행 기간(${formatBoundsLabel(bounds)}) 내여야 합니다.`
   }
   if (
     body.date !== undefined &&
@@ -118,7 +122,11 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const body = await request.json()
 
-  const error = validateItem(body)
+  const client = createRouteHandlerSupabase()
+  const tripId = getTripIdFromRequest(request)
+  const bounds = tripId ? await fetchTripBounds(client, tripId) : null
+
+  const error = validateItem(body, bounds)
   if (error) return NextResponse.json({ error }, { status: 400 })
 
   const now = new Date().toISOString()
@@ -143,8 +151,6 @@ export async function POST(request: NextRequest) {
   if (body.time_start !== undefined) item.time_start = body.time_start as string
   if (body.time_end !== undefined && body.time_end !== null) item.time_end = body.time_end as string
 
-  const client = createRouteHandlerSupabase()
-  const tripId = getTripIdFromRequest(request)
   const items = await readItems(client, tripId)
   items.push(item)
   await writeItems(client, items, tripId)

--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import type { Category, ReservationStatus, TripItem, TripPriority, Link as TripLink } from '@/types'
 import { useItems } from '@/lib/hooks/useItems'
-import { useTripPath } from '@/lib/hooks/useTripContext'
+import { useTrip, useTripPath } from '@/lib/hooks/useTripContext'
 import {
   CATEGORY_OPTIONS,
   ITEM_FIELD_LABELS,
@@ -12,8 +12,6 @@ import {
   TRIP_PRIORITY_OPTIONS,
   RESERVATION_STATUS_META,
   RESERVATION_STATUS_OPTIONS,
-  TRIP_DATE_MAX,
-  TRIP_DATE_MIN,
 } from '@/lib/itemOptions'
 
 interface FormData {
@@ -42,6 +40,9 @@ interface ItemFormProps {
 export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
   const router = useRouter()
   const tripPath = useTripPath()
+  const trip = useTrip()
+  const dateMin = trip.startDate ?? undefined
+  const dateMax = trip.endDate ?? undefined
   const { createItem, updateItem, deleteItem } = useItems()
   const [form, setForm] = useState<FormData>({
     name: initialData?.name ?? '',
@@ -222,8 +223,8 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
               <input
                 type="date"
                 value={form.date}
-                min={TRIP_DATE_MIN}
-                max={TRIP_DATE_MAX}
+                min={dateMin}
+                max={dateMax}
                 onChange={e => setField('date', e.target.value)}
                 className={inputClass}
               />
@@ -248,8 +249,8 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
               <input
                 type="date"
                 value={form.end_date}
-                min={TRIP_DATE_MIN}
-                max={TRIP_DATE_MAX}
+                min={dateMin}
+                max={dateMax}
                 onChange={e => setField('end_date', e.target.value)}
                 className={inputClass}
               />

--- a/components/Panel/ItemPanel.tsx
+++ b/components/Panel/ItemPanel.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom'
 import type { TripItem } from '@/types'
 import PanelItemForm from './PanelItemForm'
 import { useItems } from '@/lib/hooks/useItems'
+import { useTrip } from '@/lib/hooks/useTripContext'
 import {
   CATEGORY_OPTIONS,
   CHIP_TONE,
@@ -14,8 +15,6 @@ import {
   TRIP_PRIORITY_OPTIONS,
   RESERVATION_STATUS_META,
   RESERVATION_STATUS_OPTIONS,
-  TRIP_DATE_MAX,
-  TRIP_DATE_MIN,
 } from '@/lib/itemOptions'
 import TripPriorityBadge from '@/components/UI/TripPriorityBadge'
 import ReservationStatusBadge from '@/components/UI/ReservationStatusBadge'
@@ -238,6 +237,9 @@ function ItemDetailView({
   onFieldSave: (changes: Record<string, unknown>) => Promise<void>
   onDeleteRequest: () => void
 }) {
+  const trip = useTrip()
+  const dateMin = trip.startDate ?? undefined
+  const dateMax = trip.endDate ?? undefined
   const [editing, setEditing] = useState<InlineField | null>(null)
   const [vals, setVals] = useState({
     name: item.name,
@@ -461,7 +463,7 @@ function ItemDetailView({
 
         <InlineRow label="시작 날짜">
           {editing === 'date'
-            ? inlineInput('date', { type: 'date', min: TRIP_DATE_MIN, max: TRIP_DATE_MAX })
+            ? inlineInput('date', { type: 'date', min: dateMin, max: dateMax })
             : <span className={vals.date ? 'text-sm text-fg cursor-text' : emptyClass} onClick={() => activate('date')}>{vals.date || '날짜 선택'}</span>
           }
         </InlineRow>
@@ -475,7 +477,7 @@ function ItemDetailView({
 
         <InlineRow label="종료 날짜">
           {editing === 'end_date'
-            ? inlineInput('end_date', { type: 'date', min: TRIP_DATE_MIN, max: TRIP_DATE_MAX })
+            ? inlineInput('end_date', { type: 'date', min: dateMin, max: dateMax })
             : <span className={vals.end_date ? 'text-sm text-fg cursor-text' : emptyClass} onClick={() => activate('end_date')}>{vals.end_date || '날짜 선택'}</span>
           }
         </InlineRow>

--- a/components/Panel/PanelItemForm.tsx
+++ b/components/Panel/PanelItemForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from 'react'
 import type { Category, ReservationStatus, TripItem, TripPriority, Link as TripLink } from '@/types'
 import { useItems } from '@/lib/hooks/useItems'
+import { useTrip } from '@/lib/hooks/useTripContext'
 import {
   CATEGORY_OPTIONS,
   ITEM_FIELD_LABELS,
@@ -10,8 +11,6 @@ import {
   TRIP_PRIORITY_OPTIONS,
   RESERVATION_STATUS_META,
   RESERVATION_STATUS_OPTIONS,
-  TRIP_DATE_MAX,
-  TRIP_DATE_MIN,
 } from '@/lib/itemOptions'
 
 interface FormData {
@@ -40,6 +39,9 @@ export interface PanelItemFormProps {
 
 export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }: PanelItemFormProps) {
   const { updateItem } = useItems()
+  const trip = useTrip()
+  const dateMin = trip.startDate ?? undefined
+  const dateMax = trip.endDate ?? undefined
   const [form, setForm] = useState<FormData>({
     name: item.name,
     category: item.category,
@@ -192,8 +194,8 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
                 <input
                   type="date"
                   value={form.date}
-                  min={TRIP_DATE_MIN}
-                  max={TRIP_DATE_MAX}
+                  min={dateMin}
+                  max={dateMax}
                   onChange={e => setField('date', e.target.value)}
                   className={inputClass}
                 />
@@ -213,8 +215,8 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
                 <input
                   type="date"
                   value={form.end_date}
-                  min={TRIP_DATE_MIN}
-                  max={TRIP_DATE_MAX}
+                  min={dateMin}
+                  max={dateMax}
                   onChange={e => setField('end_date', e.target.value)}
                   className={inputClass}
                 />

--- a/lib/itemOptions.ts
+++ b/lib/itemOptions.ts
@@ -29,7 +29,13 @@ export const RESERVATION_STATUS_OPTIONS: ReservationStatus[] = [
   '예약완료',
 ]
 
+/**
+ * @deprecated 단일 NYC trip 시대 잔재. 신규 코드는 사용 금지.
+ * trip 기간은 항상 현재 trip context(useTrip().startDate/endDate) 또는
+ * `fetchTripBounds(client, tripId)` 로 동적으로 가져온다.
+ */
 export const TRIP_DATE_MIN = '2026-07-01'
+/** @deprecated 단일 NYC trip 시대 잔재. */
 export const TRIP_DATE_MAX = '2026-07-31'
 
 export const ITEM_FIELD_LABELS = {

--- a/lib/trips.ts
+++ b/lib/trips.ts
@@ -1,5 +1,41 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 
+export type TripBounds = {
+  start: string | null
+  end: string | null
+}
+
+/**
+ * 주어진 trip 의 시작·종료일을 조회한다. RLS 가 멤버 권한을 검증.
+ * 둘 다 null 이면 검증 생략 의미.
+ */
+export async function fetchTripBounds(
+  client: SupabaseClient,
+  tripId: string,
+): Promise<TripBounds | null> {
+  const { data, error } = await client
+    .from('trips')
+    .select('start_date, end_date')
+    .eq('id', tripId)
+    .maybeSingle()
+  if (error || !data) return null
+  return { start: data.start_date as string | null, end: data.end_date as string | null }
+}
+
+export function isDateWithinBounds(date: string, bounds: TripBounds | null): boolean {
+  if (!bounds) return true
+  if (bounds.start && date < bounds.start) return false
+  if (bounds.end && date > bounds.end) return false
+  return true
+}
+
+export function formatBoundsLabel(bounds: TripBounds | null): string {
+  if (!bounds || (!bounds.start && !bounds.end)) return '기간이 설정되지 않은 여행'
+  const start = bounds.start ?? '~'
+  const end = bounds.end ?? '~'
+  return `${start} ~ ${end}`
+}
+
 export type TripSummary = {
   id: string
   title: string


### PR DESCRIPTION
## 관련 이슈
Closes #144

## 변경 이유
멀티 trip 마이그레이션의 가장 큰 거짓말. 단일 NYC trip 시절 박힌 `TRIP_DATE_MIN=2026-07-01`, `TRIP_DATE_MAX=2026-07-31` 가 모든 trip 의 item 날짜를 그 범위로 강제해, NYC 외 trip 에서 item 추가가 400 으로 거부되던 문제 해소.

## 변경 범위
- `lib/trips.ts`: `fetchTripBounds(client, tripId)`, `isDateWithinBounds(date, bounds)`, `formatBoundsLabel(bounds)` 유틸 추가.
- `app/api/items/route.ts`, `app/api/items/[id]/route.ts`: 요청 처리 시 해당 trip 의 `start_date`/`end_date` 를 한 번 fetch 해 동적 검증. trip 기간이 null 이면 검증 생략 (자유 입력).
- `ItemForm` / `PanelItemForm` / `ItemPanel(ItemDetailView)`: date input `min`/`max` 를 `useTrip()` 의 `startDate`/`endDate` 로 동적 바인딩.
- `lib/itemOptions.ts`: `TRIP_DATE_MIN`/`TRIP_DATE_MAX` 는 `@deprecated` 주석만 남기고 import 0건.

## 검증
- `npm run lint` ✅
- `npm run build` ✅
- NYC trip (2026-07-01 ~ 31): 기존 데이터 범위 내, 영향 없음.
- 기간 다른 신규 trip: 해당 trip 기간 내 item 추가 가능.
- 기간이 비어있는 trip: 모든 날짜 허용 (자유).

## 기본기 5문항
- [x] 여행 이름 보임 (G-1)
- [x] U 동작 가능 (G-2)
- [x] 시트 적응형 (G-6 별도)
- [x] 카피 약속 검증 — 마법사 약속한 ‟다른 기간 trip 도 item 추가 가능" 이 본 PR 로 실현
- [x] 모바일·데스크탑 동등 — 양쪽 폼 모두 동적 min/max

## 남은 작업 / 리스크
- `TRIP_DATE_MIN/MAX` 상수 자체는 backward-compat 위해 export 유지 (deprecated). 다음 라운드에서 완전 제거 가능.