### PR TITLE
feat(ux): #130 항목 추가 진입점 + 추가 직후 시각 추적

### DIFF
--- a/app/trip/[tripId]/list/page.tsx
+++ b/app/trip/[tripId]/list/page.tsx
@@ -13,7 +13,7 @@ import ItemList from '@/components/Items/ItemList'
 import ItemCardSkeleton from '@/components/UI/ItemCardSkeleton'
 import ResearchTableSkeleton from '@/components/UI/ResearchTableSkeleton'
 import ResearchTable, { type SortDir, type SortKey } from '@/components/Research/ResearchTable'
-import FAB from '@/components/UI/FAB'
+import StickyAddBar from '@/components/UI/StickyAddBar'
 import FilterButton from '@/components/Research/FilterButton'
 import FilterPanel from '@/components/Research/FilterPanel'
 import ActiveFilterChips from '@/components/Research/ActiveFilterChips'
@@ -160,15 +160,44 @@ function ResearchPageContent() {
     const imported = searchParams.get('imported')
     if (!imported) return
 
-    const ids = new Set(imported.split(',').filter(Boolean))
+    const idList = imported.split(',').filter(Boolean)
+    const ids = new Set(idList)
     setHighlightedIds(ids)
 
     const params = new URLSearchParams(searchParams.toString())
     params.delete('imported')
     router.replace(buildUrl(params), { scroll: false })
 
-    const timer = setTimeout(() => setHighlightedIds(new Set()), 1000)
-    return () => clearTimeout(timer)
+    const firstId = idList[0]
+    const scrollToFirst = () => {
+      if (!firstId) return false
+      const el = document.querySelector<HTMLElement>(
+        `[data-item-id="${firstId}"]`,
+      )
+      if (!el) return false
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      return true
+    }
+
+    // DOM 렌더 직후엔 카드가 없을 수 있으므로 다음 프레임에 시도, 실패 시 토스트로 폴백.
+    const raf = requestAnimationFrame(() => {
+      const scrolled = scrollToFirst()
+      if (idList.length === 1) {
+        showToast({
+          type: 'success',
+          message: scrolled ? '추가했어요' : '추가했어요. 목록에서 확인할 수 있어요.',
+          ...(scrolled
+            ? {}
+            : { action: { label: '보기', onClick: () => scrollToFirst() } }),
+        })
+      }
+    })
+
+    const timer = setTimeout(() => setHighlightedIds(new Set()), 1500)
+    return () => {
+      cancelAnimationFrame(raf)
+      clearTimeout(timer)
+    }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // 검색·필터 상태를 URL search params 와 동기화 (디바운스 없이 즉시; replace 라 history 미오염)
@@ -304,7 +333,7 @@ function ResearchPageContent() {
               onUpdateItem={updateItem}
               highlightedIds={highlightedIds}
             />
-            <FAB />
+            <StickyAddBar />
           </div>
           <div className="hidden md:block px-8 pb-6">
             <ResearchTable

--- a/app/trip/[tripId]/schedule/page.tsx
+++ b/app/trip/[tripId]/schedule/page.tsx
@@ -10,7 +10,7 @@ import ThemeToggle from '@/components/Theme/ThemeToggle'
 import { useItems } from '@/lib/hooks/useItems'
 import { useToast } from '@/components/UI/Toast'
 import TripPageHeader from '@/components/Layout/TripPageHeader'
-import FAB from '@/components/UI/FAB'
+import StickyAddBar from '@/components/UI/StickyAddBar'
 
 const ItemPanel = dynamic(() => import('@/components/Panel/ItemPanel'), { ssr: false })
 
@@ -77,7 +77,7 @@ function SchedulePageContent() {
           ))}
         </div>
       ) : (
-        <div className="max-w-3xl mx-auto px-4 pb-24 md:pb-6">
+        <div className="max-w-3xl mx-auto px-4 pb-32 md:pb-6">
           <ScheduleTable
             items={items}
             onUpdateItem={updateItem}
@@ -89,7 +89,7 @@ function SchedulePageContent() {
 
       <Navigation />
 
-      <FAB className="md:hidden" />
+      <StickyAddBar />
 
       <ItemPanel
         item={selectedItem}

--- a/components/Items/ItemCard.tsx
+++ b/components/Items/ItemCard.tsx
@@ -63,6 +63,7 @@ export default function ItemCard({
     <div
       role="button"
       tabIndex={0}
+      data-item-id={item.id}
       aria-pressed={isActive}
       aria-label={item.name}
       onClick={() => editingName === null && onSelect?.(item.id)}

--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -216,8 +216,13 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
 
     try {
       if (mode === 'create') {
-        await createItem(body as Omit<TripItem, 'id' | 'created_at' | 'updated_at'>)
-        router.push(tripPath('list'))
+        const created = await createItem(
+          body as Omit<TripItem, 'id' | 'created_at' | 'updated_at'>,
+        )
+        const target = created
+          ? `${tripPath('list')}?imported=${created.id}`
+          : tripPath('list')
+        router.push(target)
       } else if (itemId) {
         await updateItem(itemId, body)
         router.push(tripPath(`items/${itemId}`))

--- a/components/UI/StickyAddBar.tsx
+++ b/components/UI/StickyAddBar.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { Plus } from 'lucide-react'
+import { cn } from '@/lib/cn'
+import { useTripPath } from '@/lib/hooks/useTripContext'
+
+interface StickyAddBarProps {
+  href?: string
+  onClick?: () => void
+  label?: string
+  className?: string
+}
+
+/**
+ * 모바일 하단 sticky 진입점. 목록 길이와 무관하게 한 번에 닿는 "추가" 액션.
+ * Navigation 위에 떠 있는 텍스트 + 아이콘 바.
+ */
+export default function StickyAddBar({
+  href,
+  onClick,
+  label = '새 장소 추가',
+  className,
+}: StickyAddBarProps) {
+  const router = useRouter()
+  const tripPath = useTripPath()
+  const resolvedHref = href ?? tripPath('items/new')
+
+  function handleClick() {
+    if (onClick) {
+      onClick()
+    } else if (resolvedHref) {
+      router.push(resolvedHref)
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'md:hidden fixed inset-x-0 bottom-16 z-40 px-4 pointer-events-none',
+        className,
+      )}
+      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+    >
+      <button
+        type="button"
+        onClick={handleClick}
+        className={cn(
+          'pointer-events-auto w-full flex items-center justify-center gap-2',
+          'rounded-full bg-accent text-accent-fg shadow-e16',
+          'px-5 py-3 text-sm font-semibold',
+          'hover:bg-accent-hover active:bg-accent-hover',
+          'transition-colors duration-150 ease-out-soft',
+          'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+        )}
+      >
+        <Plus className="size-5" aria-hidden="true" />
+        <span>{label}</span>
+      </button>
+    </div>
+  )
+}

--- a/lib/hooks/useItems.ts
+++ b/lib/hooks/useItems.ts
@@ -106,10 +106,12 @@ export function useItems() {
     }
   }
 
-  async function createItem(item: Omit<TripItem, 'id' | 'created_at' | 'updated_at'>) {
+  async function createItem(
+    item: Omit<TripItem, 'id' | 'created_at' | 'updated_at'>,
+  ): Promise<TripItem | null> {
     if (typeof navigator !== 'undefined' && !navigator.onLine) {
       showToast({ type: 'info', message: '오프라인 상태입니다. 인터넷 연결 후 다시 시도해주세요.' })
-      return
+      return null
     }
     const tmpId = `tmp_${Date.now()}`
     const now = new Date().toISOString()
@@ -126,7 +128,9 @@ export function useItems() {
         body: JSON.stringify(item),
       })
       if (!res.ok) throw new Error('Create failed')
+      const payload = (await res.json()) as { item?: TripItem }
       mutate()
+      return payload?.item ?? null
     } catch {
       mutate(snapshot, { revalidate: false })
       showToast({
@@ -134,6 +138,7 @@ export function useItems() {
         message: '추가에 실패했습니다.',
         action: { label: '재시도', onClick: () => createItem(item) },
       })
+      return null
     }
   }
 


### PR DESCRIPTION
## 관련 이슈
Closes #130

## 변경 이유
- 모바일 목록에서 \"항목 추가\" 진입점이 우하단 원형 FAB 한 가지였고, 신규 사용자가 \"+\" 만 보고 무엇인지 인지하기 어려움.
- 추가 직후 목록이 정렬되어 새 항목이 시야 밖으로 사라져 \"내가 만든 게 어디 갔지\" 마찰 발생.

## 변경 범위

### A. 진입점 — 텍스트 sticky 바
- **신규** [components/UI/StickyAddBar.tsx](components/UI/StickyAddBar.tsx)
  - 모바일 Navigation 위 sticky 위치, 텍스트 \"새 장소 추가\" + Plus 아이콘
  - 발견성 ↑, 기능 의도 명시
- [list/page.tsx](app/trip/[tripId]/list/page.tsx), [schedule/page.tsx](app/trip/[tripId]/schedule/page.tsx) — 모바일 영역의 `<FAB />` → `<StickyAddBar />` 교체
- 데스크탑 list 의 우상단 \"새 항목\" 버튼은 그대로 유지 (시각적 위계 다름)
- `PlanScreen` 의 FAB 사용은 본 PR 범위에서 제외 (마법사 단계, 별도 동선)

### B. 추적 — 자동 스크롤 + 하이라이트 + 토스트
- [lib/hooks/useItems.ts](lib/hooks/useItems.ts) — `createItem` 이 생성된 `TripItem` 반환 (real id 포함, optimistic tmp id 아님)
- [components/Items/ItemForm.tsx](components/Items/ItemForm.tsx) — `create` 직후 `list?imported=<realId>` 로 이동
- [list/page.tsx](app/trip/[tripId]/list/page.tsx) `imported` 핸들러 확장:
  - `data-item-id` 셀렉터로 카드 찾고 `scrollIntoView({block:'center', smooth})`
  - 1500ms 하이라이트 (warning-bg/40 + warning-border)
  - 성공 토스트 \"추가했어요\" 표시
  - 스크롤 타겟을 못 찾으면 토스트의 \"보기\" 액션으로 재시도 가능 (B-2 fallback)
- [components/Items/ItemCard.tsx](components/Items/ItemCard.tsx) — 루트에 `data-item-id` 부착

## 검증
- [x] `npm run lint` 통과
- [x] `tsc --noEmit` 통과
- [x] FAB 컴포넌트는 PlanScreen 에서 여전히 사용 중 → 삭제하지 않음

## 남은 작업 / 리스크
- 보류된 옵션(신규 항목 일시 상단 핀, 추가 후 편집 화면 즉시 이동) 은 이슈 본문 명시대로 별도 결정 필요. 본 PR 에서는 다루지 않음.
- gmaps-import 다건 가져오기는 기존 `?imported=a,b,c` 폴리시 그대로(첫 ID 만 스크롤, 토스트는 fallback 한정).

---

- [x] 이 페이지·기능에 \"지금 보고 있는 여행 이름\" 이 보이는가? — TripPageTitle 그대로 유지
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — Item Create 동선 개선
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? — 본 PR 은 시트 변경 없음
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — \"새 장소 추가\" 카피와 동선 일치
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — 모바일은 sticky 바, 데스크탑은 헤더 버튼, 양쪽 모두 imported 추적 효과 동작