### PR TITLE
feat(basics): #156 G-15 GET /api/trips + dashboard SWR 전환

### DIFF
--- a/app/api/trips/route.ts
+++ b/app/api/trips/route.ts
@@ -1,5 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createRouteHandlerSupabase } from '@/lib/supabase-server'
+import { listUserTrips } from '@/lib/trips'
+
+export async function GET() {
+  try {
+    const client = createRouteHandlerSupabase()
+    const { data: userData } = await client.auth.getUser()
+    if (!userData.user) {
+      return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+    }
+    const trips = await listUserTrips(client)
+    return NextResponse.json({ trips })
+  } catch (e) {
+    console.error('[GET /api/trips]', e)
+    return NextResponse.json({ error: '여행 목록을 불러오지 못했습니다.' }, { status: 500 })
+  }
+}
 
 function sanitizeText(v: unknown): string | null {
   if (typeof v !== 'string') return null

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
+import useSWR from 'swr'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { LogOut, MapPin, MoreVertical, Plus, Search, Trash2, User } from 'lucide-react'
@@ -51,11 +52,25 @@ interface Props {
   userEmail: string | null
 }
 
+const fetcher = (url: string) => fetch(url).then((r) => r.json())
+
 export default function DashboardClient({ initialTrips, userEmail }: Props) {
   const router = useRouter()
   const confirm = useConfirm()
   const { showToast } = useToast()
-  const [trips, setTrips] = useState<TripSummary[]>(initialTrips)
+  const { data, mutate: mutateTrips } = useSWR<{ trips: TripSummary[] }>(
+    '/api/trips',
+    fetcher,
+    { fallbackData: { trips: initialTrips }, revalidateOnFocus: false },
+  )
+  const trips = data?.trips ?? initialTrips
+  // legacy state (탬플릿 호환). 실제 보존은 SWR 캐시.
+  const setTrips = (updater: (prev: TripSummary[]) => TripSummary[]) => {
+    mutateTrips(
+      (cur) => ({ trips: updater(cur?.trips ?? initialTrips) }),
+      { revalidate: false },
+    )
+  }
   const [query, setQuery] = useState('')
   const [sort, setSort] = useState<SortKey>('created_desc')
   const [menuOpen, setMenuOpen] = useState<string | null>(null)


### PR DESCRIPTION
Closes #156

## 변경 범위
- `app/api/trips/route.ts`: `GET` 핸들러 추가. RLS 가 본인 trip 만 반환.
- `app/dashboard/DashboardClient.tsx`: `useSWR('/api/trips')` 도입. initialTrips 는 fallbackData. setTrips 어댑터 → mutate 위임. revalidateOnFocus: false.

## 검증
- `npm run lint` ✅, `npm run build` ✅