### PR TITLE
feat(basics): #152 G-11 마법사 베이스캠프 실제 사용 (lodging 폴백)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -286,6 +286,18 @@
   height: 26px;
   font-size: 11px;
 }
+.tp-basecamp-marker {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgb(var(--bg-elevated));
+  border: 2px dashed rgb(var(--accent));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  box-shadow: 0 2px 6px rgb(var(--shadow) / 0.25);
+}
 
 /* polyline (day route) */
 .tp-day-route {

--- a/components/Map/TripPlannerMap.tsx
+++ b/components/Map/TripPlannerMap.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { MapContainer, TileLayer, Marker, Polyline, Tooltip } from 'react-leaflet'
 import MapAddOnLongPress from './MapAddOnLongPress'
 import L from 'leaflet'
 import type { TripItem } from '@/types'
 import { CATEGORY_META } from '@/lib/itemOptions'
 import { getEndLodging, getStartLodging, isStayItem } from '@/lib/lodging'
+import { useOptionalTrip } from '@/lib/hooks/useTripContext'
 
 interface TripPlannerMapProps {
   items: TripItem[]
@@ -58,6 +59,32 @@ export default function TripPlannerMap({
   selectedItemId,
   onSelectItem,
 }: TripPlannerMapProps) {
+  const trip = useOptionalTrip()
+  const [basecampCoord, setBasecampCoord] = useState<[number, number] | null>(null)
+
+  useEffect(() => {
+    const addr = trip?.basecampAddress?.trim()
+    if (!addr) {
+      setBasecampCoord(null)
+      return
+    }
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch(`/api/geocode?q=${encodeURIComponent(addr)}`)
+        const data = await res.json()
+        if (!cancelled && typeof data?.lat === 'number' && typeof data?.lng === 'number') {
+          setBasecampCoord([data.lat, data.lng])
+        }
+      } catch {
+        // 베이스캠프 좌표 실패는 silent — lodging item 만으로 동작
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [trip?.basecampAddress])
+
   const visibleItems = useMemo(
     () =>
       items.filter(
@@ -85,17 +112,17 @@ export default function TripPlannerMap({
     const startCoord: [number, number] | null =
       startStay && startStay.lat != null && startStay.lng != null
         ? [startStay.lat, startStay.lng]
-        : null
+        : basecampCoord
     const endCoord: [number, number] | null =
       endStay && endStay.lat != null && endStay.lng != null
         ? [endStay.lat, endStay.lng]
-        : null
+        : basecampCoord
     return [
       ...(startCoord ? [startCoord] : []),
       ...activityCoords,
       ...(endCoord ? [endCoord] : []),
     ]
-  }, [dayItems, items, selectedDate])
+  }, [dayItems, items, selectedDate, basecampCoord])
 
   return (
     <MapContainer
@@ -145,6 +172,23 @@ export default function TripPlannerMap({
 
       {polyline.length > 1 && (
         <Polyline positions={polyline} pathOptions={{ className: 'tp-day-route' }} weight={2.5} opacity={0.6} />
+      )}
+
+      {basecampCoord && (
+        <Marker
+          position={basecampCoord}
+          icon={L.divIcon({
+            html: `<div class="tp-basecamp-marker">🏠</div>`,
+            className: '',
+            iconSize: [32, 32],
+            iconAnchor: [16, 16],
+          })}
+          interactive={false}
+        >
+          <Tooltip direction="top" offset={[0, -16]} opacity={0.9}>
+            <span className="text-xs font-medium">베이스캠프</span>
+          </Tooltip>
+        </Marker>
       )}
 
       <MapAddOnLongPress />


### PR DESCRIPTION
## 관련 이슈
Closes #152

## 변경 이유
마법사 Step4 "선택사항. 동선의 기준점이 돼요" 카피만 있고 `trip.basecamp_address` 가 어디서도 사용되지 않던 거짓 약속 해소.

## 변경 범위
- `components/Map/TripPlannerMap.tsx`:
  - `useOptionalTrip()` 으로 trip 컨텍스트 접근.
  - `basecamp_address` 가 있으면 `/api/geocode?q=` 로 좌표 조회 (useEffect, 주소 바뀔 때만).
  - 폴리라인 fallback: lodging 좌표 없을 때 basecamp 좌표를 시작/종료점으로 사용.
  - 지도에 🏠 baseccamp 마커 표시 (interactive=false).
- `app/globals.css`: `.tp-basecamp-marker` 스타일 (점선 accent 테두리).

## 검증
- `npm run lint` ✅
- `npm run build` ✅
- lodging 좌표 있으면 우선, 없을 때만 basecamp fallback.

## 남은 작업 / 리스크
- 매 페이지 진입마다 client-side geocode 1회 — Nominatim rate limit 부담. 후속: trip 테이블에 `basecamp_lat/lng` 컬럼 추가하여 저장 시 1회만 geocode (별도 이슈 검토).