### PR TITLE
feat(basics): #160 G-19 PUT /api/items/[id] → PATCH 시맨틱 정리

### DIFF
--- a/app/api/items/[id]/route.ts
+++ b/app/api/items/[id]/route.ts
@@ -106,7 +106,7 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
   return NextResponse.json({ item })
 }
 
-export async function PUT(request: NextRequest, { params }: RouteContext) {
+export async function PATCH(request: NextRequest, { params }: RouteContext) {
   const client = createRouteHandlerSupabase()
   const tripId = getTripIdFromRequest(request)
   const items = await readItems(client, tripId)
@@ -140,6 +140,9 @@ export async function PUT(request: NextRequest, { params }: RouteContext) {
 
   return NextResponse.json({ item: updated })
 }
+
+/** @deprecated PUT 은 호환용 alias. 신규 호출은 PATCH 사용. 다음 메이저에서 제거 예정. */
+export const PUT = PATCH
 
 export async function DELETE(request: NextRequest, { params }: RouteContext) {
   const client = createRouteHandlerSupabase()

--- a/lib/hooks/useItems.ts
+++ b/lib/hooks/useItems.ts
@@ -66,7 +66,7 @@ export function useItems() {
     )
     try {
       const res = await fetch(withTripId(`/api/items/${id}`, tripId), {
-        method: 'PUT',
+        method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(changes),
       })


### PR DESCRIPTION
## 관련 이슈
Closes #160

## 변경 범위
- `app/api/items/[id]/route.ts`: 핸들러를 PATCH 로 rename. PUT 은 호환 alias (`export const PUT = PATCH`) 로 한 릴리즈 유지 — `@deprecated` 주석.
- `lib/hooks/useItems.ts`: 호출 method 도 PATCH.

## 검증
- `npm run lint` ✅, `npm run build` ✅