### PR TITLE
chore(basics): 게이트 완료 후속 정리 (sort URL · TRIP_DATE 제거 · confirmingClose)

### DIFF
--- a/app/trip/[tripId]/list/page.tsx
+++ b/app/trip/[tripId]/list/page.tsx
@@ -12,7 +12,7 @@ import Navigation from '@/components/Layout/Navigation'
 import ItemList from '@/components/Items/ItemList'
 import ItemCardSkeleton from '@/components/UI/ItemCardSkeleton'
 import ResearchTableSkeleton from '@/components/UI/ResearchTableSkeleton'
-import ResearchTable from '@/components/Research/ResearchTable'
+import ResearchTable, { type SortDir, type SortKey } from '@/components/Research/ResearchTable'
 import FAB from '@/components/UI/FAB'
 import FilterButton from '@/components/Research/FilterButton'
 import FilterPanel from '@/components/Research/FilterPanel'
@@ -55,6 +55,12 @@ function ResearchPageContent() {
   const [highlightedIds, setHighlightedIds] = useState<Set<string>>(new Set())
 
   const [query, setQuery] = useState(() => searchParams.get('q') ?? '')
+  const [sortKey, setSortKey] = useState<SortKey>(
+    () => (searchParams.get('sort') as SortKey | null) ?? 'trip_priority',
+  )
+  const [sortDir, setSortDir] = useState<SortDir>(
+    () => (searchParams.get('dir') === 'desc' ? 'desc' : 'asc'),
+  )
   const [filterState, setFilterState] = useState<FilterState>(() => ({
     categories: parseCsv(searchParams.get('cat')) as Category[],
     tripPriorities: parseCsv(searchParams.get('pri')) as TripPriority[],
@@ -177,12 +183,14 @@ function ResearchPageContent() {
     setOrDel('pri', filterState.tripPriorities.join(','))
     setOrDel('res', filterState.reservationStatuses.join(','))
     setOrDel('excl', filterState.showExcluded ? '1' : '')
+    setOrDel('sort', sortKey !== 'trip_priority' ? sortKey : '')
+    setOrDel('dir', sortDir !== 'asc' ? sortDir : '')
     const next = buildUrl(params)
     if (next !== `${pathname}${searchParams.toString() ? `?${searchParams.toString()}` : ''}`) {
       router.replace(next, { scroll: false })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query, filterState])
+  }, [query, filterState, sortKey, sortDir])
 
   useEffect(() => {
     if (isLoading || !selectedItemId) return
@@ -305,6 +313,12 @@ function ResearchPageContent() {
               onCreateItem={createItem}
               onOpenPanel={handleSelectItem}
               hasActiveSearch={query.trim().length > 0 || activeCount > 0}
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSortChange={(k, d) => {
+                setSortKey(k)
+                setSortDir(d)
+              }}
             />
           </div>
         </>

--- a/components/Panel/ItemPanel.tsx
+++ b/components/Panel/ItemPanel.tsx
@@ -34,7 +34,6 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
   const confirm = useConfirm()
   const [mode, setMode] = useState<'view' | 'edit'>('view')
   const [isDirty, setIsDirty] = useState(false)
-  const [confirmingClose, setConfirmingClose] = useState(false)
   const [keyboardHeight, setKeyboardHeight] = useState(0)
   const [savingField, setSavingField] = useState<'category' | 'trip_priority' | 'reservation_status' | null>(null)
   const [openField, setOpenField] = useState<'category' | 'trip_priority' | 'reservation_status' | null>(null)
@@ -43,7 +42,6 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
   useEffect(() => {
     setMode('view')
     setIsDirty(false)
-    setConfirmingClose(false)
     setSavingField(null)
     setOpenField(null)
   }, [item?.id])
@@ -52,32 +50,10 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
     if (!isOpen) {
       setMode('view')
       setIsDirty(false)
-      setConfirmingClose(false)
       setSavingField(null)
       setOpenField(null)
     }
   }, [isOpen])
-
-  useEffect(() => {
-    if (!isOpen) return
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
-        if (confirmingClose) {
-          setConfirmingClose(false)
-        } else if (mode === 'edit' && isDirty) {
-          setConfirmingClose(true)
-        } else {
-          onClose()
-        }
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    document.body.style.overflow = 'hidden'
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown)
-      document.body.style.overflow = ''
-    }
-  }, [confirmingClose, isDirty, isOpen, mode, onClose])
 
   useEffect(() => {
     const vv = window.visualViewport
@@ -107,16 +83,17 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
     if (delta > 50) onClose()
   }
 
-  function tryClose() {
+  async function tryClose() {
     if (mode === 'edit' && isDirty) {
-      setConfirmingClose(true)
-    } else {
-      onClose()
+      const ok = await confirm({
+        title: '저장하지 않고 닫기',
+        description: '변경사항이 저장되지 않습니다. 계속하시겠습니까?',
+        confirmLabel: '나가기',
+        cancelLabel: '계속 편집',
+        tone: 'destructive',
+      })
+      if (!ok) return
     }
-  }
-
-  function handleDiscardAndClose() {
-    setConfirmingClose(false)
     onClose()
   }
 
@@ -173,7 +150,6 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
           </button>
         ) : null
       }
-      dismissibleBackdrop={!isDirty || mode !== 'edit'}
     >
       <div ref={panelRef} className="flex-1 flex flex-col overflow-hidden">
         {displayItem && mode === 'view' && (
@@ -200,19 +176,6 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
         )}
       </div>
 
-      {confirmingClose && (
-        <div className="absolute bottom-0 left-0 right-0 bg-bg-elevated border-t-2 border-warning-border px-5 pt-4 pb-6 z-10">
-          <p className="text-sm font-medium text-fg mb-3">변경사항이 있습니다. 저장하지 않고 나가시겠습니까?</p>
-          <div className="flex gap-3">
-            <button onClick={handleDiscardAndClose} className="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium text-accent-fg bg-accent hover:bg-accent-hover transition-colors">
-              나가기
-            </button>
-            <button onClick={() => setConfirmingClose(false)} className="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium text-fg-muted border border-border hover:bg-bg-subtle transition-colors">
-              계속 편집
-            </button>
-          </div>
-        </div>
-      )}
     </Sheet>
   )
 }

--- a/components/Research/ResearchTable.tsx
+++ b/components/Research/ResearchTable.tsx
@@ -9,8 +9,8 @@ import PriorityCell from '@/components/Schedule/cells/PriorityCell'
 import StatusCell from '@/components/Schedule/cells/StatusCell'
 import BudgetCell from '@/components/Schedule/cells/BudgetCell'
 import type { Category, ReservationStatus } from '@/types'
-type SortKey = 'name' | 'trip_priority' | 'reservation_status' | 'budget'
-type SortDir = 'asc' | 'desc'
+export type SortKey = 'name' | 'trip_priority' | 'reservation_status' | 'budget'
+export type SortDir = 'asc' | 'desc'
 
 type EditableField = 'name' | 'category' | 'trip_priority' | 'reservation_status' | 'budget'
 const EDITABLE_FIELDS: EditableField[] = ['name', 'category', 'trip_priority', 'reservation_status', 'budget']
@@ -26,6 +26,10 @@ interface ResearchTableProps {
   onCreateItem: (item: Omit<TripItem, 'id' | 'created_at' | 'updated_at'>) => void
   onOpenPanel: (id: string) => void
   hasActiveSearch?: boolean
+  /** 외부에서 정렬 제어 (URL 동기화용). 미지정 시 컴포넌트 내부 state. */
+  sortKey?: SortKey
+  sortDir?: SortDir
+  onSortChange?: (key: SortKey, dir: SortDir) => void
 }
 
 function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
@@ -50,17 +54,25 @@ export default function ResearchTable({
   onCreateItem,
   onOpenPanel,
   hasActiveSearch = false,
+  sortKey: sortKeyProp,
+  sortDir: sortDirProp,
+  onSortChange,
 }: ResearchTableProps) {
   const [editingCell, setEditingCell] = useState<EditingCell | null>(null)
-  const [sortKey, setSortKey] = useState<SortKey>('trip_priority')
-  const [sortDir, setSortDir] = useState<SortDir>('asc')
+  const [internalSortKey, setInternalSortKey] = useState<SortKey>('trip_priority')
+  const [internalSortDir, setInternalSortDir] = useState<SortDir>('asc')
+
+  const controlled = sortKeyProp !== undefined && sortDirProp !== undefined && onSortChange !== undefined
+  const sortKey = controlled ? sortKeyProp! : internalSortKey
+  const sortDir = controlled ? sortDirProp! : internalSortDir
 
   function handleSortHeader(key: SortKey) {
-    if (key === sortKey) {
-      setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+    const nextDir: SortDir = key === sortKey ? (sortDir === 'asc' ? 'desc' : 'asc') : 'asc'
+    if (controlled) {
+      onSortChange!(key, nextDir)
     } else {
-      setSortKey(key)
-      setSortDir('asc')
+      setInternalSortKey(key)
+      setInternalSortDir(nextDir)
     }
   }
   const [addingRow, setAddingRow] = useState(false)

--- a/lib/itemOptions.ts
+++ b/lib/itemOptions.ts
@@ -29,15 +29,6 @@ export const RESERVATION_STATUS_OPTIONS: ReservationStatus[] = [
   '예약완료',
 ]
 
-/**
- * @deprecated 단일 NYC trip 시대 잔재. 신규 코드는 사용 금지.
- * trip 기간은 항상 현재 trip context(useTrip().startDate/endDate) 또는
- * `fetchTripBounds(client, tripId)` 로 동적으로 가져온다.
- */
-export const TRIP_DATE_MIN = '2026-07-01'
-/** @deprecated 단일 NYC trip 시대 잔재. */
-export const TRIP_DATE_MAX = '2026-07-31'
-
 export const ITEM_FIELD_LABELS = {
   category: '카테고리',
   trip_priority: '이번 여행에서',


### PR DESCRIPTION
## 변경 이유
기본기 게이트 22 건 머지 후 follow-up 정리. 각 작업이 너무 작아 별도 이슈로 가지 않아도 되는 것들 한 번에.

## 변경 범위
1. **`TRIP_DATE_MIN/MAX` 완전 제거** (lib/itemOptions.ts) — G-3 (#144) 에서 deprecated 처리 후 직접 import 0 건 확인. 단일 NYC trip 시대 잔재 코드 청소.
2. **ItemPanel `confirmingClose` → `useConfirm()` 통합** — G-10 (#151) 의 공통 ConfirmDialog 패턴으로 일원화. 인라인 컨펌 UI ~25 라인 축소, 다이얼로그 톤 일관.
3. **list sort URL 동기화** — G-13 (#154) 의 미완 정렬 부분 보강. `?sort=&dir=` 로 sort 상태 보존. `ResearchTable` 이 controlled (외부 sort 제어) / uncontrolled (legacy) 양쪽 지원.

## 검증
- `npm run lint` ✅
- `npm run build` ✅

## 기본기 5문항
- [x] 여행 이름 (G-1 완료)
- [x] 1클릭 추가 (G-7 완료)
- [x] 모달 적응형 (G-6 완료)
- [x] 카피 약속 — N/A (정리 PR)
- [x] 모바일·데스크탑 동등

## 남은 작업 / 리스크
없음.