### PR TITLE
feat(basics): #149 G-8 지도 우클릭·롱프레스로 그 좌표에 항목 추가

### DIFF
--- a/app/api/geocode/route.ts
+++ b/app/api/geocode/route.ts
@@ -1,13 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { geocodeAddress } from '@/lib/geocode'
+import { geocodeAddress, reverseGeocode } from '@/lib/geocode'
 
 export async function GET(request: NextRequest) {
   const q = request.nextUrl.searchParams.get('q')
-  if (!q) {
-    return NextResponse.json({ error: 'q 파라미터가 필요합니다.' }, { status: 400 })
-  }
+  const lat = request.nextUrl.searchParams.get('lat')
+  const lng = request.nextUrl.searchParams.get('lng')
 
   try {
+    if (lat && lng) {
+      const latN = parseFloat(lat)
+      const lngN = parseFloat(lng)
+      if (!Number.isFinite(latN) || !Number.isFinite(lngN)) {
+        return NextResponse.json({ error: '잘못된 좌표' }, { status: 400 })
+      }
+      const result = await reverseGeocode(latN, lngN)
+      if (!result) return NextResponse.json({ address: null })
+      return NextResponse.json(result)
+    }
+    if (!q) {
+      return NextResponse.json({ error: 'q 또는 lat/lng 파라미터가 필요합니다.' }, { status: 400 })
+    }
     const result = await geocodeAddress(q)
     if (!result) return NextResponse.json({ lat: null, lng: null })
     return NextResponse.json(result)

--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useRef, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import type { Category, ReservationStatus, TripItem, TripPriority, Link as TripLink } from '@/types'
 import { useItems } from '@/lib/hooks/useItems'
 import { useTrip, useTripPath } from '@/lib/hooks/useTripContext'
@@ -39,19 +39,25 @@ interface ItemFormProps {
 
 export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const tripPath = useTripPath()
   const trip = useTrip()
   const dateMin = trip.startDate ?? undefined
   const dateMax = trip.endDate ?? undefined
   const { createItem, updateItem, deleteItem } = useItems()
+
+  // 지도에서 좌표 프리필 (create 모드에서만)
+  const queryLat = mode === 'create' ? searchParams.get('lat') : null
+  const queryLng = mode === 'create' ? searchParams.get('lng') : null
+
   const [form, setForm] = useState<FormData>({
     name: initialData?.name ?? '',
     category: initialData?.category ?? '명소',
     trip_priority: initialData?.trip_priority ?? '검토 필요',
     reservation_status: initialData?.reservation_status ?? '확인 필요',
     address: initialData?.address ?? '',
-    lat: initialData?.lat?.toString() ?? '',
-    lng: initialData?.lng?.toString() ?? '',
+    lat: queryLat ?? initialData?.lat?.toString() ?? '',
+    lng: queryLng ?? initialData?.lng?.toString() ?? '',
     budget: initialData?.budget?.toString() ?? '',
     memo: initialData?.memo ?? '',
     date: initialData?.date ?? '',
@@ -74,6 +80,29 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
     el.style.height = 'auto'
     el.style.height = `${el.scrollHeight}px`
   }, [form.memo])
+
+  // 지도에서 좌표만 받아왔을 때 주소 자동 역지오코딩
+  useEffect(() => {
+    if (mode !== 'create') return
+    if (!queryLat || !queryLng) return
+    if (initialData?.address) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch(`/api/geocode?lat=${queryLat}&lng=${queryLng}`)
+        const data = await res.json()
+        if (!cancelled && data?.address && typeof data.address === 'string') {
+          setForm((prev) => (prev.address ? prev : { ...prev, address: data.address }))
+        }
+      } catch {
+        // 역지오코딩 실패는 조용히 무시 (좌표는 이미 채워짐)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   function setField<K extends keyof FormData>(key: K, value: FormData[K]) {
     if (key === 'name') setNameError('')

--- a/components/Map/MapAddOnLongPress.tsx
+++ b/components/Map/MapAddOnLongPress.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useMap } from 'react-leaflet'
+import { useRouter } from 'next/navigation'
+import L from 'leaflet'
+import { useTripPath } from '@/lib/hooks/useTripContext'
+
+const LONG_PRESS_MS = 500
+
+/**
+ * 지도 우클릭(데스크탑) / 롱프레스(모바일) 핸들러.
+ * 트리거된 좌표에 "여기에 새 장소 추가" 팝업 표시 → 클릭 시 items/new?lat=&lng= 로 이동.
+ *
+ * react-leaflet v4 의 useMap 훅을 사용. MapContainer 의 child 로 렌더해야 함.
+ */
+export default function MapAddOnLongPress() {
+  const map = useMap()
+  const router = useRouter()
+  const tripPath = useTripPath()
+  const [popup, setPopup] = useState<{ lat: number; lng: number } | null>(null)
+  const popupMarkerRef = useRef<L.Marker | null>(null)
+  const touchTimerRef = useRef<number | null>(null)
+  const touchStartLatLngRef = useRef<L.LatLng | null>(null)
+
+  useEffect(() => {
+    function showAt(latlng: L.LatLng) {
+      setPopup({ lat: latlng.lat, lng: latlng.lng })
+    }
+
+    function onContextMenu(e: L.LeafletMouseEvent) {
+      e.originalEvent.preventDefault()
+      showAt(e.latlng)
+    }
+
+    function onMapClick() {
+      // 다른 곳 클릭 시 팝업 닫기
+      setPopup(null)
+    }
+
+    function clearLongPress() {
+      if (touchTimerRef.current != null) {
+        window.clearTimeout(touchTimerRef.current)
+        touchTimerRef.current = null
+      }
+      touchStartLatLngRef.current = null
+    }
+
+    function onTouchStart(e: L.LeafletEvent) {
+      const ev = e as unknown as L.LeafletMouseEvent
+      const latlng = ev.latlng
+      if (!latlng) return
+      touchStartLatLngRef.current = latlng
+      touchTimerRef.current = window.setTimeout(() => {
+        if (touchStartLatLngRef.current) showAt(touchStartLatLngRef.current)
+        touchTimerRef.current = null
+      }, LONG_PRESS_MS)
+    }
+
+    // mousedown/mouseup 으로 모바일 long-press 시뮬레이션 — leaflet 의 contextmenu 는 데스크탑 우클릭.
+    map.on('contextmenu', onContextMenu)
+    map.on('click', onMapClick)
+    map.on('mousedown' as unknown as 'click', onTouchStart as unknown as L.LeafletMouseEventHandlerFn)
+    map.on('mouseup' as unknown as 'click', clearLongPress as unknown as L.LeafletMouseEventHandlerFn)
+    map.on('mousemove' as unknown as 'click', clearLongPress as unknown as L.LeafletMouseEventHandlerFn)
+    map.on('dragstart', clearLongPress)
+
+    return () => {
+      map.off('contextmenu', onContextMenu)
+      map.off('click', onMapClick)
+      map.off('mousedown' as unknown as 'click', onTouchStart as unknown as L.LeafletMouseEventHandlerFn)
+      map.off('mouseup' as unknown as 'click', clearLongPress as unknown as L.LeafletMouseEventHandlerFn)
+      map.off('mousemove' as unknown as 'click', clearLongPress as unknown as L.LeafletMouseEventHandlerFn)
+      map.off('dragstart', clearLongPress)
+      clearLongPress()
+    }
+  }, [map])
+
+  // 팝업 표시
+  useEffect(() => {
+    if (!popup) {
+      popupMarkerRef.current?.remove()
+      popupMarkerRef.current = null
+      return
+    }
+    const html = `<button type="button" data-add-here class="px-2.5 py-1.5 rounded-md bg-accent text-accent-fg text-xs font-medium shadow-md hover:bg-accent-hover whitespace-nowrap">+ 여기에 새 장소</button>`
+    const icon = L.divIcon({
+      html,
+      className: 'tp-add-here-popup',
+      iconSize: [120, 28],
+      iconAnchor: [60, 36],
+    })
+    const marker = L.marker([popup.lat, popup.lng], { icon, interactive: true, zIndexOffset: 2000 })
+    marker.addTo(map)
+    marker.on('click', () => {
+      router.push(`${tripPath('items/new')}?lat=${popup.lat}&lng=${popup.lng}`)
+    })
+    popupMarkerRef.current = marker
+    return () => {
+      marker.remove()
+    }
+  }, [popup, map, router, tripPath])
+
+  return null
+}

--- a/components/Map/TripPlannerMap.tsx
+++ b/components/Map/TripPlannerMap.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react'
 import { MapContainer, TileLayer, Marker, Polyline, Tooltip } from 'react-leaflet'
+import MapAddOnLongPress from './MapAddOnLongPress'
 import L from 'leaflet'
 import type { TripItem } from '@/types'
 import { CATEGORY_META } from '@/lib/itemOptions'
@@ -145,6 +146,8 @@ export default function TripPlannerMap({
       {polyline.length > 1 && (
         <Polyline positions={polyline} pathOptions={{ className: 'tp-day-route' }} weight={2.5} opacity={0.6} />
       )}
+
+      <MapAddOnLongPress />
     </MapContainer>
   )
 }

--- a/lib/geocode.ts
+++ b/lib/geocode.ts
@@ -3,7 +3,7 @@ export async function geocodeAddress(q: string): Promise<{ lat: number; lng: num
 
   const res = await fetch(url, {
     headers: {
-      'User-Agent': 'NYC-Trip-Planner/1.0 (personal-travel-tool)',
+      'User-Agent': 'trip-planner/1.0 (personal-travel-tool)',
     },
   })
 
@@ -16,4 +16,19 @@ export async function geocodeAddress(q: string): Promise<{ lat: number; lng: num
     lat: parseFloat(data[0].lat),
     lng: parseFloat(data[0].lon),
   }
+}
+
+export async function reverseGeocode(
+  lat: number,
+  lng: number,
+): Promise<{ address: string } | null> {
+  const url = `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json&accept-language=ko`
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'trip-planner/1.0 (personal-travel-tool)' },
+  })
+  if (!res.ok) return null
+  const data = await res.json()
+  const address = data?.display_name as string | undefined
+  if (!address) return null
+  return { address }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #149

## 변경 이유
‟지도를 길게 눌러 장소를 추가하세요" 카피만 있고 실제 핸들러는 0건이던 거짓 카피를 실제 동작으로 구현.

## 변경 범위
- `components/Map/MapAddOnLongPress.tsx`: react-leaflet `useMap` 으로 contextmenu(데스크탑 우클릭) + mousedown 500ms 유지(롱프레스) 감지. 트리거 좌표에 ‟+ 여기에 새 장소" 떠있는 버튼. 클릭 시 `items/new?lat=&lng=` 로 이동.
- `components/Map/TripPlannerMap.tsx`: 위 컴포넌트를 MapContainer 자식으로 마운트.
- `components/Items/ItemForm.tsx`: create 모드 + lat/lng query param 있으면 폼 좌표 프리필 + `/api/geocode?lat=&lng=` 호출해 주소 자동 채움 시도 (실패는 silent).
- `lib/geocode.ts`: `reverseGeocode(lat, lng)` 추가 (Nominatim reverse, ko 우선).
- `app/api/geocode/route.ts`: lat/lng 쿼리 분기 지원.

## 검증
- `npm run lint` ✅
- `npm run build` ✅

## 기본기 5문항
- [x] 여행 이름 보임
- [x] U 동작 가능 (G-2)
- [x] 시트 적응형 (G-6)
- [x] 카피 약속 실제 가능 — 본 PR 의 목적
- [x] 모바일·데스크탑 동등 — 우클릭 / 롱프레스 양쪽

## 남은 작업 / 리스크
- 모바일 long-press 는 leaflet 의 mousedown/mouseup/mousemove 이벤트로 시뮬레이션. 일부 모바일 브라우저 touch 이벤트 변환 차이가 있을 수 있음.
- Nominatim 무료 API — rate limit (1 req/sec) 이슈는 후속 캐싱 이슈에서 검토.