### PR TITLE
feat(basics): #157 G-16 공통 TripPageHeader

### DIFF
--- a/app/trip/[tripId]/gmaps-import/page.tsx
+++ b/app/trip/[tripId]/gmaps-import/page.tsx
@@ -6,7 +6,7 @@ import Navigation from '@/components/Layout/Navigation'
 import UrlInput from '@/components/GmapsImport/UrlInput'
 import CandidateList from '@/components/GmapsImport/CandidateList'
 import { useTripPath } from '@/lib/hooks/useTripContext'
-import TripPageTitle from '@/components/UI/TripPageTitle'
+import TripPageHeader from '@/components/Layout/TripPageHeader'
 import type { ImportCandidate } from '@/types'
 
 type PageState = 'idle' | 'loading' | 'review' | 'importing' | 'done'
@@ -107,13 +107,13 @@ export default function GmapsImportPage() {
 
   return (
     <div className="md:pl-44 min-h-screen bg-bg-elevated">
-      <div className="max-w-2xl mx-auto px-4 py-8 pb-24 md:pb-8">
-        <div className="mb-6">
-          <TripPageTitle section="구글맵 연동" />
-          <p className="text-sm text-fg-muted mt-1">
-            구글맵 공개 리스트에서 장소를 가져와 추가합니다.
-          </p>
-        </div>
+      <div className="max-w-2xl mx-auto pb-24 md:pb-8">
+        <TripPageHeader
+          section="구글맵 연동"
+          body={<p className="text-sm text-fg-muted mt-1">구글맵 공개 리스트에서 장소를 가져와 추가합니다.</p>}
+          className="mb-6"
+        />
+        <div className="px-4">
 
         {(state === 'idle' || state === 'loading') && (
           <div className="bg-bg-elevated rounded-xl border border-border p-6">
@@ -175,6 +175,7 @@ export default function GmapsImportPage() {
             <p className="text-sm text-fg-muted">전체 탭으로 이동 중…</p>
           </div>
         )}
+        </div>
       </div>
       <Navigation />
     </div>

--- a/app/trip/[tripId]/schedule/page.tsx
+++ b/app/trip/[tripId]/schedule/page.tsx
@@ -9,7 +9,7 @@ import ScheduleTable from '@/components/Schedule/ScheduleTable'
 import ThemeToggle from '@/components/Theme/ThemeToggle'
 import { useItems } from '@/lib/hooks/useItems'
 import { useToast } from '@/components/UI/Toast'
-import TripPageTitle from '@/components/UI/TripPageTitle'
+import TripPageHeader from '@/components/Layout/TripPageHeader'
 import FAB from '@/components/UI/FAB'
 
 const ItemPanel = dynamic(() => import('@/components/Panel/ItemPanel'), { ssr: false })
@@ -66,14 +66,9 @@ function SchedulePageContent() {
 
   return (
     <div className="md:pl-44 bg-bg text-fg min-h-screen">
-      <header className="max-w-3xl mx-auto px-4 pt-4">
-        <div className="flex items-center justify-between mb-4">
-          <TripPageTitle section="일정" />
-          <div className="md:hidden">
-            <ThemeToggle />
-          </div>
-        </div>
-      </header>
+      <div className="max-w-3xl mx-auto">
+        <TripPageHeader section="일정" />
+      </div>
 
       {isLoading ? (
         <div className="max-w-3xl mx-auto px-4 space-y-2">

--- a/components/Layout/TripPageHeader.tsx
+++ b/components/Layout/TripPageHeader.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import EditableTripTitle from '@/components/Trip/EditableTripTitle'
+import ThemeToggle from '@/components/Theme/ThemeToggle'
+
+interface Props {
+  section: string
+  /** 우측 액션 슬롯 (공유 버튼·페이지 고유 액션 등). */
+  actions?: ReactNode
+  /** 데스크탑 헤더 본문 (검색·필터 등 페이지 고유 영역). 모바일에선 같은 영역 렌더. */
+  body?: ReactNode
+  className?: string
+}
+
+/**
+ * 모든 /trip/[tripId]/** 페이지 공통 헤더.
+ * - 좌: TripPageTitle (trip 제목 인라인 편집 · ⋯ 설정 · 섹션명)
+ * - 우: 페이지 고유 액션 + 모바일 ThemeToggle
+ * - 하단: 페이지 고유 body 슬롯 (검색·필터 등)
+ *
+ * G-1/G-2 의 인라인 편집·여행 설정 시트가 자동 포함.
+ */
+export default function TripPageHeader({ section, actions, body, className = '' }: Props) {
+  return (
+    <header className={`px-4 md:px-8 pt-4 ${className}`}>
+      <div className="flex items-center justify-between mb-4 gap-3">
+        <EditableTripTitle section={section} />
+        <div className="flex items-center gap-2">
+          {actions}
+          <div className="md:hidden">
+            <ThemeToggle />
+          </div>
+        </div>
+      </div>
+      {body}
+    </header>
+  )
+}


### PR DESCRIPTION
Closes #157

## 변경 범위
- `components/Layout/TripPageHeader.tsx` 신설: `EditableTripTitle` + 우측 actions + 모바일 ThemeToggle + body 슬롯.
- schedule / gmaps-import 헤더를 TripPageHeader 로 통일.
- list / map 은 자체 layout 유지: list 는 검색·필터 통합 헤더, map 은 floating overlay. EditableTripTitle/TripContextLabel 을 이미 공유.

## 검증
- `npm run lint` ✅, `npm run build` ✅

## 남은 작업
- list / map 의 헤더도 추후 더 깊은 정렬 가능 (별도 이슈로 분리 권장).