### PR TITLE
feat(basics): #154 G-13 list 검색·필터 URL 동기화

### DIFF
--- a/app/trip/[tripId]/list/page.tsx
+++ b/app/trip/[tripId]/list/page.tsx
@@ -35,6 +35,11 @@ export default function ResearchPage() {
   )
 }
 
+function parseCsv(v: string | null): string[] {
+  if (!v) return []
+  return v.split(',').filter(Boolean)
+}
+
 function ResearchPageContent() {
   const router = useRouter()
   const pathname = usePathname()
@@ -49,13 +54,13 @@ function ResearchPageContent() {
   )
   const [highlightedIds, setHighlightedIds] = useState<Set<string>>(new Set())
 
-  const [query, setQuery] = useState('')
-  const [filterState, setFilterState] = useState<FilterState>({
-    categories: [],
-    tripPriorities: [],
-    reservationStatuses: [],
-    showExcluded: false,
-  })
+  const [query, setQuery] = useState(() => searchParams.get('q') ?? '')
+  const [filterState, setFilterState] = useState<FilterState>(() => ({
+    categories: parseCsv(searchParams.get('cat')) as Category[],
+    tripPriorities: parseCsv(searchParams.get('pri')) as TripPriority[],
+    reservationStatuses: parseCsv(searchParams.get('res')) as ReservationStatus[],
+    showExcluded: searchParams.get('excl') === '1',
+  }))
   const [filterPanelOpen, setFilterPanelOpen] = useState(false)
   const activeCount = useMemo(() => getActiveFilterCount(filterState), [filterState])
 
@@ -159,6 +164,25 @@ function ResearchPageContent() {
     const timer = setTimeout(() => setHighlightedIds(new Set()), 1000)
     return () => clearTimeout(timer)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // 검색·필터 상태를 URL search params 와 동기화 (디바운스 없이 즉시; replace 라 history 미오염)
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString())
+    const setOrDel = (k: string, v: string) => {
+      if (v) params.set(k, v)
+      else params.delete(k)
+    }
+    setOrDel('q', query.trim())
+    setOrDel('cat', filterState.categories.join(','))
+    setOrDel('pri', filterState.tripPriorities.join(','))
+    setOrDel('res', filterState.reservationStatuses.join(','))
+    setOrDel('excl', filterState.showExcluded ? '1' : '')
+    const next = buildUrl(params)
+    if (next !== `${pathname}${searchParams.toString() ? `?${searchParams.toString()}` : ''}`) {
+      router.replace(next, { scroll: false })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, filterState])
 
   useEffect(() => {
     if (isLoading || !selectedItemId) return

--- a/components/Map/MapSidePanel.tsx
+++ b/components/Map/MapSidePanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { Search, MapPin, CalendarRange } from 'lucide-react'
 import type { Category, TripItem } from '@/types'
 import { CATEGORY_META, CATEGORY_OPTIONS, TRIP_PRIORITY_META } from '@/lib/itemOptions'
@@ -221,8 +222,21 @@ function CandidatesView({
   selectedItemId: string | null
   onSelectItem: (id: string) => void
 }) {
-  const [query, setQuery] = useState('')
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [query, setQuery] = useState(() => searchParams.get('q') ?? '')
   const [categoryFilter, setCategoryFilter] = useState<Category | null>(null)
+
+  // 검색어를 URL ?q 로 동기화 — list 와 공유 (뷰 전환 시 검색 유지)
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString())
+    if (query.trim()) params.set('q', query.trim())
+    else params.delete('q')
+    const next = params.toString() ? `${pathname}?${params.toString()}` : pathname
+    router.replace(next, { scroll: false })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query])
 
   const counts = useMemo(() => categoryCounts(items), [items])
   const filtered = useMemo(() => {


### PR DESCRIPTION
## 관련 이슈
Closes #154

## 변경 이유
검색·필터 상태가 URL 미동기화라 list↔map↔schedule 전환·새로고침·뒤로가기 시 상태가 사라지던 문제 해소.

## 변경 범위
- `app/trip/[tripId]/list/page.tsx`:
  - 초기값을 `searchParams` 에서 읽기 (`q`, `cat`, `pri`, `res`, `excl`).
  - 상태 변경 시 useEffect 로 URL 갱신 (router.replace, scroll: false).
- `components/Map/MapSidePanel.tsx`: 동일 `q` 키로 URL 동기화 — list↔map 검색어 공유.

## 검증
- `npm run lint` ✅
- `npm run build` ✅
- list 검색 후 map 으로 전환 → 검색어 유지 확인.
- 새로고침해도 필터 보존.

## 남은 작업 / 리스크
- 정렬(sortKey/sortDir) 은 ResearchTable 내부 state — URL 동기화는 후속 이슈로 분리 권장 (page 레벨로 lift 필요).
- schedule collapsedDates 는 G-20 (#161) 별도.