### PR TITLE
feat(basics): #159 G-18 ItemForm 저장 바 visualViewport 처리

### DIFF
--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -75,6 +75,24 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
   const [geocodeError, setGeocodeError] = useState('')
   const memoRef = useRef<HTMLTextAreaElement>(null)
   const nameRef = useRef<HTMLInputElement>(null)
+  const [keyboardHeight, setKeyboardHeight] = useState(0)
+
+  // visualViewport 기반 키보드 인지 — 저장 바가 가려지지 않도록
+  useEffect(() => {
+    const vv = window.visualViewport
+    if (!vv) return
+    const handler = () => {
+      const offset = window.innerHeight - vv.height - vv.offsetTop
+      setKeyboardHeight(Math.max(0, offset))
+    }
+    handler()
+    vv.addEventListener('resize', handler)
+    vv.addEventListener('scroll', handler)
+    return () => {
+      vv.removeEventListener('resize', handler)
+      vv.removeEventListener('scroll', handler)
+    }
+  }, [])
 
   useEffect(() => {
     const el = memoRef.current
@@ -356,8 +374,13 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
       {error && <p className="text-sm text-critical-fg">{error}</p>}
 
       <div
-        className="fixed left-0 right-0 md:static bg-bg-elevated/95 backdrop-blur border-t md:border-t-0 px-4 py-3 md:px-0 md:py-0 z-40"
-        style={{ bottom: 'calc(3.5rem + env(safe-area-inset-bottom))' }}
+        className="fixed left-0 right-0 md:static bg-bg-elevated/95 backdrop-blur border-t md:border-t-0 px-4 py-3 md:px-0 md:py-0 z-40 transition-[bottom] duration-150"
+        style={{
+          bottom:
+            keyboardHeight > 0
+              ? `${keyboardHeight}px`
+              : 'calc(3.5rem + env(safe-area-inset-bottom))',
+        }}
       >
         <div className="max-w-lg mx-auto md:max-w-none flex gap-3">
           {mode === 'edit' && (


### PR DESCRIPTION
## 관련 이슈
Closes #159

## 변경 범위
- `components/Items/ItemForm.tsx`: `keyboardHeight` 상태 + `window.visualViewport` resize/scroll 핸들러로 키보드 높이 추적. 저장 바 bottom 을 동적으로 키보드 위까지 올림.

## 검증
- `npm run lint` ✅, `npm run build` ✅

## 기본기 5문항
- [x] 여행 이름
- [x] 1클릭 추가 (G-7 완료)
- [x] 모달 적응형 (G-6 완료)
- [x] 카피 약속
- [x] 모바일·데스크탑 동등 — 본 PR 의 목적