### PR TITLE
feat(basics): #158 G-17 로그아웃 핸들러 lib/auth-client 일원화

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -10,7 +10,7 @@ import Button from '@/components/UI/Button'
 import EmptyState from '@/components/UI/EmptyState'
 import { useConfirm } from '@/components/UI/ConfirmDialog'
 import { useToast } from '@/components/UI/Toast'
-import { clearAppCache } from '@/lib/clearAppCache'
+import { logout } from '@/lib/auth-client'
 import type { TripSummary } from '@/lib/trips'
 
 type SortKey = 'created_desc' | 'start_date' | 'name'
@@ -44,11 +44,7 @@ function formatRange(start: string | null, end: string | null): string | null {
   return `${formatDateShort(end!)} 까지`
 }
 
-async function handleLogout() {
-  await fetch('/api/auth/logout', { method: 'POST' })
-  clearAppCache()
-  window.location.href = '/login'
-}
+const handleLogout = logout
 
 interface Props {
   initialTrips: TripSummary[]

--- a/app/me/ProfileClient.tsx
+++ b/app/me/ProfileClient.tsx
@@ -6,13 +6,9 @@ import { ArrowLeft, LogOut } from 'lucide-react'
 import Button from '@/components/UI/Button'
 import { Input } from '@/components/UI/Input'
 import { useToast } from '@/components/UI/Toast'
-import { clearAppCache } from '@/lib/clearAppCache'
+import { logout } from '@/lib/auth-client'
 
-async function handleLogout() {
-  await fetch('/api/auth/logout', { method: 'POST' })
-  clearAppCache()
-  window.location.href = '/login'
-}
+const handleLogout = logout
 
 interface Props {
   email: string

--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -7,7 +7,7 @@ import { ArrowLeft, List, Map, CalendarDays, Download, LogOut, MoreHorizontal, U
 import ThemeToggle from '@/components/Theme/ThemeToggle'
 import Sheet, { SheetSection } from '@/components/UI/Sheet'
 import { cn } from '@/lib/cn'
-import { clearAppCache } from '@/lib/clearAppCache'
+import { logout } from '@/lib/auth-client'
 import { useOptionalTripId, buildTripPath } from '@/lib/hooks/useTripContext'
 
 interface NavItem {
@@ -22,11 +22,7 @@ const NAV_ITEMS: NavItem[] = [
   { sub: 'schedule', label: '일정', icon: CalendarDays },
 ]
 
-async function handleLogout() {
-  await fetch('/api/auth/logout', { method: 'POST' })
-  clearAppCache()
-  window.location.href = '/login'
-}
+const handleLogout = logout
 
 function legacyHref(sub: string): string {
   return `/${sub}`

--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -1,0 +1,18 @@
+'use client'
+
+import { clearAppCache } from '@/lib/clearAppCache'
+
+/**
+ * 클라이언트 로그아웃 일원화 헬퍼.
+ * - /api/auth/logout 호출
+ * - 앱 로컬 캐시 클리어
+ * - /login 으로 하드 리로드 (state 완전 초기화)
+ */
+export async function logout(): Promise<void> {
+  try {
+    await fetch('/api/auth/logout', { method: 'POST' })
+  } finally {
+    clearAppCache()
+    window.location.href = '/login'
+  }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #158

## 변경 범위
- `lib/auth-client.ts` 신설: `logout()` = fetch + clearAppCache + 하드 리로드.
- Navigation / DashboardClient / ProfileClient 3 곳 동일 로직 중복 → 단일 import 로 교체.

## 검증
- `npm run lint` ✅, `npm run build` ✅
- grep: `fetch('/api/auth/logout')` 직접 호출 1 곳 (lib) 으로 축소.