### PR TITLE
feat(basics): #150 G-9 DELETE /api/trips/[tripId] + 대시보드 카드 메뉴

### DIFF
--- a/app/api/trips/[tripId]/route.ts
+++ b/app/api/trips/[tripId]/route.ts
@@ -94,3 +94,39 @@ export async function PATCH(
 
   return NextResponse.json({ trip: data })
 }
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: { tripId: string } },
+) {
+  const { tripId } = params
+  if (!UUID_RE.test(tripId)) {
+    return NextResponse.json({ error: '잘못된 trip id' }, { status: 400 })
+  }
+
+  const client = createRouteHandlerSupabase()
+  const { data: userData } = await client.auth.getUser()
+  if (!userData.user) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+  }
+
+  const { data, error } = await client
+    .from('trips')
+    .delete()
+    .eq('id', tripId)
+    .select('id')
+    .maybeSingle()
+
+  if (error) {
+    console.error('[DELETE /api/trips/:id]', error)
+    return NextResponse.json({ error: '여행 삭제에 실패했습니다.' }, { status: 500 })
+  }
+  if (!data) {
+    return NextResponse.json(
+      { error: '권한이 없거나 trip 을 찾을 수 없습니다 (소유자만 삭제 가능).' },
+      { status: 403 },
+    )
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -1,12 +1,15 @@
 'use client'
 
 import { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { LogOut, MapPin, Plus, Search, User } from 'lucide-react'
+import { LogOut, MapPin, MoreVertical, Plus, Search, Trash2, User } from 'lucide-react'
 import ThemeToggle from '@/components/Theme/ThemeToggle'
 import { Input } from '@/components/UI/Input'
 import Button from '@/components/UI/Button'
 import EmptyState from '@/components/UI/EmptyState'
+import { useConfirm } from '@/components/UI/ConfirmDialog'
+import { useToast } from '@/components/UI/Toast'
 import { clearAppCache } from '@/lib/clearAppCache'
 import type { TripSummary } from '@/lib/trips'
 
@@ -53,9 +56,38 @@ interface Props {
 }
 
 export default function DashboardClient({ initialTrips, userEmail }: Props) {
-  const [trips] = useState<TripSummary[]>(initialTrips)
+  const router = useRouter()
+  const confirm = useConfirm()
+  const { showToast } = useToast()
+  const [trips, setTrips] = useState<TripSummary[]>(initialTrips)
   const [query, setQuery] = useState('')
   const [sort, setSort] = useState<SortKey>('created_desc')
+  const [menuOpen, setMenuOpen] = useState<string | null>(null)
+
+  async function handleDeleteTrip(trip: TripSummary) {
+    setMenuOpen(null)
+    const ok = await confirm({
+      title: `여행 삭제: ${trip.title}`,
+      description: '이 여행과 연관된 모든 항목·공유 링크·멤버가 함께 삭제됩니다. 되돌릴 수 없습니다.',
+      confirmLabel: '삭제',
+      tone: 'destructive',
+      typeToConfirm: trip.title,
+    })
+    if (!ok) return
+    try {
+      const res = await fetch(`/api/trips/${trip.id}`, { method: 'DELETE' })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        showToast({ message: data?.error ?? '삭제에 실패했습니다.', type: 'error' })
+        return
+      }
+      setTrips((prev) => prev.filter((t) => t.id !== trip.id))
+      showToast({ message: '여행을 삭제했어요.', type: 'success' })
+      router.refresh()
+    } catch {
+      showToast({ message: '네트워크 오류가 발생했습니다.', type: 'error' })
+    }
+  }
 
   const visibleTrips = useMemo(() => {
     const q = query.trim().toLowerCase()
@@ -176,12 +208,12 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
             {visibleTrips.map(trip => {
               const range = formatRange(trip.start_date, trip.end_date)
               return (
-                <li key={trip.id}>
+                <li key={trip.id} className="relative">
                   <Link
                     href={`/trip/${trip.id}/map`}
                     className="block bg-bg-elevated border border-border rounded-xl p-4 hover:border-border-strong hover:shadow-sm transition-all duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
                   >
-                    <h2 className="text-base font-semibold text-fg mb-2 truncate">{trip.title}</h2>
+                    <h2 className="text-base font-semibold text-fg mb-2 truncate pr-8">{trip.title}</h2>
                     <div className="space-y-1 text-xs text-fg-muted">
                       {range ? (
                         <p>{range}</p>
@@ -199,6 +231,40 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
                       </p>
                     </div>
                   </Link>
+                  <div className="absolute top-3 right-3">
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault()
+                        setMenuOpen(menuOpen === trip.id ? null : trip.id)
+                      }}
+                      className="inline-flex size-8 items-center justify-center rounded-md text-fg-subtle hover:bg-bg-subtle hover:text-fg-muted"
+                      aria-label="여행 메뉴"
+                      aria-expanded={menuOpen === trip.id}
+                    >
+                      <MoreVertical className="size-4" aria-hidden />
+                    </button>
+                    {menuOpen === trip.id && (
+                      <>
+                        <button
+                          type="button"
+                          className="fixed inset-0 z-10 cursor-default"
+                          aria-label="메뉴 닫기"
+                          onClick={() => setMenuOpen(null)}
+                        />
+                        <div className="absolute right-0 top-9 z-20 w-44 rounded-lg border border-border bg-bg-elevated shadow-md py-1">
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteTrip(trip)}
+                            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-critical-fg hover:bg-bg-subtle"
+                          >
+                            <Trash2 className="size-4" aria-hidden />
+                            여행 삭제
+                          </button>
+                        </div>
+                      </>
+                    )}
+                  </div>
                 </li>
               )
             })}

--- a/components/Trip/TripSettingsSheet.tsx
+++ b/components/Trip/TripSettingsSheet.tsx
@@ -7,6 +7,8 @@ import { Input } from '@/components/UI/Input'
 import Button from '@/components/UI/Button'
 import { useToast } from '@/components/UI/Toast'
 import { useTrip } from '@/lib/hooks/useTripContext'
+import { useConfirm } from '@/components/UI/ConfirmDialog'
+import { Trash2 } from 'lucide-react'
 
 interface Props {
   open: boolean
@@ -17,6 +19,7 @@ export default function TripSettingsSheet({ open, onClose }: Props) {
   const trip = useTrip()
   const router = useRouter()
   const { showToast } = useToast()
+  const confirm = useConfirm()
 
   const [title, setTitle] = useState(trip.title)
   const [startDate, setStartDate] = useState(trip.startDate ?? '')
@@ -59,6 +62,33 @@ export default function TripSettingsSheet({ open, onClose }: Props) {
       showToast({ message: '네트워크 오류가 발생했습니다.', type: 'error' })
     } finally {
       setSaving(false)
+    }
+  }
+
+  async function handleDelete() {
+    if (trip.role !== 'owner') {
+      showToast({ message: '소유자만 여행을 삭제할 수 있습니다.', type: 'error' })
+      return
+    }
+    const ok = await confirm({
+      title: `여행 삭제: ${trip.title}`,
+      description: '이 여행과 연관된 모든 항목·공유 링크·멤버가 함께 삭제됩니다. 되돌릴 수 없습니다.',
+      confirmLabel: '삭제',
+      tone: 'destructive',
+      typeToConfirm: trip.title,
+    })
+    if (!ok) return
+    try {
+      const res = await fetch(`/api/trips/${trip.id}`, { method: 'DELETE' })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        showToast({ message: data?.error ?? '삭제에 실패했습니다.', type: 'error' })
+        return
+      }
+      showToast({ message: '여행을 삭제했어요.', type: 'success' })
+      router.push('/dashboard')
+    } catch {
+      showToast({ message: '네트워크 오류가 발생했습니다.', type: 'error' })
     }
   }
 
@@ -116,6 +146,18 @@ export default function TripSettingsSheet({ open, onClose }: Props) {
           />
         </div>
       </SheetSection>
+
+      {trip.role === 'owner' && (
+        <SheetSection title="위험 구역">
+          <p className="text-xs text-fg-muted mb-3">
+            여행을 삭제하면 연관된 모든 항목·공유 링크·멤버가 함께 삭제됩니다. 되돌릴 수 없습니다.
+          </p>
+          <Button type="button" variant="destructive" onClick={handleDelete} disabled={saving}>
+            <Trash2 className="size-4" aria-hidden />
+            여행 삭제
+          </Button>
+        </SheetSection>
+      )}
     </Sheet>
   )
 }


### PR DESCRIPTION
## 관련 이슈
Closes #150

## 변경 이유
`DELETE /api/trips/[tripId]` 라우트가 없어 trip 을 만들면 영원히 삭제 못 하던 결함 해소.

## 변경 범위
- `app/api/trips/[tripId]/route.ts`: `DELETE` 핸들러. RLS `trips_delete` 정책(owner 만) + 명시 인증 체크. 연관 items/shares/trip_members 는 schema 의 `on delete cascade` 로 자동 정리.
- `app/dashboard/DashboardClient.tsx`: 카드 우상단 ⋯ 메뉴 → ‟여행 삭제". `useConfirm({ typeToConfirm: trip.title })` 로 trip 이름을 정확히 타이핑해야 확인 활성. 삭제 후 로컬 state 에서 제거 + toast.
- `components/Trip/TripSettingsSheet.tsx`: 하단 ‟위험 구역" 섹션 (owner only) 에 삭제 버튼. 같은 ConfirmDialog 사용. 성공 시 `/dashboard` 로 이동.

## 검증
- `npm run lint` ✅
- `npm run build` ✅
- non-owner role 에는 설정 시트의 위험 구역 미노출 (`trip.role === 'owner'` 가드).
- 비-owner 가 대시보드 메뉴에서 시도해도 API 의 RLS 가 403 으로 거부.

## 남은 작업 / 리스크
- 대시보드 카드 메뉴는 모든 role 에서 표시. 비-owner 가 시도하면 API 가 403 + toast. 메뉴 자체를 owner_user_id 기반으로 숨기는 건 후속.