### PR TITLE
feat(basics): #151 G-10 window.confirm 3건 → 공통 ConfirmDialog

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { SWRProvider } from '@/lib/providers/SWRProvider'
 import { ToastProvider } from '@/components/UI/Toast'
+import { ConfirmProvider } from '@/components/UI/ConfirmDialog'
 import { ThemeProvider } from '@/components/Theme/ThemeProvider'
 import OfflineBanner from '@/components/UI/OfflineBanner'
 
@@ -10,8 +11,10 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     <ThemeProvider>
       <SWRProvider>
         <ToastProvider>
-          <OfflineBanner />
-          {children}
+          <ConfirmProvider>
+            <OfflineBanner />
+            {children}
+          </ConfirmProvider>
         </ToastProvider>
       </SWRProvider>
     </ThemeProvider>

--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import type { Category, ReservationStatus, TripItem, TripPriority, Link as TripLink } from '@/types'
 import { useItems } from '@/lib/hooks/useItems'
 import { useTrip, useTripPath } from '@/lib/hooks/useTripContext'
+import { useConfirm } from '@/components/UI/ConfirmDialog'
 import {
   CATEGORY_OPTIONS,
   ITEM_FIELD_LABELS,
@@ -45,6 +46,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
   const dateMin = trip.startDate ?? undefined
   const dateMax = trip.endDate ?? undefined
   const { createItem, updateItem, deleteItem } = useItems()
+  const confirm = useConfirm()
 
   // 지도에서 좌표 프리필 (create 모드에서만)
   const queryLat = mode === 'create' ? searchParams.get('lat') : null
@@ -209,7 +211,13 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
   }
 
   async function handleDelete() {
-    if (!confirm('이 항목을 삭제하시겠습니까?')) return
+    const ok = await confirm({
+      title: '항목 삭제',
+      description: '이 항목을 삭제하시겠습니까?',
+      confirmLabel: '삭제',
+      tone: 'destructive',
+    })
+    if (!ok) return
     setLoading(true)
     if (itemId) {
       await deleteItem(itemId)

--- a/components/Panel/ItemPanel.tsx
+++ b/components/Panel/ItemPanel.tsx
@@ -6,6 +6,7 @@ import type { TripItem } from '@/types'
 import PanelItemForm from './PanelItemForm'
 import { useItems } from '@/lib/hooks/useItems'
 import { useTrip } from '@/lib/hooks/useTripContext'
+import { useConfirm } from '@/components/UI/ConfirmDialog'
 import {
   CATEGORY_OPTIONS,
   CHIP_TONE,
@@ -29,6 +30,7 @@ export interface ItemPanelProps {
 
 export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: ItemPanelProps) {
   const { deleteItem, updateItem } = useItems()
+  const confirm = useConfirm()
   const [mode, setMode] = useState<'view' | 'edit'>('view')
   const [isDirty, setIsDirty] = useState(false)
   const [confirmingClose, setConfirmingClose] = useState(false)
@@ -118,7 +120,13 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
   }
 
   async function handleDelete(id: string) {
-    if (!confirm('이 항목을 삭제하시겠습니까?')) return
+    const ok = await confirm({
+      title: '항목 삭제',
+      description: '이 항목을 삭제하시겠습니까?',
+      confirmLabel: '삭제',
+      tone: 'destructive',
+    })
+    if (!ok) return
     await deleteItem(id)
     onDelete(id)
     onClose()

--- a/components/Share/ShareDialog.tsx
+++ b/components/Share/ShareDialog.tsx
@@ -5,6 +5,7 @@ import { Copy, Plus, Trash2, Check, AlertCircle } from 'lucide-react'
 import Sheet from '@/components/UI/Sheet'
 import Button from '@/components/UI/Button'
 import { useToast } from '@/components/UI/Toast'
+import { useConfirm } from '@/components/UI/ConfirmDialog'
 import type { Share } from '@/lib/share'
 import { isShareActive } from '@/lib/share'
 import { buildShareUrl } from '@/lib/sharedTrip'
@@ -22,6 +23,7 @@ export default function ShareDialog({ open, onClose, tripId }: Props) {
   const [error, setError] = useState<string | null>(null)
   const [copiedToken, setCopiedToken] = useState<string | null>(null)
   const { showToast } = useToast()
+  const confirm = useConfirm()
 
   const origin = useMemo(() => (typeof window !== 'undefined' ? window.location.origin : ''), [])
 
@@ -64,7 +66,13 @@ export default function ShareDialog({ open, onClose, tripId }: Props) {
   }
 
   const handleRevoke = async (token: string) => {
-    if (!window.confirm('이 링크를 회수하시겠어요? 이후로 접속이 차단됩니다.')) return
+    const ok = await confirm({
+      title: '공유 링크 회수',
+      description: '이 링크를 회수하시겠어요? 이후로 접속이 차단됩니다.',
+      confirmLabel: '회수',
+      tone: 'destructive',
+    })
+    if (!ok) return
     try {
       const res = await fetch(`/api/trips/${tripId}/shares/${token}/revoke`, { method: 'POST' })
       if (!res.ok) throw new Error('회수에 실패했습니다.')

--- a/components/UI/ConfirmDialog.tsx
+++ b/components/UI/ConfirmDialog.tsx
@@ -1,0 +1,197 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { createPortal } from 'react-dom'
+import Button from './Button'
+import { Input } from './Input'
+import { cn } from '@/lib/cn'
+
+export type ConfirmTone = 'default' | 'destructive'
+
+export interface ConfirmOptions {
+  title: string
+  description?: ReactNode
+  confirmLabel?: string
+  cancelLabel?: string
+  tone?: ConfirmTone
+  /**
+   * 입력해야 하는 확인 문자열. 사용자가 정확히 같은 값을 타이핑해야 확인 가능.
+   * trip 삭제처럼 파괴력이 큰 액션에서 사용.
+   */
+  typeToConfirm?: string
+}
+
+type ConfirmContextValue = (opts: ConfirmOptions) => Promise<boolean>
+
+const ConfirmContext = createContext<ConfirmContextValue | null>(null)
+
+export function useConfirm(): ConfirmContextValue {
+  const v = useContext(ConfirmContext)
+  if (!v) throw new Error('useConfirm 은 ConfirmProvider 내부에서만 사용 가능합니다.')
+  return v
+}
+
+interface PendingState extends ConfirmOptions {
+  resolve: (value: boolean) => void
+}
+
+export function ConfirmProvider({ children }: { children: ReactNode }) {
+  const [pending, setPending] = useState<PendingState | null>(null)
+
+  const confirm = useCallback<ConfirmContextValue>(
+    (opts) =>
+      new Promise<boolean>((resolve) => {
+        setPending({ ...opts, resolve })
+      }),
+    [],
+  )
+
+  function handleResolve(value: boolean) {
+    pending?.resolve(value)
+    setPending(null)
+  }
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      {pending && <ConfirmDialog options={pending} onResolve={handleResolve} />}
+    </ConfirmContext.Provider>
+  )
+}
+
+function ConfirmDialog({
+  options,
+  onResolve,
+}: {
+  options: ConfirmOptions
+  onResolve: (value: boolean) => void
+}) {
+  const [typed, setTyped] = useState('')
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+  const previouslyFocused = useRef<HTMLElement | null>(null)
+
+  const requiresTyping = !!options.typeToConfirm
+  const canConfirm = !requiresTyping || typed === options.typeToConfirm
+
+  useEffect(() => {
+    previouslyFocused.current = document.activeElement as HTMLElement | null
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onResolve(false)
+        return
+      }
+      if (e.key === 'Tab' && dialogRef.current) {
+        const focusables = dialogRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        )
+        if (focusables.length === 0) return
+        const first = focusables[0]
+        const last = focusables[focusables.length - 1]
+        const active = document.activeElement
+        if (e.shiftKey && active === first) {
+          e.preventDefault()
+          last.focus()
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+
+    // 첫 포커스
+    window.setTimeout(() => {
+      const target = dialogRef.current?.querySelector<HTMLElement>(
+        '[data-autofocus], input:not([disabled]), button:not([disabled])',
+      )
+      target?.focus()
+    }, 30)
+
+    return () => {
+      document.removeEventListener('keydown', handleKey)
+      document.body.style.overflow = prevOverflow
+      previouslyFocused.current?.focus?.()
+    }
+  }, [onResolve])
+
+  if (typeof window === 'undefined') return null
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-title"
+      className="fixed inset-0 z-[1200] flex items-center justify-center px-4"
+    >
+      <button
+        type="button"
+        aria-label="닫기"
+        onClick={() => onResolve(false)}
+        className="absolute inset-0 bg-overlay animate-fade-in cursor-default"
+      />
+      <div
+        ref={dialogRef}
+        className={cn(
+          'relative w-full max-w-sm rounded-2xl bg-bg-elevated border border-border shadow-e28',
+          'animate-fade-in',
+        )}
+      >
+        <div className="px-5 pt-5 pb-3">
+          <h2 id="confirm-title" className="text-base font-semibold text-fg mb-2">
+            {options.title}
+          </h2>
+          {options.description ? (
+            <div className="text-sm text-fg-muted leading-relaxed">{options.description}</div>
+          ) : null}
+        </div>
+
+        {requiresTyping && (
+          <div className="px-5 pb-2 space-y-1.5">
+            <p className="text-xs text-fg-subtle">
+              계속하려면{' '}
+              <code className="px-1 rounded bg-bg-subtle text-fg font-mono text-[11px]">
+                {options.typeToConfirm}
+              </code>{' '}
+              를 입력하세요
+            </p>
+            <Input
+              label="확인 문자열"
+              hideLabel
+              value={typed}
+              onChange={(e) => setTyped(e.target.value)}
+              data-autofocus
+              autoComplete="off"
+            />
+          </div>
+        )}
+
+        <div className="border-t border-border px-5 py-3 flex items-center justify-end gap-2">
+          <Button variant="ghost" onClick={() => onResolve(false)}>
+            {options.cancelLabel ?? '취소'}
+          </Button>
+          <Button
+            variant={options.tone === 'destructive' ? 'destructive' : 'primary'}
+            onClick={() => canConfirm && onResolve(true)}
+            disabled={!canConfirm}
+            data-autofocus={requiresTyping ? undefined : true}
+          >
+            {options.confirmLabel ?? '확인'}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}


### PR DESCRIPTION
## 관련 이슈
Closes #151

## 변경 이유
ItemPanel/ItemForm/ShareDialog 가 사용하던 네이티브 `window.confirm()` 은 디자인 가이드 위반·다크모드 미적용·모바일 어색. G-9 의 trip 삭제 같은 강한 파괴 액션의 ‟타이핑 확인" 도 지원 필요.

## 변경 범위
- `components/UI/ConfirmDialog.tsx`: `ConfirmProvider` + `useConfirm()` 훅. 옵션:
  - `title`, `description`, `confirmLabel`, `cancelLabel`
  - `tone: 'default' | 'destructive'` — destructive 는 critical 버튼
  - `typeToConfirm: string` — 정확히 같은 값을 입력해야 확인 활성 (강한 케이스용)
  - esc/backdrop 닫기, 포커스 트랩, 포털 렌더, body 스크롤 잠금
- `app/providers.tsx`: `ConfirmProvider` 를 ToastProvider 안에 마운트.
- `components/Panel/ItemPanel.tsx`, `components/Items/ItemForm.tsx`, `components/Share/ShareDialog.tsx`: 네이티브 confirm 3건 모두 `useConfirm()` 로 교체.

## 검증
- `npm run lint` ✅
- `npm run build` ✅
- grep 으로 `window.confirm` / 네이티브 `confirm(` 호출 0건 확인 (모두 hook 호출로 교체).

## 남은 작업 / 리스크
- G-9 (#150) 의 trip 삭제는 본 PR 의 `typeToConfirm: trip.title` 옵션을 사용 예정.