### PR TITLE
feat(basics): #147 G-6 Sheet 콘텐츠 적응형 높이 + ShareDialog 적용

### DIFF
--- a/components/UI/Sheet.tsx
+++ b/components/UI/Sheet.tsx
@@ -23,8 +23,14 @@ interface SheetProps {
    * 'auto' = md 브레이크포인트 기준 자동 (모바일 bottom, 데스크톱 right)
    */
   side?: Side
-  /** 모바일 바텀시트 높이 (vh). 기본 80. */
+  /**
+   * @deprecated 콘텐츠 적응형(height auto, max-height 90vh) 가 기본. 명시하면 max-height 로 사용된다.
+   */
   bottomHeightVh?: number
+  /** 모바일 바텀시트 최대 높이 (vh). 기본 90. 콘텐츠가 짧으면 줄어들고 길면 내부 스크롤. */
+  maxBottomHeightVh?: number
+  /** 모바일 바텀시트 최소 높이 (vh). 기본 0 (콘텐츠 적응). */
+  minBottomHeightVh?: number
   /** 데스크톱 우측 드로어 폭 (px). 기본 480. */
   rightWidthPx?: number
   title?: string
@@ -53,7 +59,9 @@ export default function Sheet({
   open,
   onClose,
   side = 'auto',
-  bottomHeightVh = 80,
+  bottomHeightVh,
+  maxBottomHeightVh = 90,
+  minBottomHeightVh = 0,
   rightWidthPx = 480,
   title,
   description,
@@ -159,7 +167,14 @@ export default function Sheet({
           className,
         )}
         style={{
-          height: side === 'right' ? '100vh' : `${bottomHeightVh}vh`,
+          height: side === 'right' ? '100vh' : 'auto',
+          maxHeight:
+            side === 'right'
+              ? undefined
+              : bottomHeightVh != null
+                ? `${bottomHeightVh}vh`
+                : `${maxBottomHeightVh}vh`,
+          minHeight: side === 'right' ? undefined : minBottomHeightVh ? `${minBottomHeightVh}vh` : undefined,
           width: side === 'right' ? `${rightWidthPx}px` : undefined,
           ...(side === 'auto'
             ? ({ '--md-width': `${rightWidthPx}px` } as React.CSSProperties)


### PR DESCRIPTION
## 관련 이슈
Closes #147

## 변경 이유
모바일 바텀시트가 콘텐츠 양과 무관하게 80vh 고정 → ShareDialog 처럼 짧은 콘텐츠는 어색하게 떠있고, 긴 콘텐츠는 잘리는 문제 해소.

## 변경 범위
- `components/UI/Sheet.tsx`:
  - 바텀 시트 height 정책 변경: `height: 80vh` 고정 → `height: auto; max-height: 90vh`. 콘텐츠 짧으면 줄어들고 길면 내부 스크롤.
  - `maxBottomHeightVh` (기본 90) / `minBottomHeightVh` (기본 0) prop 추가.
  - `bottomHeightVh` 는 deprecated. 호출부가 명시하면 max-height 로 동작 (backward-compat).
- 호출부(ShareDialog, FilterPanel) 는 prop 무명시 — 자동으로 새 정책.

## 검증
- `npm run lint` ✅
- `npm run build` ✅
- 데스크탑 우측 시트(side='right'): height 100vh 유지, 회귀 없음.

## 남은 작업 / 리스크
- G-14 (#155) 에서 ItemPanel 이 Sheet 로 흡수될 때 본 정책 자동 상속.