### PR TITLE
feat(auth): #128 로그인/가입 에러 메시지 UX 분기 + 확인 메일 재전송

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { signInWithEmail } from '@/lib/auth'
+import { mapAuthError } from '@/lib/auth-errors'
 
 export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => null)
@@ -7,14 +8,32 @@ export async function POST(request: NextRequest) {
   const password = typeof body?.password === 'string' ? body.password : ''
 
   if (!email || !password) {
-    return NextResponse.json({ error: '이메일과 비밀번호를 입력해주세요.' }, { status: 400 })
+    return NextResponse.json(
+      { error: '이메일과 비밀번호를 입력해주세요.', code: 'invalid_credentials' },
+      { status: 400 },
+    )
   }
 
   const { error } = await signInWithEmail(email, password)
   if (error) {
+    const mapped = mapAuthError(error)
+
+    // 계정 enumeration 방지: 비번 틀림 / 미가입 / 잠긴 계정은 모두 동일 메시지.
+    if (mapped.code === 'invalid_credentials' || mapped.code === 'generic') {
+      return NextResponse.json(
+        {
+          error: '이메일 또는 비밀번호가 올바르지 않습니다.',
+          code: 'invalid_credentials',
+        },
+        { status: 401 },
+      )
+    }
+
+    // email_not_confirmed / rate_limit 는 UX 상 별도 분기.
+    const status = mapped.code === 'rate_limit' ? 429 : 400
     return NextResponse.json(
-      { error: '자격증명이 올바르지 않습니다.' },
-      { status: 401 },
+      { error: mapped.message, code: mapped.code },
+      { status },
     )
   }
 

--- a/app/api/auth/resend-confirmation/route.ts
+++ b/app/api/auth/resend-confirmation/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resendSignupConfirmation } from '@/lib/auth'
+
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => null)
+  const email = typeof body?.email === 'string' ? body.email.trim() : ''
+
+  // 열거 방지: email 비어있어도 ok 응답.
+  if (!email) {
+    return NextResponse.json({ ok: true })
+  }
+
+  const origin = new URL(request.url).origin
+  const emailRedirectTo = `${origin}/api/auth/callback?next=/login`
+  await resendSignupConfirmation(email, emailRedirectTo)
+
+  // 결과(존재 여부 / rate limit) 와 무관하게 ok.
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { signUpWithEmail } from '@/lib/auth'
+import { mapAuthError } from '@/lib/auth-errors'
 
 export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => null)
@@ -22,9 +23,11 @@ export async function POST(request: NextRequest) {
     if (/already/i.test(error.message)) {
       return NextResponse.json({ ok: true, needsEmailConfirmation: true })
     }
+    const mapped = mapAuthError(error)
+    const status = mapped.code === 'rate_limit' ? 429 : 400
     return NextResponse.json(
-      { error: '회원가입에 실패했습니다. 입력 정보를 확인해주세요.' },
-      { status: 400 },
+      { error: mapped.message, code: mapped.code },
+      { status },
     )
   }
 

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -5,26 +5,36 @@ import { useState, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { clearAppCache } from '@/lib/clearAppCache'
 import { ErrorBanner } from '@/components/UI'
+import { useToast } from '@/components/UI/Toast'
+import type { AuthErrorCode } from '@/lib/auth-errors'
 
 export default function LoginForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const { showToast } = useToast()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [error, setError] = useState('')
+  const [errorState, setErrorState] = useState<{
+    code: AuthErrorCode | 'init'
+    message: string
+  } | null>(null)
   const [loading, setLoading] = useState(false)
+  const [resending, setResending] = useState(false)
 
   useEffect(() => {
     const err = searchParams.get('error')
     if (err === 'invalid_link') {
-      setError('만료되었거나 사용된 링크입니다. 재설정 링크를 다시 받아주세요.')
+      setErrorState({
+        code: 'init',
+        message: '만료되었거나 사용된 링크입니다. 재설정 링크를 다시 받아주세요.',
+      })
     }
   }, [searchParams])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setLoading(true)
-    setError('')
+    setErrorState(null)
 
     const res = await fetch('/api/auth/login', {
       method: 'POST',
@@ -34,16 +44,44 @@ export default function LoginForm() {
 
     if (res.ok) {
       clearAppCache()
-      // 로그인 후에는 풀 페이지 리로드: Next.js 라우터 캐시가 미인증 상태를
-      // 캐시하고 있어서 router.push를 쓰면 쿠키가 설정돼도 기존 캐시를 재사용.
       window.location.href = '/dashboard'
       return
-    } else {
-      const data = await res.json()
-      setError(data.error || '로그인에 실패했습니다.')
-      setLoading(false)
+    }
+
+    const data = (await res.json().catch(() => ({}))) as {
+      error?: string
+      code?: AuthErrorCode
+    }
+    setErrorState({
+      code: data.code ?? 'invalid_credentials',
+      message: data.error ?? '로그인에 실패했습니다.',
+    })
+    setLoading(false)
+  }
+
+  async function handleResendConfirmation() {
+    if (!email) return
+    setResending(true)
+    try {
+      await fetch('/api/auth/resend-confirmation', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      })
+      showToast({
+        type: 'success',
+        message: '확인 메일을 다시 보냈어요. 메일함을 확인해주세요.',
+      })
+    } finally {
+      setResending(false)
     }
   }
+
+  const errorTone =
+    errorState?.code === 'email_not_confirmed' ||
+    errorState?.code === 'rate_limit'
+      ? 'warning'
+      : 'critical'
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-bg via-bg-subtle to-bg flex items-center justify-center p-4">
@@ -99,9 +137,24 @@ export default function LoginForm() {
             />
           </div>
 
-          {error && (
-            <ErrorBanner tone="critical" onDismiss={() => setError('')}>
-              {error}
+          {errorState && (
+            <ErrorBanner
+              tone={errorTone}
+              onDismiss={() => setErrorState(null)}
+              action={
+                errorState.code === 'email_not_confirmed' ? (
+                  <button
+                    type="button"
+                    onClick={handleResendConfirmation}
+                    disabled={resending || !email}
+                    className="text-xs font-semibold underline underline-offset-2 disabled:opacity-50"
+                  >
+                    {resending ? '재전송 중…' : '확인 메일 재전송'}
+                  </button>
+                ) : undefined
+              }
+            >
+              {errorState.message}
             </ErrorBanner>
           )}
 

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useState } from 'react'
 import { clearAppCache } from '@/lib/clearAppCache'
+import { ErrorBanner } from '@/components/UI'
 
 export default function SignupForm() {
   const [email, setEmail] = useState('')
@@ -107,9 +108,9 @@ export default function SignupForm() {
             </div>
 
             {error && (
-              <div className="bg-critical-bg border border-critical-border rounded-lg px-3 py-2">
-                <p className="text-critical-fg text-sm">{error}</p>
-              </div>
+              <ErrorBanner tone="critical" onDismiss={() => setError('')}>
+                {error}
+              </ErrorBanner>
             )}
 
             <button

--- a/lib/auth-errors.ts
+++ b/lib/auth-errors.ts
@@ -1,0 +1,64 @@
+import type { AuthError } from '@supabase/supabase-js'
+
+export type AuthErrorCode =
+  | 'email_not_confirmed'
+  | 'rate_limit'
+  | 'weak_password'
+  | 'invalid_credentials'
+  | 'generic'
+
+export interface MappedAuthError {
+  code: AuthErrorCode
+  message: string
+}
+
+/**
+ * Supabase AuthError → 사용자 메시지 매핑.
+ * 계정 enumeration 방지를 위해 호출부에서 invalid_credentials/generic 은
+ * 동일 메시지로 응답해야 한다.
+ */
+export function mapAuthError(
+  error: AuthError | null | undefined,
+): MappedAuthError {
+  if (!error) {
+    return { code: 'generic', message: '요청을 처리하지 못했습니다.' }
+  }
+
+  const code = (error as { code?: string }).code
+  const status = (error as { status?: number }).status
+  const msg = error.message ?? ''
+
+  if (code === 'email_not_confirmed' || /not.*confirm/i.test(msg)) {
+    return {
+      code: 'email_not_confirmed',
+      message: '이메일 확인이 필요합니다. 메일함에서 확인 링크를 눌러주세요.',
+    }
+  }
+
+  if (
+    status === 429 ||
+    code === 'over_request_rate_limit' ||
+    code === 'over_email_send_rate_limit' ||
+    /rate.?limit/i.test(msg)
+  ) {
+    return {
+      code: 'rate_limit',
+      message: '요청이 잠시 차단되었어요. 잠시 후 다시 시도해주세요.',
+    }
+  }
+
+  if (
+    code === 'weak_password' ||
+    /password.*(short|weak|too.?short|at least)/i.test(msg)
+  ) {
+    return {
+      code: 'weak_password',
+      message: '비밀번호가 너무 짧거나 약해요. 8자 이상으로 설정해주세요.',
+    }
+  }
+
+  return {
+    code: 'invalid_credentials',
+    message: '이메일 또는 비밀번호가 올바르지 않습니다.',
+  }
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -57,3 +57,12 @@ export async function exchangeCodeForSession(code: string) {
   const supabase = createRouteHandlerSupabase()
   return supabase.auth.exchangeCodeForSession(code)
 }
+
+export async function resendSignupConfirmation(email: string, emailRedirectTo: string) {
+  const supabase = createRouteHandlerSupabase()
+  return supabase.auth.resend({
+    type: 'signup',
+    email,
+    options: { emailRedirectTo },
+  })
+}


### PR DESCRIPTION
## 관련 이슈
Closes #128

## 변경 이유
인증 실패 메시지가 모두 단일 \"자격증명이 올바르지 않습니다.\" 였음. 특히 \"가입 후 메일 확인 안 함 → 로그인 실패\" 흐름에서 사용자가 다음 행동을 알 수 없어 막힘. 보안(계정 enumeration) 을 지키는 범위에서 분기를 도입.

## 변경 범위

### 백엔드
- **신규** [lib/auth-errors.ts](lib/auth-errors.ts) — Supabase `AuthError` → `{ code, message }` 매퍼
  - 코드: `email_not_confirmed` / `rate_limit` / `weak_password` / `invalid_credentials` / `generic`
- **[app/api/auth/login/route.ts](app/api/auth/login/route.ts)**
  - 401 응답에 `code` 포함
  - `invalid_credentials` / `generic` → 단일 한국어 메시지 (enumeration 방지)
  - `email_not_confirmed` → 400 + 분기 메시지
  - `rate_limit` → 429 + 분기 메시지
- **[app/api/auth/signup/route.ts](app/api/auth/signup/route.ts)**
  - 기존 `already` enumeration 방지 정책 유지
  - 그 외 에러는 매퍼 통과 (예: weak password 한국어 매핑)
- **신규** [app/api/auth/resend-confirmation/route.ts](app/api/auth/resend-confirmation/route.ts)
  - 결과/존재 여부 노출 없이 항상 `{ ok: true }` 응답
- [lib/auth.ts](lib/auth.ts) — `resendSignupConfirmation` 헬퍼 추가

### 프론트
- **[app/login/LoginForm.tsx](app/login/LoginForm.tsx)**
  - 응답의 `code` 기반 분기
  - `email_not_confirmed` → warning 톤 배너 + \"확인 메일 재전송\" 액션 버튼
  - `rate_limit` → warning 톤
  - 그 외 → critical 톤
  - ad-hoc 인라인 div → `<ErrorBanner>` (#127 패턴 적용)
- **[app/signup/SignupForm.tsx](app/signup/SignupForm.tsx)** — `<ErrorBanner>` 적용

## 분기 매트릭스 (구현 결과)

| 상황 | 응답 status / code | 사용자 메시지 | 부가 액션 |
|---|---|---|---|
| 비번 틀림 / 미가입 / 잠긴 계정 | 401 / `invalid_credentials` | \"이메일 또는 비밀번호가 올바르지 않습니다.\" | — |
| 미확인 계정 로그인 | 400 / `email_not_confirmed` | \"이메일 확인이 필요합니다…\" | \"확인 메일 재전송\" |
| 호출 빈도 초과 | 429 / `rate_limit` | \"요청이 잠시 차단되었어요…\" | — |
| 가입 - 중복 이메일 | 200 (정책 유지) | \"확인 메일을 보냈습니다\" 화면 | — |
| 가입 - 약한 비번 | 400 / `weak_password` | \"비밀번호가 너무 짧거나 약해요…\" | — |
| 재전송 | 200 (항상) | (성공 토스트 표시) | — |

## 검증
- [x] `npm run lint` 통과
- [x] `tsc --noEmit` 통과
- [x] enumeration 방지: 비번 틀림 / 미가입 / 잠긴 계정은 동일 메시지 (코드 분기 없음)
- [x] 재전송 라우트는 입력 결과를 노출하지 않음

## 남은 작업 / 리스크
- 실제 Supabase 에서 `email_not_confirmed` 가 발화하려면 #133 (Confirm email 재활성화 + SMTP) 가 선행되어야 한다. 현재는 코드 분기만 마련. 본 PR 범위는 클라이언트/서버 UX 정합성.
- 다른 surface(forgot, update-password) 는 별도 이슈 — 본 PR 은 #128 본문의 명시 surface 만 다룸.

---

- [x] 이 페이지·기능에 \"지금 보고 있는 여행 이름\" 이 보이는가? — 인증 화면, 해당 없음
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — 해당 없음
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? — 본 PR 은 시트 없음
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — \"확인 메일 재전송\" 버튼은 실제 API 호출과 연결
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — ErrorBanner 는 폼 너비 적응형, 양쪽 동등