### PR TITLE
feat(basics): #148 G-7 항목 추가 동선 전 뷰 통일

### DIFF
--- a/app/trip/[tripId]/list/page.tsx
+++ b/app/trip/[tripId]/list/page.tsx
@@ -3,7 +3,8 @@
 import { Suspense, useEffect, useMemo, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import dynamic from 'next/dynamic'
-import { Search, Share2 } from 'lucide-react'
+import Link from 'next/link'
+import { Plus, Search, Share2 } from 'lucide-react'
 import ShareDialog from '@/components/Share/ShareDialog'
 import { useTripId } from '@/lib/hooks/useTripContext'
 import TripPageTitle from '@/components/UI/TripPageTitle'
@@ -191,6 +192,13 @@ function ResearchPageContent() {
         <div className="flex items-center justify-between mb-4">
           <TripPageTitle section="목록" />
           <div className="flex items-center gap-2">
+            <Link
+              href={`/trip/${tripId}/items/new`}
+              className="hidden md:inline-flex items-center gap-1.5 rounded-md bg-accent text-accent-fg px-3 py-1.5 text-sm font-medium hover:bg-accent-hover"
+            >
+              <Plus className="size-4" aria-hidden />
+              새 항목
+            </Link>
             <button
               type="button"
               onClick={() => setShareDialogOpen(true)}

--- a/app/trip/[tripId]/schedule/page.tsx
+++ b/app/trip/[tripId]/schedule/page.tsx
@@ -10,6 +10,7 @@ import ThemeToggle from '@/components/Theme/ThemeToggle'
 import { useItems } from '@/lib/hooks/useItems'
 import { useToast } from '@/components/UI/Toast'
 import TripPageTitle from '@/components/UI/TripPageTitle'
+import FAB from '@/components/UI/FAB'
 
 const ItemPanel = dynamic(() => import('@/components/Panel/ItemPanel'), { ssr: false })
 
@@ -92,6 +93,8 @@ function SchedulePageContent() {
       )}
 
       <Navigation />
+
+      <FAB className="md:hidden" />
 
       <ItemPanel
         item={selectedItem}

--- a/components/Plan/PlanScreen.tsx
+++ b/components/Plan/PlanScreen.tsx
@@ -7,6 +7,9 @@ import Navigation from '@/components/Layout/Navigation'
 import MapSidePanel, { type DaySummary } from '@/components/Map/MapSidePanel'
 import ThemeToggle from '@/components/Theme/ThemeToggle'
 import FAB from '@/components/UI/FAB'
+import { useTripPath } from '@/lib/hooks/useTripContext'
+import Link from 'next/link'
+import { Plus } from 'lucide-react'
 import { useItems } from '@/lib/hooks/useItems'
 import {
   PANEL_SNAP_POINTS_VH,
@@ -82,6 +85,7 @@ function buildDaySummaries(items: TripItem[]): DaySummary[] {
 export default function PlanScreen({ basePath }: PlanScreenProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const tripPath = useTripPath()
   const { items, isLoading } = useItems()
   const { showToast } = useToast()
 
@@ -174,6 +178,14 @@ export default function PlanScreen({ basePath }: PlanScreenProps) {
           <div className="pointer-events-none absolute top-3 left-3 z-[600] max-w-[60%] rounded-md bg-bg-elevated/90 px-2.5 py-1.5 shadow-sm backdrop-blur">
             <TripContextLabel />
           </div>
+          <Link
+            href={tripPath('items/new')}
+            className="absolute top-3 right-3 z-[600] inline-flex items-center gap-1.5 rounded-lg bg-accent text-accent-fg px-3 py-2 text-sm font-medium shadow-md hover:bg-accent-hover transition-colors"
+            aria-label="새 항목 추가"
+          >
+            <Plus className="size-4" aria-hidden />
+            새 항목
+          </Link>
         </div>
       </div>
 

--- a/components/Research/ResearchTable.tsx
+++ b/components/Research/ResearchTable.tsx
@@ -174,9 +174,21 @@ export default function ResearchTable({
         <p className="text-sm font-medium text-fg mb-1">
           {hasActiveSearch ? '검색 결과가 없어요' : '아직 등록된 항목이 없어요'}
         </p>
-        <p className="text-xs text-fg-subtle">
+        <p className="text-xs text-fg-subtle mb-4">
           {hasActiveSearch ? '필터 조건을 바꿔보세요' : '항목을 추가하면 여기에 표시됩니다'}
         </p>
+        {!hasActiveSearch && (
+          <button
+            type="button"
+            onClick={() => { setAddingRow(true); setNewItemName('') }}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-accent text-accent-fg px-4 py-2 text-sm font-medium hover:bg-accent-hover transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
+            </svg>
+            새 항목 추가
+          </button>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
## 관련 이슈
Closes #148

## 변경 이유
‟+ 새 항목" 동선이 뷰마다 비대칭이라 빈 상태·데스크탑 map·schedule 모바일에서 진입점이 없거나 멀었던 문제 해소.

## 변경 범위
- **list 데스크탑**: 헤더 우측에 ‟+ 새 항목" 상시 노출 (긴 목록에서도 1클릭).
- **ResearchTable 빈 상태**: 명시적 ‟새 항목 추가" CTA 버튼.
- **schedule 모바일**: `<FAB />` 추가.
- **map 데스크탑**: 지도 우측 상단에 ‟+ 새 항목" 떠있는 버튼.
- mobile FAB 가 이미 있던 list/map 모바일은 변경 없음.

## 검증
- `npm run lint` ✅
- `npm run build` ✅
- list·map·schedule × 모바일·데스크탑 6 조합 모두 1클릭 추가 진입 확인.

## 기본기 5문항
- [x] 여행 이름 보임
- [x] 진입점 일관성 — 본 PR 의 목적
- [x] 시트 적응형 (G-6 완료)
- [x] 빈 상태 CTA 보임 (ResearchTable)
- [x] 모바일·데스크탑 동등

## 남은 작업 / 리스크
- 지도 우클릭/롱프레스 좌표 기반 추가는 G-8 (#149) 별도.