### PR TITLE
feat(basics): #145 G-4 /trip/[tripId]/page.tsx 추가 — 기본 뷰(map) 리다이렉트

### DIFF
--- a/app/trip/[tripId]/page.tsx
+++ b/app/trip/[tripId]/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from 'next/navigation'
+import { buildTripPath } from '@/lib/hooks/useTripContext'
+
+/**
+ * /trip/[tripId] 진입 시 기본 뷰(map) 로 리다이렉트.
+ * 멤버 권한 검증은 layout.tsx 에서 이미 수행됨.
+ */
+export default function TripRootPage({ params }: { params: { tripId: string } }) {
+  redirect(buildTripPath(params.tripId, 'map'))
+}


### PR DESCRIPTION
## 관련 이슈
Closes #145

## 변경 이유
`/trip/[tripId]` 에 `page.tsx` 가 없어 Next.js 404 였음. URL 단축 공유·북마크가 깨지는 문제 해소.

## 변경 범위
- `app/trip/[tripId]/page.tsx` 신설. `redirect(buildTripPath(tripId, 'map'))` 로 map 뷰로 보냄.
- 멤버 권한 검증은 `layout.tsx` 에서 이미 수행되므로 추가 검증 불필요.

## 검증
- `npm run lint` ✅
- `npm run build` ✅

## 남은 작업 / 리스크
- 사용자 마지막 뷰 기억(localStorage) 은 본 PR 범위 밖. 단순 map 고정. 후속 이슈에서 검토.