### PR TITLE
fix(sheet): side='auto' 데스크톱에서 100vh 우측 드로어 보장

### DIFF
--- a/components/UI/Sheet.tsx
+++ b/components/UI/Sheet.tsx
@@ -164,6 +164,11 @@ export default function Sheet({
           'absolute bg-bg-elevated text-fg shadow-e28 flex flex-col',
           'border border-border',
           sideClasses,
+          // side='auto' 는 모바일=bottom / 데스크톱=right 로 전환되므로,
+          // 인라인 style 의 바텀시트 사이징(height:auto/maxHeight:Xvh/no width)을
+          // 데스크톱에서는 right 드로어 사이징으로 덮어쓴다.
+          side === 'auto' &&
+            'md:!h-screen md:!max-h-none md:!min-h-0 md:w-[var(--md-width)]',
           className,
         )}
         style={{


### PR DESCRIPTION
## 증상

데스크톱에서 `여행 설정`, `ItemPanel`, `ShareDialog` 등 `side='auto'` 시트의 우측 드로어가 100vh 가 아닌 90vh 까지만 차오름.

## 근본 원인

[components/UI/Sheet.tsx](components/UI/Sheet.tsx) 의 사이징 인라인 style 분기가 `side === 'right'` vs **그 외** 2-갈래로만 짜여 있음. `side='auto'` 는 모바일=bottom / 데스크톱=right 로 반응형 전환되어야 하는데:

- **위치 분기**(`sideClasses`) 는 `md:` prefix 로 올바르게 전환됨
- **사이징 분기**는 인라인 style 이라 미디어 쿼리 불가 → 데스크톱에도 바텀시트 사이징(`height:auto; max-height:90vh; no width`)이 그대로 적용됨

부가로, `--md-width` CSS 변수는 세팅만 되고 어디서도 소비되지 않는 미완성 코드였음.

## 왜 발생했나

시트 통합 작업에서 `'auto'` 모드를 추가할 때 위치 로직만 클래스 레이어로 옮기고, 사이징은 ‟right 아니면 bottom" 단일축 가정을 그대로 둠. PR 검증이 모바일 동작만 확인하고 데스크톱 ‟auto" 케이스를 놓침.

## 수정

`side='auto'` 일 때 `md:` 브레이크포인트에서 바텀시트 사이징을 무력화하고 right 드로어 사이징을 부여하는 클래스 추가:

```
md:!h-screen md:!max-h-none md:!min-h-0 md:w-[var(--md-width)]
```

`--md-width` 도 비로소 소비됨.

## 영향 범위

`side='auto'` 사용처 모두 함께 정상화:
- `TripSettingsSheet`
- `ItemPanel`
- `ShareDialog`

`Navigation` 은 `side='bottom'` 고정이라 무관.

## 체크리스트

- [x] 모바일 바텀시트 동작 유지 (height:auto + max-height:90vh)
- [x] 데스크톱 우측 드로어 100vh 복원
- [x] 모바일·데스크톱 양쪽 동등 동작
