### PR TITLE
feat(basics): #146 G-5 로그인 화면 단일-trip 시대 카피 제거

### DIFF
--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -62,8 +62,8 @@ export default function LoginForm() {
               />
             </svg>
           </div>
-          <h1 className="text-2xl font-bold text-fg">NYC Trip Planner</h1>
-          <p className="text-sm text-fg-subtle mt-1">2026년 7월 뉴욕 여행</p>
+          <h1 className="text-2xl font-bold text-fg">trip-planner</h1>
+          <p className="text-sm text-fg-subtle mt-1">로그인하여 여행을 계획하세요</p>
         </div>
 
         <form


### PR DESCRIPTION
## 관련 이슈
Closes #146

## 변경 이유
로그인 화면에 "NYC Trip Planner / 2026년 7월 뉴욕 여행" 이 단일 trip 시대 그대로 남아 신규 사용자가 "뉴욕 여행 아닌데 가입해도 되나" 의심하는 문제 해소.

## 변경 범위
- `app/login/LoginForm.tsx`: 헤딩 → "trip-planner", 서브헤딩 → "로그인하여 여행을 계획하세요". signup 화면 톤과 일관.
- forgot / auth/update-password 도 점검 — 단일 trip 잔재 없음.
- 마법사/설정 시트의 placeholder "예: 뉴욕 ..." 은 여러 도시 예시 중 하나로 단일 trip 잔재가 아니므로 유지.

## 검증
- `npm run build` ✅
- grep 으로 "NYC" / "2026년 7월" / "2026-07" 카피 잔재 0건 확인.

## 남은 작업 / 리스크
없음.