### PR TITLE
fix: #132 파비콘 색상을 브랜드 Teal로 교정

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <rect width="32" height="32" rx="8" fill="#2563EB"/>
+  <rect width="32" height="32" rx="8" fill="#0D9488"/>
   <path d="M16 6C12.134 6 9 9.134 9 13C9 18.25 16 26 16 26C16 26 23 18.25 23 13C23 9.134 19.866 6 16 6ZM16 16C14.343 16 13 14.657 13 13C13 11.343 14.343 10 16 10C17.657 10 19 11.343 19 13C19 14.657 17.657 16 16 16Z" fill="white"/>
 </svg>


### PR DESCRIPTION
## 관련 이슈
Closes #132

## 변경 이유
파비콘이 `#2563EB` (Blue) 였는데 실제 브랜드 accent 는 Teal (`--accent: 13 148 136` = `#0D9488`). 일관성 회복.

## 변경 범위
- [app/icon.svg](app/icon.svg): 배경 사각형 fill `#2563EB` → `#0D9488`

## 검증
- [x] `npm run lint` 통과
- [x] 다른 위치에 `#2563EB` 잔여 참조 없음 (grep 확인)
- [x] `public/` 등 별도 파비콘 자산 없음 — Next.js App Router 가 `app/icon.svg` 만 사용

## 남은 작업 / 리스크
없음

---

- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? — 해당 없음(브랜드 자산)
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — 해당 없음
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? — 해당 없음
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — 해당 없음
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — 파비콘 공통