### PR TITLE
feat: 페르소나 피드백 배치 (#193-#201) — 마법사·지도·통화·import·IA 일괄 정리

### DIFF
--- a/app/api/gmaps/import/route.ts
+++ b/app/api/gmaps/import/route.ts
@@ -4,6 +4,48 @@ import { mapGoogleCategory } from '@/services/gmaps/categoryMap'
 import type { GooglePlace, TripItem } from '@/types'
 import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 import { ensureActiveTrip } from '@/lib/trip'
+import { reverseGeocode } from '@/lib/geocode'
+
+// "34°39'53.7\"N 135°29'58.3\"E" 또는 "34.123, 135.456" 같이 좌표 자체가 이름인 경우를 감지.
+const DMS_RE = /\d+°\d+['′]/
+const DECIMAL_COORD_RE = /^-?\d{1,3}\.\d+\s*,\s*-?\d{1,3}\.\d+$/
+
+function isCoordinateName(name: string): boolean {
+  const trimmed = name.trim()
+  if (!trimmed) return true
+  if (DMS_RE.test(trimmed)) return true
+  if (DECIMAL_COORD_RE.test(trimmed)) return true
+  return false
+}
+
+async function resolvePinName(
+  place: GooglePlace,
+  regionLabel: string | null,
+  fallbackIndex: number,
+): Promise<string> {
+  if (!isCoordinateName(place.name)) return place.name
+
+  // 1차: reverse geocode
+  if (typeof place.lat === 'number' && typeof place.lng === 'number') {
+    try {
+      const result = await reverseGeocode(place.lat, place.lng)
+      if (result?.address) {
+        // 너무 긴 address 는 앞 2-3 토큰만.
+        const parts = result.address.split(',').map(s => s.trim()).filter(Boolean)
+        const short = parts.slice(0, 2).join(', ')
+        if (short) return `📍 ${short}`
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  // 2차: region 폴백
+  if (regionLabel?.trim()) return `📍 핀 (${regionLabel.trim()} 근처)`
+
+  // 3차: 순번
+  return `📍 저장한 장소 ${fallbackIndex + 1}`
+}
 
 function placeToItem(
   place: GooglePlace,
@@ -58,7 +100,23 @@ export async function POST(request: NextRequest) {
       ? queryTripId
       : await ensureActiveTrip(supabase)
 
-    const rows = places.map(p => {
+    // trip region 을 한 번 fetch — 좌표만 있는 핀의 폴백 라벨에 사용.
+    const { data: tripRow } = await supabase
+      .from('trips')
+      .select('region')
+      .eq('id', tripId)
+      .maybeSingle<{ region: string | null }>()
+    const regionLabel = tripRow?.region ?? null
+
+    // 좌표만 있는 핀의 이름을 reverse geocode → region 폴백 → 순번 으로 정규화.
+    const resolvedPlaces = await Promise.all(
+      places.map(async (p, idx) => ({
+        ...p,
+        name: await resolvePinName(p, regionLabel, idx),
+      })),
+    )
+
+    const rows = resolvedPlaces.map(p => {
       const override = p.googlePlaceId ? categoryOverrides[p.googlePlaceId] : undefined
       const item = placeToItem(p, override)
       return {

--- a/app/api/trips/[tripId]/route.ts
+++ b/app/api/trips/[tripId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createRouteHandlerSupabase } from '@/lib/supabase-server'
+import { isCurrencyCode } from '@/lib/currency'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -33,6 +34,14 @@ export async function PATCH(
   }
 
   const patch: Record<string, string | null> = {}
+
+  if ('currency' in body) {
+    if (!isCurrencyCode(body.currency)) {
+      return NextResponse.json({ error: '지원하지 않는 통화 코드' }, { status: 400 })
+    }
+    patch.currency = body.currency
+  }
+
   for (const key of FIELD_KEYS) {
     if (!(key in body)) continue
     const raw = body[key]
@@ -81,7 +90,7 @@ export async function PATCH(
     .from('trips')
     .update(patch)
     .eq('id', tripId)
-    .select('id, title, start_date, end_date, region, basecamp_address')
+    .select('id, title, start_date, end_date, region, basecamp_address, currency')
     .maybeSingle()
 
   if (error) {

--- a/app/api/trips/route.ts
+++ b/app/api/trips/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 import { listUserTrips } from '@/lib/trips'
+import { isCurrencyCode } from '@/lib/currency'
 
 export async function GET() {
   try {
@@ -36,6 +37,7 @@ export async function POST(request: NextRequest) {
     const endDate = sanitizeDate(body?.end_date)
     const region = sanitizeText(body?.region)
     const basecamp = sanitizeText(body?.basecamp_address)
+    const currency = isCurrencyCode(body?.currency) ? body.currency : 'KRW'
 
     if (startDate && endDate && endDate < startDate) {
       return NextResponse.json(
@@ -59,6 +61,12 @@ export async function POST(request: NextRequest) {
     if (typeof tripId !== 'string') {
       return NextResponse.json({ error: '여행 생성에 실패했습니다.' }, { status: 500 })
     }
+
+    // currency 는 RPC 시그니처 변경을 피하기 위해 별도 UPDATE 로 반영.
+    if (currency !== 'KRW') {
+      await client.from('trips').update({ currency }).eq('id', tripId)
+    }
+
     return NextResponse.json({ tripId, title }, { status: 201 })
   } catch (e) {
     console.error('[POST /api/trips] unexpected:', e)

--- a/app/dashboard/new/NewTripWizard.tsx
+++ b/app/dashboard/new/NewTripWizard.tsx
@@ -9,13 +9,14 @@ import { Input } from '@/components/UI/Input'
 import { useToast } from '@/components/UI/Toast'
 import { cn } from '@/lib/cn'
 
-type Step = 1 | 2 | 3 | 4
+type Step = 1 | 2 | 3 | 4 | 5
 
 const STEP_TITLES: Record<Step, string> = {
   1: '여행 이름',
   2: '기간',
   3: '지역',
   4: '베이스캠프',
+  5: '확인',
 }
 
 export default function NewTripWizard() {
@@ -27,6 +28,7 @@ export default function NewTripWizard() {
   const [endDate, setEndDate] = useState('')
   const [region, setRegion] = useState('')
   const [basecamp, setBasecamp] = useState('')
+  const [basecampSkipped, setBasecampSkipped] = useState(false)
   const [submitting, setSubmitting] = useState(false)
 
   const canProceed = useMemo(() => {
@@ -40,11 +42,21 @@ export default function NewTripWizard() {
 
   function next() {
     if (!canProceed) return
-    if (step < 4) setStep((s) => (s + 1) as Step)
+    if (step < 5) setStep((s) => (s + 1) as Step)
   }
 
   function prev() {
     if (step > 1) setStep((s) => (s - 1) as Step)
+  }
+
+  function skipBasecamp() {
+    setBasecamp('')
+    setBasecampSkipped(true)
+    if (step === 4) setStep(5)
+  }
+
+  function jumpToStep(target: Step) {
+    setStep(target)
   }
 
   async function handleSubmit() {
@@ -92,7 +104,7 @@ export default function NewTripWizard() {
 
       <main className="max-w-2xl mx-auto px-4 md:px-8 py-6 pb-32">
         <ol className="flex items-center gap-2 mb-8" aria-label="단계 표시">
-          {[1, 2, 3, 4].map((n) => {
+          {[1, 2, 3, 4, 5].map((n) => {
             const done = n < step
             const current = n === step
             return (
@@ -107,7 +119,7 @@ export default function NewTripWizard() {
                 >
                   {done ? <Check className="size-4" aria-hidden="true" /> : n}
                 </div>
-                <div className="flex-1 min-w-0">
+                <div className="hidden sm:block flex-1 min-w-0">
                   <p className={cn('text-xs truncate', current ? 'text-fg font-medium' : 'text-fg-subtle')}>
                     {STEP_TITLES[n as Step]}
                   </p>
@@ -128,7 +140,11 @@ export default function NewTripWizard() {
             <Step2
               startDate={startDate}
               endDate={endDate}
-              setStartDate={setStartDate}
+              setStartDate={(v) => {
+                setStartDate(v)
+                // 종료일이 비어있거나 시작일보다 이전이면 시작일로 맞춘다 — 종료일 picker 가 시작일 월에서 열리도록.
+                if (!endDate || (v && endDate < v)) setEndDate(v)
+              }}
               setEndDate={setEndDate}
             />
           )}
@@ -138,8 +154,19 @@ export default function NewTripWizard() {
           {step === 4 && (
             <Step4
               basecamp={basecamp}
-              setBasecamp={setBasecamp}
-              summary={{ title, startDate, endDate, region }}
+              setBasecamp={(v) => {
+                setBasecamp(v)
+                if (v.trim()) setBasecampSkipped(false)
+              }}
+              onSkip={skipBasecamp}
+              skipped={basecampSkipped}
+            />
+          )}
+          {step === 5 && (
+            <Step5
+              summary={{ title, startDate, endDate, region, basecamp }}
+              basecampSkipped={basecampSkipped && !basecamp.trim()}
+              onEdit={jumpToStep}
             />
           )}
         </section>
@@ -152,7 +179,7 @@ export default function NewTripWizard() {
           >
             이전
           </Button>
-          {step < 4 ? (
+          {step < 5 ? (
             <Button onClick={next} disabled={!canProceed}>
               다음
             </Button>
@@ -180,7 +207,7 @@ function Step1({
         label="여행 이름"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
-        placeholder="예: 뉴욕 여름 휴가"
+        placeholder="예: 오사카 가을 여행"
         autoFocus
         required
       />
@@ -216,6 +243,7 @@ function Step2({
           label="종료일"
           type="date"
           value={endDate}
+          min={startDate || undefined}
           onChange={(e) => setEndDate(e.target.value)}
         />
       </div>
@@ -240,7 +268,7 @@ function Step3({
         label="지역"
         value={region}
         onChange={(e) => setRegion(e.target.value)}
-        placeholder="예: 미국 뉴욕"
+        placeholder="예: 일본 오사카"
         autoFocus
       />
       <p className="text-xs text-fg-subtle">국가·도시·테마 등 자유롭게.</p>
@@ -251,46 +279,113 @@ function Step3({
 function Step4({
   basecamp,
   setBasecamp,
-  summary,
+  onSkip,
+  skipped,
 }: {
   basecamp: string
   setBasecamp: (v: string) => void
-  summary: { title: string; startDate: string; endDate: string; region: string }
+  onSkip: () => void
+  skipped: boolean
 }) {
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <Input
         label="베이스캠프 (숙소)"
         value={basecamp}
         onChange={(e) => setBasecamp(e.target.value)}
-        placeholder="예: 맨해튼 미드타운 호텔"
+        placeholder="예: 난바 인근 호텔"
         autoFocus
       />
-      <p className="text-xs text-fg-subtle">선택사항. 동선의 기준점이 돼요.</p>
-      <div className="border-t border-border pt-4">
-        <p className="text-xs font-semibold text-fg-subtle uppercase tracking-wider mb-2">미리 보기</p>
-        <dl className="text-sm space-y-1">
-          <SummaryRow label="이름" value={summary.title} />
-          <SummaryRow
-            label="기간"
-            value={
-              summary.startDate || summary.endDate
-                ? `${summary.startDate || '?'} – ${summary.endDate || '?'}`
-                : '미정'
-            }
-          />
-          <SummaryRow label="지역" value={summary.region || '미설정'} />
-        </dl>
+      <p className="text-xs text-fg-subtle">
+        선택사항. 동선의 기준점이 돼요. 보통은 숙소 주소를 적어요.
+      </p>
+      <div className="flex items-center justify-between pt-2">
+        <button
+          type="button"
+          onClick={onSkip}
+          className="text-xs text-fg-muted underline-offset-2 hover:underline"
+        >
+          {skipped ? '나중에 정하기로 설정됨' : '나중에 정하기'}
+        </button>
+        {skipped && !basecamp.trim() && (
+          <span className="text-xs text-fg-subtle">여행을 만든 뒤 설정에서 추가할 수 있어요.</span>
+        )}
       </div>
     </div>
   )
 }
 
-function SummaryRow({ label, value }: { label: string; value: string }) {
+function Step5({
+  summary,
+  basecampSkipped,
+  onEdit,
+}: {
+  summary: { title: string; startDate: string; endDate: string; region: string; basecamp: string }
+  basecampSkipped: boolean
+  onEdit: (step: Step) => void
+}) {
   return (
-    <div className="flex items-center justify-between gap-3">
-      <dt className="text-xs text-fg-muted">{label}</dt>
-      <dd className="text-sm text-fg truncate">{value}</dd>
+    <div className="space-y-4">
+      <div>
+        <p className="text-sm font-semibold text-fg mb-1">아래 내용으로 여행을 만들어요</p>
+        <p className="text-xs text-fg-subtle">각 항목 오른쪽 ‘수정’ 으로 돌아가 바꿀 수 있어요.</p>
+      </div>
+      <dl className="divide-y divide-border rounded-lg border border-border overflow-hidden">
+        <SummaryEditRow
+          label="이름"
+          value={summary.title}
+          onEdit={() => onEdit(1)}
+        />
+        <SummaryEditRow
+          label="기간"
+          value={
+            summary.startDate || summary.endDate
+              ? `${summary.startDate || '?'} – ${summary.endDate || '?'}`
+              : '미정'
+          }
+          onEdit={() => onEdit(2)}
+        />
+        <SummaryEditRow
+          label="지역"
+          value={summary.region || '미설정'}
+          onEdit={() => onEdit(3)}
+        />
+        <SummaryEditRow
+          label="베이스캠프"
+          value={
+            summary.basecamp.trim()
+              ? summary.basecamp
+              : basecampSkipped
+                ? '나중에 정하기'
+                : '미설정'
+          }
+          onEdit={() => onEdit(4)}
+        />
+      </dl>
+    </div>
+  )
+}
+
+function SummaryEditRow({
+  label,
+  value,
+  onEdit,
+}: {
+  label: string
+  value: string
+  onEdit: () => void
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 px-3 py-2.5 bg-bg-elevated">
+      <dt className="text-xs text-fg-muted w-20 flex-shrink-0">{label}</dt>
+      <dd className="text-sm text-fg flex-1 min-w-0 truncate">{value}</dd>
+      <button
+        type="button"
+        onClick={onEdit}
+        className="text-xs text-accent hover:underline underline-offset-2"
+      >
+        수정
+      </button>
     </div>
   )
 }

--- a/app/dashboard/new/NewTripWizard.tsx
+++ b/app/dashboard/new/NewTripWizard.tsx
@@ -8,6 +8,7 @@ import Button from '@/components/UI/Button'
 import { Input } from '@/components/UI/Input'
 import { useToast } from '@/components/UI/Toast'
 import { cn } from '@/lib/cn'
+import { SUPPORTED_CURRENCIES, type CurrencyCode } from '@/lib/currency'
 
 type Step = 1 | 2 | 3 | 4 | 5
 
@@ -29,6 +30,7 @@ export default function NewTripWizard() {
   const [region, setRegion] = useState('')
   const [basecamp, setBasecamp] = useState('')
   const [basecampSkipped, setBasecampSkipped] = useState(false)
+  const [currency, setCurrency] = useState<CurrencyCode>('KRW')
   const [submitting, setSubmitting] = useState(false)
 
   const canProceed = useMemo(() => {
@@ -72,6 +74,7 @@ export default function NewTripWizard() {
           end_date: endDate || null,
           region: region.trim() || null,
           basecamp_address: basecamp.trim() || null,
+          currency,
         }),
       })
       if (!res.ok) {
@@ -160,11 +163,13 @@ export default function NewTripWizard() {
               }}
               onSkip={skipBasecamp}
               skipped={basecampSkipped}
+              currency={currency}
+              setCurrency={setCurrency}
             />
           )}
           {step === 5 && (
             <Step5
-              summary={{ title, startDate, endDate, region, basecamp }}
+              summary={{ title, startDate, endDate, region, basecamp, currency }}
               basecampSkipped={basecampSkipped && !basecamp.trim()}
               onEdit={jumpToStep}
             />
@@ -281,35 +286,58 @@ function Step4({
   setBasecamp,
   onSkip,
   skipped,
+  currency,
+  setCurrency,
 }: {
   basecamp: string
   setBasecamp: (v: string) => void
   onSkip: () => void
   skipped: boolean
+  currency: CurrencyCode
+  setCurrency: (c: CurrencyCode) => void
 }) {
   return (
-    <div className="space-y-3">
-      <Input
-        label="베이스캠프 (숙소)"
-        value={basecamp}
-        onChange={(e) => setBasecamp(e.target.value)}
-        placeholder="예: 난바 인근 호텔"
-        autoFocus
-      />
-      <p className="text-xs text-fg-subtle">
-        선택사항. 동선의 기준점이 돼요. 보통은 숙소 주소를 적어요.
-      </p>
-      <div className="flex items-center justify-between pt-2">
-        <button
-          type="button"
-          onClick={onSkip}
-          className="text-xs text-fg-muted underline-offset-2 hover:underline"
+    <div className="space-y-4">
+      <div>
+        <Input
+          label="베이스캠프 (숙소)"
+          value={basecamp}
+          onChange={(e) => setBasecamp(e.target.value)}
+          placeholder="예: 난바 인근 호텔"
+          autoFocus
+        />
+        <p className="text-xs text-fg-subtle mt-1">
+          선택사항. 동선의 기준점이 돼요. 보통은 숙소 주소를 적어요.
+        </p>
+        <div className="flex items-center justify-between pt-2">
+          <button
+            type="button"
+            onClick={onSkip}
+            className="text-xs text-fg-muted underline-offset-2 hover:underline"
+          >
+            {skipped ? '나중에 정하기로 설정됨' : '나중에 정하기'}
+          </button>
+          {skipped && !basecamp.trim() && (
+            <span className="text-xs text-fg-subtle">여행을 만든 뒤 설정에서 추가할 수 있어요.</span>
+          )}
+        </div>
+      </div>
+      <div className="border-t border-border pt-4">
+        <label className="block text-sm font-medium text-fg mb-1.5">통화</label>
+        <select
+          value={currency}
+          onChange={(e) => setCurrency(e.target.value as CurrencyCode)}
+          className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-fg focus-visible:outline-2 focus-visible:outline-accent"
         >
-          {skipped ? '나중에 정하기로 설정됨' : '나중에 정하기'}
-        </button>
-        {skipped && !basecamp.trim() && (
-          <span className="text-xs text-fg-subtle">여행을 만든 뒤 설정에서 추가할 수 있어요.</span>
-        )}
+          {SUPPORTED_CURRENCIES.map((c) => (
+            <option key={c.code} value={c.code}>
+              {c.symbol} {c.code} — {c.label}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-fg-subtle mt-1">
+          예산을 입력·표시할 통화를 정해요. 여행 설정에서 나중에 바꿀 수 있어요.
+        </p>
       </div>
     </div>
   )
@@ -320,7 +348,7 @@ function Step5({
   basecampSkipped,
   onEdit,
 }: {
-  summary: { title: string; startDate: string; endDate: string; region: string; basecamp: string }
+  summary: { title: string; startDate: string; endDate: string; region: string; basecamp: string; currency: CurrencyCode }
   basecampSkipped: boolean
   onEdit: (step: Step) => void
 }) {
@@ -359,6 +387,14 @@ function Step5({
                 ? '나중에 정하기'
                 : '미설정'
           }
+          onEdit={() => onEdit(4)}
+        />
+        <SummaryEditRow
+          label="통화"
+          value={(() => {
+            const c = SUPPORTED_CURRENCIES.find((x) => x.code === summary.currency)
+            return c ? `${c.symbol} ${c.code} — ${c.label}` : summary.currency
+          })()}
           onEdit={() => onEdit(4)}
         />
       </dl>

--- a/app/trip/[tripId]/items/[id]/page.tsx
+++ b/app/trip/[tripId]/items/[id]/page.tsx
@@ -6,6 +6,7 @@ import Navigation from '@/components/Layout/Navigation'
 import ItemMetadataChips from '@/components/UI/ItemMetadataChips'
 import { buildTripPath } from '@/lib/hooks/useTripContext'
 import TripContextLabel from '@/components/UI/TripContextLabel'
+import { formatBudget, normalizeCurrency } from '@/lib/currency'
 import type { TripItem } from '@/types'
 
 export default async function ItemDetailPage({
@@ -13,10 +14,17 @@ export default async function ItemDetailPage({
 }: {
   params: { tripId: string; id: string }
 }) {
-  const items = await readItems(createRouteHandlerSupabase(), params.tripId)
+  const client = createRouteHandlerSupabase()
+  const items = await readItems(client, params.tripId)
   const item = items.find(i => i.id === params.id)
 
   if (!item) notFound()
+  const { data: tripRow } = await client
+    .from('trips')
+    .select('currency')
+    .eq('id', params.tripId)
+    .maybeSingle<{ currency: string | null }>()
+  const tripCurrency = normalizeCurrency(tripRow?.currency)
   const scheduleRows = buildScheduleRows(item)
 
   return (
@@ -50,7 +58,7 @@ export default async function ItemDetailPage({
                 <Row key={row.label} label={row.label} value={row.value} />
               ))}
               {item.budget !== undefined && (
-                <Row label="예산" value={`$${item.budget.toLocaleString()}`} />
+                <Row label="예산" value={formatBudget(item.budget, tripCurrency)} />
               )}
             </section>
           )}

--- a/app/trip/[tripId]/layout.tsx
+++ b/app/trip/[tripId]/layout.tsx
@@ -12,6 +12,7 @@ type TripRow = {
   end_date: string | null
   region: string | null
   basecamp_address: string | null
+  currency: string | null
   trip_members: { role: TripRole }[]
 }
 
@@ -37,7 +38,7 @@ export default async function TripLayout({
   const { data, error } = await client
     .from('trips')
     .select(
-      'id, title, start_date, end_date, region, basecamp_address, trip_members!inner(role)',
+      'id, title, start_date, end_date, region, basecamp_address, currency, trip_members!inner(role)',
     )
     .eq('id', tripId)
     .eq('trip_members.user_id', userData.user.id)
@@ -61,6 +62,7 @@ export default async function TripLayout({
         endDate: data.end_date,
         region: data.region,
         basecampAddress: data.basecamp_address,
+        currency: data.currency ?? 'KRW',
         role,
       }}
     >

--- a/app/trip/[tripId]/list/page.tsx
+++ b/app/trip/[tripId]/list/page.tsx
@@ -263,10 +263,10 @@ function ResearchPageContent() {
             <button
               type="button"
               onClick={() => setShareDialogOpen(true)}
-              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-bg px-2.5 py-1.5 text-xs font-medium text-fg-muted hover:bg-bg-subtle"
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-bg px-3 py-1.5 text-sm font-medium text-fg-muted hover:bg-bg-subtle"
               aria-label="공유 링크 관리"
             >
-              <Share2 className="size-3.5" aria-hidden />
+              <Share2 className="size-4" aria-hidden />
               공유
             </button>
             <div className="md:hidden">

--- a/components/Items/ItemCard.tsx
+++ b/components/Items/ItemCard.tsx
@@ -6,6 +6,8 @@ import { CATEGORY_META } from '@/lib/itemOptions'
 import ItemMetadataChips from '@/components/UI/ItemMetadataChips'
 import LinkButton from './LinkButton'
 import { cn } from '@/lib/cn'
+import { useOptionalTrip } from '@/lib/hooks/useTripContext'
+import { formatBudget, normalizeCurrency } from '@/lib/currency'
 
 interface ItemCardProps {
   item: TripItem
@@ -24,6 +26,8 @@ export default function ItemCard({
 }: ItemCardProps) {
   const [editingName, setEditingName] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const trip = useOptionalTrip()
+  const tripCurrency = normalizeCurrency(trip?.currency)
   const scheduleLabel = formatScheduleLabel(item)
   const accentColor = CATEGORY_META[item.category]?.color ?? '#cbd5e1'
 
@@ -134,7 +138,7 @@ export default function ItemCard({
         <div className="mt-2.5 flex items-center gap-2 text-xs text-fg-muted pl-[22px] flex-wrap tabular">
           {scheduleLabel && <span>{scheduleLabel}</span>}
           {item.budget !== undefined && (
-            <span className="font-medium">${item.budget.toLocaleString()}</span>
+            <span className="font-medium">{formatBudget(item.budget, tripCurrency)}</span>
           )}
         </div>
       )}

--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import type { Category, ReservationStatus, TripItem, TripPriority, Link as TripLink } from '@/types'
 import { useItems } from '@/lib/hooks/useItems'
 import { useTrip, useTripPath } from '@/lib/hooks/useTripContext'
+import { currencyFieldLabel, normalizeCurrency } from '@/lib/currency'
 import { useConfirm } from '@/components/UI/ConfirmDialog'
 import {
   CATEGORY_OPTIONS,
@@ -329,7 +330,7 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
         </div>
 
         <div>
-          <label className={labelClass}>예산 (USD)</label>
+          <label className={labelClass}>{currencyFieldLabel('예산', normalizeCurrency(trip.currency))}</label>
           <input type="number" min="0" value={form.budget} onChange={e => setField('budget', e.target.value)} className={inputClass} placeholder="예: 50" />
         </div>
       </section>

--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -96,14 +96,32 @@ export default function Navigation() {
         side="bottom"
         title="더보기"
       >
-        <SheetSection>
-          <div className="flex items-center justify-between py-1">
-            <span className="text-sm text-fg">테마</span>
-            <ThemeToggle />
-          </div>
-        </SheetSection>
-        <SheetSection>
+        <SheetSection title="이 여행">
           <ul className="space-y-0.5">
+            <li>
+              <Link
+                href={hrefFor('gmaps-import')}
+                onClick={() => setMoreOpen(false)}
+                className="flex items-center gap-3 px-2 py-2.5 rounded-lg text-sm text-fg hover:bg-bg-subtle"
+              >
+                <Download className="size-4 shrink-0" aria-hidden />
+                구글맵 가져오기
+              </Link>
+            </li>
+          </ul>
+        </SheetSection>
+        <SheetSection title="내 계정">
+          <ul className="space-y-0.5">
+            <li>
+              <Link
+                href="/dashboard"
+                onClick={() => setMoreOpen(false)}
+                className="flex items-center gap-3 px-2 py-2.5 rounded-lg text-sm text-fg hover:bg-bg-subtle"
+              >
+                <ArrowLeft className="size-4 shrink-0" aria-hidden />
+                내 여행 목록
+              </Link>
+            </li>
             <li>
               <Link
                 href="/me"
@@ -115,24 +133,10 @@ export default function Navigation() {
               </Link>
             </li>
             <li>
-              <Link
-                href={hrefFor('gmaps-import')}
-                onClick={() => setMoreOpen(false)}
-                className="flex items-center gap-3 px-2 py-2.5 rounded-lg text-sm text-fg hover:bg-bg-subtle"
-              >
-                <Download className="size-4 shrink-0" aria-hidden />
-                구글맵 가져오기
-              </Link>
-            </li>
-            <li>
-              <Link
-                href="/dashboard"
-                onClick={() => setMoreOpen(false)}
-                className="flex items-center gap-3 px-2 py-2.5 rounded-lg text-sm text-fg hover:bg-bg-subtle"
-              >
-                <ArrowLeft className="size-4 shrink-0" aria-hidden />
-                내 여행 목록
-              </Link>
+              <div className="flex items-center justify-between gap-3 px-2 py-2 rounded-lg text-sm text-fg">
+                <span>테마</span>
+                <ThemeToggle />
+              </div>
             </li>
             <li>
               <button
@@ -188,8 +192,23 @@ export default function Navigation() {
               </li>
             )
           })}
+          <li>
+            <Link
+              href={hrefFor('gmaps-import')}
+              className={cn(
+                'flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium',
+                'transition-colors duration-150',
+                'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+                'text-fg-muted hover:bg-bg-subtle hover:text-fg',
+              )}
+            >
+              <Download className="size-4 shrink-0" aria-hidden="true" />
+              <span>구글맵 가져오기</span>
+            </Link>
+          </li>
         </ul>
         <div className="border-t border-border pt-3 mt-2 space-y-0.5">
+          <p className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-fg-subtle">내 계정</p>
           <div className="px-3 py-2 flex items-center justify-between gap-2">
             <span className="text-xs text-fg-subtle whitespace-nowrap">테마</span>
             <ThemeToggle />
@@ -204,17 +223,6 @@ export default function Navigation() {
           >
             <User className="size-4 shrink-0" aria-hidden="true" />
             <span>프로필</span>
-          </Link>
-          <Link
-            href={hrefFor('gmaps-import')}
-            className={cn(
-              'flex items-center gap-2 px-3 py-2 text-sm rounded-lg',
-              'text-fg-subtle hover:text-fg hover:bg-bg-subtle transition-colors duration-150',
-              'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
-            )}
-          >
-            <Download className="size-4 shrink-0" aria-hidden="true" />
-            <span>구글맵 가져오기</span>
           </Link>
           <button
             type="button"

--- a/components/Map/MapInitialCenter.tsx
+++ b/components/Map/MapInitialCenter.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useMap } from 'react-leaflet'
+import L from 'leaflet'
+import type { TripItem } from '@/types'
+
+interface MapInitialCenterProps {
+  items: TripItem[]
+  basecampCoord: [number, number] | null
+  region: string | null
+  fallback?: [number, number]
+  fallbackZoom?: number
+}
+
+/**
+ * trip 컨텍스트(items → basecamp → region geocode) 를 기반으로 지도 초기 중심점을 잡는다.
+ * MapContainer 의 child 로 렌더한다. 사용자가 한 번이라도 지도를 움직이면 더 이상 자동 이동하지 않는다.
+ */
+export default function MapInitialCenter({
+  items,
+  basecampCoord,
+  region,
+  fallback = [36.2048, 138.2529],
+  fallbackZoom = 5,
+}: MapInitialCenterProps) {
+  const map = useMap()
+  const settledRef = useRef(false)
+  const userMovedRef = useRef(false)
+
+  useEffect(() => {
+    const onUserMove = () => {
+      userMovedRef.current = true
+    }
+    map.on('dragstart', onUserMove)
+    map.on('zoomstart', onUserMove)
+    return () => {
+      map.off('dragstart', onUserMove)
+      map.off('zoomstart', onUserMove)
+    }
+  }, [map])
+
+  useEffect(() => {
+    if (settledRef.current || userMovedRef.current) return
+
+    const coords = items
+      .filter(i => typeof i.lat === 'number' && typeof i.lng === 'number')
+      .map(i => [i.lat as number, i.lng as number] as [number, number])
+
+    if (coords.length > 0) {
+      const bounds = L.latLngBounds(coords)
+      if (basecampCoord) bounds.extend(basecampCoord)
+      map.fitBounds(bounds, { padding: [40, 40], maxZoom: 15, animate: false })
+      settledRef.current = true
+      return
+    }
+
+    if (basecampCoord) {
+      map.setView(basecampCoord, 14, { animate: false })
+      settledRef.current = true
+      return
+    }
+
+    if (region && region.trim()) {
+      let cancelled = false
+      ;(async () => {
+        try {
+          const res = await fetch(`/api/geocode?q=${encodeURIComponent(region.trim())}`)
+          const data = await res.json()
+          if (cancelled || userMovedRef.current) return
+          if (typeof data?.lat === 'number' && typeof data?.lng === 'number') {
+            map.setView([data.lat, data.lng], 11, { animate: false })
+            settledRef.current = true
+          } else {
+            map.setView(fallback, fallbackZoom, { animate: false })
+            settledRef.current = true
+          }
+        } catch {
+          if (!cancelled && !userMovedRef.current) {
+            map.setView(fallback, fallbackZoom, { animate: false })
+            settledRef.current = true
+          }
+        }
+      })()
+      return () => {
+        cancelled = true
+      }
+    }
+
+    map.setView(fallback, fallbackZoom, { animate: false })
+    settledRef.current = true
+  }, [map, items, basecampCoord, region, fallback, fallbackZoom])
+
+  return null
+}

--- a/components/Map/ResearchMap.tsx
+++ b/components/Map/ResearchMap.tsx
@@ -4,6 +4,8 @@ import { MapContainer, TileLayer, Marker, Tooltip } from 'react-leaflet'
 import L from 'leaflet'
 import type { TripItem } from '@/types'
 import { CATEGORY_META } from '@/lib/itemOptions'
+import MapInitialCenter from './MapInitialCenter'
+import { useOptionalTrip } from '@/lib/hooks/useTripContext'
 
 function createEmojiChipIcon(emoji: string) {
   return L.divIcon({
@@ -20,17 +22,23 @@ interface ResearchMapProps {
 }
 
 export default function ResearchMap({ items, onSelectItem }: ResearchMapProps) {
+  const trip = useOptionalTrip()
   const mapItems = items.filter(
     item => item.trip_priority !== '제외' && item.lat !== undefined && item.lng !== undefined
   )
 
   return (
     <MapContainer
-      center={[40.7128, -74.006]}
-      zoom={13}
+      center={[36.2048, 138.2529]}
+      zoom={5}
       style={{ height: '100%', width: '100%' }}
       className="touch-none"
     >
+      <MapInitialCenter
+        items={mapItems}
+        basecampCoord={null}
+        region={trip?.region ?? null}
+      />
       <TileLayer
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
         url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"

--- a/components/Map/ResearchMap.tsx
+++ b/components/Map/ResearchMap.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { MapContainer, TileLayer, Marker, Tooltip } from 'react-leaflet'
+import { MapContainer, TileLayer, Marker, Tooltip, ZoomControl } from 'react-leaflet'
 import L from 'leaflet'
 import type { TripItem } from '@/types'
 import { CATEGORY_META } from '@/lib/itemOptions'
@@ -31,9 +31,11 @@ export default function ResearchMap({ items, onSelectItem }: ResearchMapProps) {
     <MapContainer
       center={[36.2048, 138.2529]}
       zoom={5}
+      zoomControl={false}
       style={{ height: '100%', width: '100%' }}
       className="touch-none"
     >
+      <ZoomControl position="bottomright" />
       <MapInitialCenter
         items={mapItems}
         basecampCoord={null}

--- a/components/Map/ScheduleMap.tsx
+++ b/components/Map/ScheduleMap.tsx
@@ -8,6 +8,7 @@ import TripPriorityBadge from '@/components/UI/TripPriorityBadge'
 import { getEndLodging, getStartLodging, isStayItem } from '@/lib/lodging'
 import MapInitialCenter from './MapInitialCenter'
 import { useOptionalTrip } from '@/lib/hooks/useTripContext'
+import { formatBudget, normalizeCurrency } from '@/lib/currency'
 
 interface ScheduleMapProps {
   items: TripItem[]
@@ -132,7 +133,7 @@ export default function ScheduleMap({ items, onSelectItem }: ScheduleMapProps) {
                 </p>
                 {item.time_start && <p className="text-xs text-fg-muted">{item.time_start}</p>}
                 {item.budget !== undefined && (
-                  <p className="text-xs text-fg-muted">${item.budget}</p>
+                  <p className="text-xs text-fg-muted">{formatBudget(item.budget, normalizeCurrency(trip?.currency))}</p>
                 )}
                 <TripPriorityBadge tripPriority={item.trip_priority} />
               </div>

--- a/components/Map/ScheduleMap.tsx
+++ b/components/Map/ScheduleMap.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useMemo } from 'react'
-import { MapContainer, TileLayer, Marker, Popup, Polyline } from 'react-leaflet'
+import { MapContainer, TileLayer, Marker, Popup, Polyline, ZoomControl } from 'react-leaflet'
 import L from 'leaflet'
 import type { TripItem } from '@/types'
 import TripPriorityBadge from '@/components/UI/TripPriorityBadge'
@@ -75,7 +75,7 @@ export default function ScheduleMap({ items, onSelectItem }: ScheduleMapProps) {
       {/* Date chips */}
       {confirmedDates.length > 0 && (
         <div
-          className="absolute top-2 left-12 right-2 z-[1000] flex gap-2 overflow-x-auto pb-1"
+          className="absolute top-2 left-3 right-2 z-[1000] flex gap-2 overflow-x-auto pb-1"
           style={{ scrollbarWidth: 'none' }}
         >
           {confirmedDates.map(date => (
@@ -97,9 +97,11 @@ export default function ScheduleMap({ items, onSelectItem }: ScheduleMapProps) {
       <MapContainer
         center={[36.2048, 138.2529]}
         zoom={5}
+        zoomControl={false}
         style={{ height: '100%', width: '100%' }}
         className="touch-none"
       >
+        <ZoomControl position="bottomright" />
         <MapInitialCenter
           items={dayItems}
           basecampCoord={null}

--- a/components/Map/ScheduleMap.tsx
+++ b/components/Map/ScheduleMap.tsx
@@ -6,6 +6,8 @@ import L from 'leaflet'
 import type { TripItem } from '@/types'
 import TripPriorityBadge from '@/components/UI/TripPriorityBadge'
 import { getEndLodging, getStartLodging, isStayItem } from '@/lib/lodging'
+import MapInitialCenter from './MapInitialCenter'
+import { useOptionalTrip } from '@/lib/hooks/useTripContext'
 
 interface ScheduleMapProps {
   items: TripItem[]
@@ -22,6 +24,7 @@ function createNumberIcon(num: number) {
 }
 
 export default function ScheduleMap({ items, onSelectItem }: ScheduleMapProps) {
+  const trip = useOptionalTrip()
   const confirmedDates = useMemo(() => {
     return collectScheduleDates(items.filter(i => i.trip_priority === '확정'))
   }, [items])
@@ -92,11 +95,16 @@ export default function ScheduleMap({ items, onSelectItem }: ScheduleMapProps) {
       )}
 
       <MapContainer
-        center={[40.7128, -74.006]}
-        zoom={13}
+        center={[36.2048, 138.2529]}
+        zoom={5}
         style={{ height: '100%', width: '100%' }}
         className="touch-none"
       >
+        <MapInitialCenter
+          items={dayItems}
+          basecampCoord={null}
+          region={trip?.region ?? null}
+        />
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
           url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"

--- a/components/Map/SelectedItemPan.tsx
+++ b/components/Map/SelectedItemPan.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useMap } from 'react-leaflet'
+import type { TripItem } from '@/types'
+
+interface Props {
+  selectedItem: TripItem | null
+}
+
+/**
+ * 선택된 item 이 현재 뷰포트 밖이면 부드럽게 panTo.
+ * 줌 레벨은 보존. 이미 보이는 마커를 클릭한 경우엔 지도가 움직이지 않음.
+ */
+export default function SelectedItemPan({ selectedItem }: Props) {
+  const map = useMap()
+  const lastIdRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!selectedItem) {
+      lastIdRef.current = null
+      return
+    }
+    if (selectedItem.id === lastIdRef.current) return
+    if (typeof selectedItem.lat !== 'number' || typeof selectedItem.lng !== 'number') return
+    lastIdRef.current = selectedItem.id
+
+    const target = map.options.crs?.latLngToPoint
+      ? [selectedItem.lat, selectedItem.lng]
+      : [selectedItem.lat, selectedItem.lng]
+    const bounds = map.getBounds()
+    const latLng = { lat: selectedItem.lat, lng: selectedItem.lng } as { lat: number; lng: number }
+    if (bounds.contains([latLng.lat, latLng.lng])) {
+      // 이미 뷰포트 안 — 지도 이동 없음
+      void target
+      return
+    }
+    map.panTo([latLng.lat, latLng.lng], { animate: true, duration: 0.4 })
+  }, [map, selectedItem])
+
+  return null
+}

--- a/components/Map/TripPlannerMap.tsx
+++ b/components/Map/TripPlannerMap.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { MapContainer, TileLayer, Marker, Polyline, Tooltip } from 'react-leaflet'
 import MapAddOnLongPress from './MapAddOnLongPress'
+import MapInitialCenter from './MapInitialCenter'
 import L from 'leaflet'
 import type { TripItem } from '@/types'
 import { CATEGORY_META } from '@/lib/itemOptions'
@@ -126,11 +127,16 @@ export default function TripPlannerMap({
 
   return (
     <MapContainer
-      center={[40.7128, -74.006]}
-      zoom={13}
+      center={[36.2048, 138.2529]}
+      zoom={5}
       style={{ height: '100%', width: '100%' }}
       className="touch-none"
     >
+      <MapInitialCenter
+        items={visibleItems}
+        basecampCoord={basecampCoord}
+        region={trip?.region ?? null}
+      />
       <TileLayer
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
         url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"

--- a/components/Map/TripPlannerMap.tsx
+++ b/components/Map/TripPlannerMap.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { MapContainer, TileLayer, Marker, Polyline, Tooltip } from 'react-leaflet'
+import { MapContainer, TileLayer, Marker, Polyline, Tooltip, ZoomControl } from 'react-leaflet'
 import MapAddOnLongPress from './MapAddOnLongPress'
 import MapInitialCenter from './MapInitialCenter'
 import L from 'leaflet'
@@ -129,9 +129,11 @@ export default function TripPlannerMap({
     <MapContainer
       center={[36.2048, 138.2529]}
       zoom={5}
+      zoomControl={false}
       style={{ height: '100%', width: '100%' }}
       className="touch-none"
     >
+      <ZoomControl position="bottomright" />
       <MapInitialCenter
         items={visibleItems}
         basecampCoord={basecampCoord}

--- a/components/Map/TripPlannerMap.tsx
+++ b/components/Map/TripPlannerMap.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { MapContainer, TileLayer, Marker, Polyline, Tooltip, ZoomControl } from 'react-leaflet'
 import MapAddOnLongPress from './MapAddOnLongPress'
 import MapInitialCenter from './MapInitialCenter'
+import SelectedItemPan from './SelectedItemPan'
 import L from 'leaflet'
 import type { TripItem } from '@/types'
 import { CATEGORY_META } from '@/lib/itemOptions'
@@ -138,6 +139,11 @@ export default function TripPlannerMap({
         items={visibleItems}
         basecampCoord={basecampCoord}
         region={trip?.region ?? null}
+      />
+      <SelectedItemPan
+        selectedItem={
+          (selectedItemId && visibleItems.find(i => i.id === selectedItemId)) || null
+        }
       />
       <TileLayer
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'

--- a/components/Panel/ItemPanel.tsx
+++ b/components/Panel/ItemPanel.tsx
@@ -8,6 +8,7 @@ import Sheet from '@/components/UI/Sheet'
 import { useItems } from '@/lib/hooks/useItems'
 import { useTrip } from '@/lib/hooks/useTripContext'
 import { useConfirm } from '@/components/UI/ConfirmDialog'
+import { formatBudget, currencyFieldLabel, normalizeCurrency } from '@/lib/currency'
 import {
   CATEGORY_OPTIONS,
   CHIP_TONE,
@@ -207,6 +208,7 @@ function ItemDetailView({
   const trip = useTrip()
   const dateMin = trip.startDate ?? undefined
   const dateMax = trip.endDate ?? undefined
+  const tripCurrency = normalizeCurrency(trip.currency)
   const [editing, setEditing] = useState<InlineField | null>(null)
   const [vals, setVals] = useState({
     name: item.name,
@@ -456,7 +458,7 @@ function ItemDetailView({
           }
         </InlineRow>
 
-        <InlineRow label="예산 (USD)">
+        <InlineRow label={currencyFieldLabel('예산', tripCurrency)}>
           {editing === 'budget'
             ? <input
                 autoFocus
@@ -473,7 +475,7 @@ function ItemDetailView({
                 placeholder="0"
               />
             : <span className={vals.budget ? 'text-sm font-medium text-fg cursor-text' : emptyClass} onClick={() => activate('budget')}>
-                {vals.budget ? `$${parseInt(vals.budget).toLocaleString()}` : '입력'}
+                {vals.budget ? formatBudget(parseInt(vals.budget), tripCurrency) : '입력'}
               </span>
           }
         </InlineRow>

--- a/components/Panel/ItemPanel.tsx
+++ b/components/Panel/ItemPanel.tsx
@@ -27,9 +27,11 @@ export interface ItemPanelProps {
   onClose: () => void
   onSave: () => void
   onDelete: (id: string) => void
+  /** non-modal: 백드롭 dim 제거, 뒤쪽 지도와 상호작용 가능. 지도 뷰에서 사용. */
+  nonModal?: boolean
 }
 
-export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: ItemPanelProps) {
+export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete, nonModal }: ItemPanelProps) {
   const { deleteItem, updateItem } = useItems()
   const confirm = useConfirm()
   const [mode, setMode] = useState<'view' | 'edit'>('view')
@@ -138,6 +140,7 @@ export default function ItemPanel({ item, isOpen, onClose, onSave, onDelete }: I
       onClose={tryClose}
       side="auto"
       rightWidthPx={520}
+      transparentBackdrop={nonModal}
       title={mode === 'edit' ? '편집' : '상세 정보'}
       headerActions={
         mode === 'edit' && displayItem ? (

--- a/components/Panel/PanelItemForm.tsx
+++ b/components/Panel/PanelItemForm.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from 'react'
 import type { Category, ReservationStatus, TripItem, TripPriority, Link as TripLink } from '@/types'
 import { useItems } from '@/lib/hooks/useItems'
 import { useTrip } from '@/lib/hooks/useTripContext'
+import { currencyFieldLabel, normalizeCurrency } from '@/lib/currency'
 import {
   CATEGORY_OPTIONS,
   ITEM_FIELD_LABELS,
@@ -232,7 +233,7 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
               </Field>
             </div>
           </div>
-          <Field label="예산 (USD)">
+          <Field label={currencyFieldLabel('예산', normalizeCurrency(trip.currency))}>
             <input type="number" min="0" value={form.budget} onChange={e => setField('budget', e.target.value)} className={inputClass} placeholder="예: 50" />
           </Field>
         </section>

--- a/components/Plan/PlanScreen.tsx
+++ b/components/Plan/PlanScreen.tsx
@@ -247,6 +247,7 @@ export default function PlanScreen({ basePath }: PlanScreenProps) {
         onClose={handleClosePanel}
         onSave={handleSaved}
         onDelete={handleDeleted}
+        nonModal
       />
     </div>
   )

--- a/components/Research/ResearchTable.tsx
+++ b/components/Research/ResearchTable.tsx
@@ -179,7 +179,7 @@ export default function ResearchTable({
     }
   }
 
-  if (items.length === 0) {
+  if (items.length === 0 && !addingRow) {
     return (
       <div className="flex flex-col items-center justify-center py-20 text-center">
         <div className="text-4xl mb-3">{hasActiveSearch ? '🔍' : '📍'}</div>

--- a/components/Schedule/DateGroupHeader.tsx
+++ b/components/Schedule/DateGroupHeader.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+import { useOptionalTrip } from '@/lib/hooks/useTripContext'
+import { formatBudget, normalizeCurrency } from '@/lib/currency'
+
 interface DateGroupHeaderProps {
   date: string
   dayOffset: number | null
@@ -30,6 +33,7 @@ export default function DateGroupHeader({
   onToggleCollapse,
   onAddItem,
 }: DateGroupHeaderProps) {
+  const trip = useOptionalTrip()
   const isUndated = date === '__undated__'
 
   return (
@@ -77,7 +81,7 @@ export default function DateGroupHeader({
         )}
         {totalBudget > 0 && (
           <span className="text-xs text-fg-muted tabular-nums">
-            ${totalBudget.toLocaleString()}
+            {formatBudget(totalBudget, normalizeCurrency(trip?.currency))}
           </span>
         )}
         <button

--- a/components/Schedule/ScheduleTable.tsx
+++ b/components/Schedule/ScheduleTable.tsx
@@ -5,7 +5,8 @@ import type { ReservationStatus, TripItem } from '@/types'
 import { CATEGORY_META, RESERVATION_STATUS_META } from '@/lib/itemOptions'
 import { haversineKm } from '@/lib/distance'
 import { getLodgingForDate, isLodgingMidStay } from '@/lib/lodging'
-import { useOptionalTripId } from '@/lib/hooks/useTripContext'
+import { useOptionalTripId, useOptionalTrip } from '@/lib/hooks/useTripContext'
+import { formatBudget as fmtBudget, normalizeCurrency } from '@/lib/currency'
 import { EDITABLE_FIELDS, type EditableField } from './TableRow'
 import TableRow from './TableRow'
 import DateGroupHeader from './DateGroupHeader'
@@ -32,9 +33,9 @@ function daysBetween(a: string, b: string): number {
   return Math.round((db - da) / (1000 * 60 * 60 * 24)) + 1
 }
 
-function formatBudget(value?: number) {
+function formatBudget(value: number | undefined, currency: string) {
   if (value === undefined) return ''
-  return `$${value.toLocaleString()}`
+  return fmtBudget(value, normalizeCurrency(currency))
 }
 
 function formatTimeRange(item: TripItem) {
@@ -92,8 +93,9 @@ function MobileScheduleItemCard({
   item: TripItem
   onOpenPanel: (id: string) => void
 }) {
+  const trip = useOptionalTrip()
   const status = getStatusMeta(item.reservation_status)
-  const budget = formatBudget(item.budget)
+  const budget = formatBudget(item.budget, trip?.currency ?? 'KRW')
   const time = formatTimeRange(item)
   const emoji = CATEGORY_META[item.category]?.emoji ?? '📌'
 

--- a/components/Schedule/ScheduleTable.tsx
+++ b/components/Schedule/ScheduleTable.tsx
@@ -437,7 +437,18 @@ export default function ScheduleTable({
       <div className="flex flex-col items-center justify-center py-20 text-center">
         <div className="text-4xl mb-3">🗓️</div>
         <p className="text-sm font-medium text-fg mb-1">아직 등록된 항목이 없어요</p>
-        <p className="text-xs text-fg-subtle">전체 탭에서 장소를 추가하면<br />여기에 날짜별로 표시됩니다</p>
+        <p className="text-xs text-fg-subtle mb-4">장소를 추가하면 여기에 날짜별로 표시됩니다</p>
+        {tripId && (
+          <a
+            href={`/trip/${tripId}/items/new`}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-accent text-accent-fg px-4 py-2 text-sm font-medium hover:bg-accent-hover transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
+            </svg>
+            새 항목 추가
+          </a>
+        )}
       </div>
     )
   }

--- a/components/Schedule/TableRow.tsx
+++ b/components/Schedule/TableRow.tsx
@@ -1,11 +1,13 @@
 'use client'
 
+import { useRef } from 'react'
 import type { Category, ReservationStatus, TripItem } from '@/types'
 import NameCell from './cells/NameCell'
 import TimeCell from './cells/TimeCell'
 import CategoryCell from './cells/CategoryCell'
 import StatusCell from './cells/StatusCell'
 import BudgetCell from './cells/BudgetCell'
+import { useOptionalTrip } from '@/lib/hooks/useTripContext'
 
 export type EditableField = 'time_start' | 'name' | 'category' | 'reservation_status' | 'budget'
 export const EDITABLE_FIELDS: EditableField[] = [
@@ -144,8 +146,12 @@ export default function TableRow({
         />
       </div>
 
-      {/* 상세 버튼 */}
-      <div className="w-8 flex-shrink-0 flex items-center justify-center py-2.5 opacity-0 group-hover:opacity-100 transition-opacity">
+      {/* 날짜 이동 + 상세 버튼 */}
+      <div className="w-16 flex-shrink-0 flex items-center justify-end gap-1 pr-2 py-2.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+        <DateChangeButton
+          currentDate={item.date ?? null}
+          onChange={(next) => onCellSave('date', next)}
+        />
         <button
           type="button"
           onClick={() => onOpenPanel(item.id)}
@@ -158,6 +164,56 @@ export default function TableRow({
           </svg>
         </button>
       </div>
+    </div>
+  )
+}
+
+function DateChangeButton({
+  currentDate,
+  onChange,
+}: {
+  currentDate: string | null
+  onChange: (next: string | null) => void
+}) {
+  const trip = useOptionalTrip()
+  const inputRef = useRef<HTMLInputElement>(null)
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => {
+          const el = inputRef.current
+          if (!el) return
+          // showPicker 는 신규 브라우저 지원, 폴백으로 focus+click
+          if (typeof (el as HTMLInputElement & { showPicker?: () => void }).showPicker === 'function') {
+            ;(el as HTMLInputElement & { showPicker: () => void }).showPicker()
+          } else {
+            el.focus()
+            el.click()
+          }
+        }}
+        className="p-1 text-fg-subtle hover:text-fg rounded transition-colors"
+        aria-label="다른 날짜로 이동"
+        title="다른 날짜로 이동"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M6 2a1 1 0 011 1v1h6V3a1 1 0 112 0v1h1a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2h1V3a1 1 0 011-1zM4 8v8h12V8H4z" clipRule="evenodd" />
+        </svg>
+      </button>
+      <input
+        ref={inputRef}
+        type="date"
+        value={currentDate ?? ''}
+        min={trip?.startDate ?? undefined}
+        max={trip?.endDate ?? undefined}
+        onChange={(e) => {
+          const next = e.target.value || null
+          if (next !== currentDate) onChange(next)
+        }}
+        className="absolute inset-0 opacity-0 pointer-events-none"
+        tabIndex={-1}
+        aria-hidden
+      />
     </div>
   )
 }

--- a/components/Schedule/cells/BudgetCell.tsx
+++ b/components/Schedule/cells/BudgetCell.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import { useOptionalTrip } from '@/lib/hooks/useTripContext'
+import { formatBudget, normalizeCurrency } from '@/lib/currency'
 
 interface BudgetCellProps {
   value: number | undefined
@@ -11,6 +13,8 @@ interface BudgetCellProps {
 }
 
 export default function BudgetCell({ value, isEditing, onClick, onBlur, onKeyDown }: BudgetCellProps) {
+  const trip = useOptionalTrip()
+  const currency = normalizeCurrency(trip?.currency)
   const inputRef = useRef<HTMLInputElement>(null)
   const [draft, setDraft] = useState(value !== undefined ? String(value) : '')
 
@@ -61,7 +65,7 @@ export default function BudgetCell({ value, isEditing, onClick, onBlur, onKeyDow
       onClick={onClick}
     >
       {value !== undefined ? (
-        `$${value.toLocaleString()}`
+        formatBudget(value, currency)
       ) : (
         <span className="text-fg-subtle">—</span>
       )}

--- a/components/Trip/TripSettingsSheet.tsx
+++ b/components/Trip/TripSettingsSheet.tsx
@@ -9,6 +9,7 @@ import { useToast } from '@/components/UI/Toast'
 import { useTrip } from '@/lib/hooks/useTripContext'
 import { useConfirm } from '@/components/UI/ConfirmDialog'
 import { Trash2 } from 'lucide-react'
+import { SUPPORTED_CURRENCIES, normalizeCurrency, type CurrencyCode } from '@/lib/currency'
 
 interface Props {
   open: boolean
@@ -26,6 +27,7 @@ export default function TripSettingsSheet({ open, onClose }: Props) {
   const [endDate, setEndDate] = useState(trip.endDate ?? '')
   const [region, setRegion] = useState(trip.region ?? '')
   const [basecamp, setBasecamp] = useState(trip.basecampAddress ?? '')
+  const [currency, setCurrency] = useState<CurrencyCode>(normalizeCurrency(trip.currency))
   const [saving, setSaving] = useState(false)
 
   async function handleSave() {
@@ -48,6 +50,7 @@ export default function TripSettingsSheet({ open, onClose }: Props) {
           end_date: endDate || null,
           region: region.trim() || null,
           basecamp_address: basecamp.trim() || null,
+          currency,
         }),
       })
       const data = await res.json()
@@ -144,6 +147,23 @@ export default function TripSettingsSheet({ open, onClose }: Props) {
             value={basecamp}
             onChange={(e) => setBasecamp(e.target.value)}
           />
+          <div>
+            <label className="block text-sm font-medium text-fg mb-1.5">통화</label>
+            <select
+              value={currency}
+              onChange={(e) => setCurrency(e.target.value as CurrencyCode)}
+              className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-fg focus-visible:outline-2 focus-visible:outline-accent"
+            >
+              {SUPPORTED_CURRENCIES.map((c) => (
+                <option key={c.code} value={c.code}>
+                  {c.symbol} {c.code} — {c.label}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-fg-subtle mt-1">
+              예산 입력·표시에 사용해요. 기존 항목의 수치는 그대로 유지돼요.
+            </p>
+          </div>
         </div>
       </SheetSection>
 

--- a/components/UI/Sheet.tsx
+++ b/components/UI/Sheet.tsx
@@ -46,6 +46,11 @@ interface SheetProps {
   contentClassName?: string
   /** 백드롭 클릭 시 닫기 (기본 true) */
   dismissibleBackdrop?: boolean
+  /**
+   * 백드롭 dim 을 제거하고 클릭이 뒤로 통과되도록 한다 (non-modal 모드).
+   * 지도 뷰의 아이템 패널처럼, 패널이 열려있어도 뒤쪽 지도와 상호작용해야 할 때 사용.
+   */
+  transparentBackdrop?: boolean
 }
 
 /**
@@ -72,6 +77,7 @@ export default function Sheet({
   className,
   contentClassName,
   dismissibleBackdrop = true,
+  transparentBackdrop = false,
 }: SheetProps) {
   const sheetRef = useRef<HTMLDivElement | null>(null)
   const previouslyFocused = useRef<HTMLElement | null>(null)
@@ -145,24 +151,30 @@ export default function Sheet({
   return createPortal(
     <div
       role="dialog"
-      aria-modal="true"
+      aria-modal={transparentBackdrop ? undefined : 'true'}
       aria-labelledby={title ? 'sheet-title' : undefined}
       aria-describedby={description ? 'sheet-desc' : undefined}
-      className="fixed inset-0 z-[1100]"
+      className={cn(
+        'fixed inset-0 z-[1100]',
+        transparentBackdrop && 'pointer-events-none',
+      )}
     >
       {/* backdrop */}
-      <button
-        type="button"
-        aria-label={closeLabel}
-        onClick={handleBackdropClick}
-        className="absolute inset-0 bg-overlay animate-fade-in cursor-default"
-      />
+      {transparentBackdrop ? null : (
+        <button
+          type="button"
+          aria-label={closeLabel}
+          onClick={handleBackdropClick}
+          className="absolute inset-0 bg-overlay animate-fade-in cursor-default"
+        />
+      )}
       {/* sheet */}
       <div
         ref={sheetRef}
         className={cn(
           'absolute bg-bg-elevated text-fg shadow-e28 flex flex-col',
           'border border-border',
+          transparentBackdrop && 'pointer-events-auto',
           sideClasses,
           // side='auto' 는 모바일=bottom / 데스크톱=right 로 전환되므로,
           // 인라인 style 의 바텀시트 사이징(height:auto/maxHeight:Xvh/no width)을

--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -1,0 +1,71 @@
+/**
+ * Trip 단위 통화 표시·포맷팅.
+ * 기존 USD 고정에서 벗어나기 위한 헬퍼.
+ */
+
+export type CurrencyCode =
+  | 'KRW'
+  | 'USD'
+  | 'JPY'
+  | 'EUR'
+  | 'GBP'
+  | 'CNY'
+  | 'THB'
+  | 'VND'
+  | 'TWD'
+  | 'HKD'
+  | 'SGD'
+  | 'AUD'
+  | 'CAD'
+
+export const SUPPORTED_CURRENCIES: { code: CurrencyCode; label: string; symbol: string }[] = [
+  { code: 'KRW', label: '대한민국 원', symbol: '₩' },
+  { code: 'JPY', label: '일본 엔', symbol: '¥' },
+  { code: 'USD', label: '미국 달러', symbol: '$' },
+  { code: 'EUR', label: '유로', symbol: '€' },
+  { code: 'GBP', label: '영국 파운드', symbol: '£' },
+  { code: 'CNY', label: '중국 위안', symbol: '¥' },
+  { code: 'THB', label: '태국 바트', symbol: '฿' },
+  { code: 'VND', label: '베트남 동', symbol: '₫' },
+  { code: 'TWD', label: '대만 달러', symbol: 'NT$' },
+  { code: 'HKD', label: '홍콩 달러', symbol: 'HK$' },
+  { code: 'SGD', label: '싱가포르 달러', symbol: 'S$' },
+  { code: 'AUD', label: '호주 달러', symbol: 'A$' },
+  { code: 'CAD', label: '캐나다 달러', symbol: 'C$' },
+]
+
+const ZERO_DECIMAL: CurrencyCode[] = ['KRW', 'JPY', 'VND']
+
+export function isCurrencyCode(value: unknown): value is CurrencyCode {
+  return typeof value === 'string' && SUPPORTED_CURRENCIES.some(c => c.code === value)
+}
+
+export function normalizeCurrency(value: unknown, fallback: CurrencyCode = 'KRW'): CurrencyCode {
+  return isCurrencyCode(value) ? value : fallback
+}
+
+export function formatBudget(value: number, currency: CurrencyCode = 'KRW'): string {
+  const decimals = ZERO_DECIMAL.includes(currency) ? 0 : 2
+  try {
+    return new Intl.NumberFormat('ko-KR', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: decimals,
+      minimumFractionDigits: 0,
+    }).format(value)
+  } catch {
+    const meta = SUPPORTED_CURRENCIES.find(c => c.code === currency)
+    const sym = meta?.symbol ?? ''
+    return `${sym}${Math.round(value).toLocaleString('ko-KR')}`
+  }
+}
+
+/** 입력 placeholder 등에 쓰는 통화 심볼. */
+export function currencySymbol(currency: CurrencyCode = 'KRW'): string {
+  return SUPPORTED_CURRENCIES.find(c => c.code === currency)?.symbol ?? ''
+}
+
+/** 라벨 (입력 필드 등). 예: "예산 (₩)" */
+export function currencyFieldLabel(prefix: string, currency: CurrencyCode = 'KRW'): string {
+  return `${prefix} (${currencySymbol(currency)})`
+}

--- a/lib/hooks/useTripContext.tsx
+++ b/lib/hooks/useTripContext.tsx
@@ -11,6 +11,7 @@ export type TripContextValue = {
   endDate: string | null
   region: string | null
   basecampAddress: string | null
+  currency: string
   role: TripRole
 }
 

--- a/supabase/migration_199_trips_currency.sql
+++ b/supabase/migration_199_trips_currency.sql
@@ -1,0 +1,15 @@
+-- #199 trip 단위 currency 도입.
+-- 기존 USD 고정에서 벗어나, trip 별로 표시·입력 통화를 갖는다.
+-- 기존 trip 은 한국 사용자 비중을 고려하여 일괄 'KRW' 로 초기화.
+--
+-- Supabase SQL Editor 에서 1회 실행. 재실행 안전.
+
+begin;
+
+alter table public.trips
+  add column if not exists currency varchar(3) not null default 'KRW';
+
+-- 기존 데이터: 컬럼 추가 시 default 가 적용되지만, 명시적으로 한 번 더 보정.
+update public.trips set currency = 'KRW' where currency is null;
+
+commit;


### PR DESCRIPTION
## 요약

페르소나 테스트(일본 여행 계획) 에서 발굴한 9개 이슈 (#193-#201) 를 한 번에 정리한 배치. 이슈마다 별도 PR 로 쪼개기보다 컨텍스트가 끊기지 않게 단일 브랜치에 커밋만 나눠 처리.

## 포함 이슈와 커밋

| 이슈 | 커밋 | 변경 요지 |
|---|---|---|
| [#194](https://github.com/Useful-Dogus/trip-planner/issues/194) 지도 초기 중심점 region 폴백 | `fix(map): #194` | 뉴욕 하드코딩 제거. `MapInitialCenter` 신규 — items bbox → basecamp → region geocode → 폴백. 사용자 이동 시 자동 재중심 비활성화. |
| [#195](https://github.com/Useful-Dogus/trip-planner/issues/195) 줌 컨트롤이 제목 가림 | `fix(map): #195` | Leaflet 줌 컨트롤을 좌상단 → 우하단. 3개 맵 모두. |
| [#197](https://github.com/Useful-Dogus/trip-planner/issues/197) 빈 상태 추가 무동작 + 날짜 변경 부재 | `fix(crud): #197` | ResearchTable 빈 상태 CTA 가 무동작이던 버그 fix. ScheduleTable 빈 상태에 직접 CTA 추가. 일정 뷰 행에 '다른 날짜로 이동' 버튼 추가 (native date picker, trip 기간 범위 제한). |
| [#193](https://github.com/Useful-Dogus/trip-planner/issues/193) 마법사 종료일/베이스캠프 skip/요약 step | `feat(wizard): #193` | 시작일 선택 시 종료일 자동 시작일로 (picker 가 그 월에서 열림) + `min` 부여. 베이스캠프 step 에 '나중에 정하기'. 5번째 '확인' step 추가, 각 항목 옆 '수정' 으로 점프. |
| [#198](https://github.com/Useful-Dogus/trip-planner/issues/198) 지도 인터랙션 dim 제거 + progressive | `feat(map): #198` | `Sheet` 에 `transparentBackdrop` 추가. `ItemPanel.nonModal` 으로 지도 뷰에서 dim 제거 + 뒤쪽 지도 인터랙티브 유지. 마커가 가려질 때만 부드럽게 panTo (줌 보존). |
| [#196](https://github.com/Useful-Dogus/trip-planner/issues/196) user-scope 와 trip-scope 메뉴 분리 | `refactor(nav): #196` | 데스크탑 사이드바와 모바일 더보기 시트에 '내 계정' / '이 여행' 그룹 헤딩으로 시각 분리. 구글맵 가져오기는 trip-scope 메인 nav 로 승격. |
| [#199](https://github.com/Useful-Dogus/trip-planner/issues/199) Trip 단위 currency, USD 고정 제거 | `feat(currency): #199` | DB 마이그레이션 추가 (`supabase/migration_199_trips_currency.sql`). `lib/currency.ts` 신규. 마법사·설정에 통화 selector (default KRW). 모든 budget 표시·라벨이 trip currency 기준. |
| [#200](https://github.com/Useful-Dogus/trip-planner/issues/200) Gmaps import 핀 이름 폴백 | `feat(import): #200` | DMS/decimal 좌표만 있는 이름 감지 → reverse geocode → region 폴백 → 순번 폴백. |
| [#201](https://github.com/Useful-Dogus/trip-planner/issues/201) 시각 언어 audit (핵심) | `chore(ui): #201` | 목록 헤더 '공유' 버튼 크기를 '새 항목' 과 통일. 전수 audit (이모지→아이콘 등) 은 후속 별도 이슈로 이관. |

## 마이그레이션 필요

- `supabase/migration_199_trips_currency.sql` 을 Supabase SQL Editor 에서 1회 실행해야 currency 컬럼이 생긴다. 컬럼이 없어도 코드는 `KRW` 폴백으로 동작하지만, 사용자가 통화를 바꿔도 저장되지 않음.

## 자기검열 체크리스트 (CLAUDE.md)

- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가 — #195 로 가시성 보장
- [x] 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가 — #197 의 빈 상태 CTA · 날짜 이동 으로 갭 메움
- [x] 시트는 콘텐츠 양에 맞게 표시되는가 — Sheet 의 콘텐츠 적응형 기본 모드 유지
- [x] 마법사 카피의 약속이 실제 가능한가 — #193 베이스캠프 skip 및 요약 step '수정' 동선 구현
- [x] 모바일·데스크탑 동등한가 — 6개 변경 모두 양쪽 확인

## 후속 이슈 후보 (이번 배치에서 의도적으로 제외)

- #199 의 home currency 환산 표시 (예산 합계 옆 "≈ ₩XXX")
- #200 의 import 결과 화면 '이름 미정 일괄 편집' UI
- #201 의 전수 audit (카테고리 이모지 → lucide 아이콘셋, 칩 색상 다이어트, 칩 남용 정리)
- #196 의 데스크탑 우상단 아바타 드롭다운 (현재는 사이드바 내부 그룹 헤딩으로 분리)

## 테스트 계획

- [ ] 새 trip 생성 → 마법사 5 step 정상 진행, 각 step 의 "수정" 링크로 점프
- [ ] 베이스캠프 skip 후 trip 생성 → 지도가 region 기반으로 열림 (뉴욕 아님)
- [ ] 일본 trip 만들고 currency JPY 선택 → 모든 budget 입력·표시가 JPY 포맷
- [ ] 항목 list 빈 상태 → "새 항목 추가" 클릭 시 입력 입장
- [ ] 일정 뷰 행 호버 → 캘린더 아이콘 클릭 → 다른 날짜 이동 → 그룹 이동 확인
- [ ] 지도 뷰 마커 클릭 → 사이드 패널 열려도 지도 dim 안 됨, 뒤쪽 마커 클릭 가능
- [ ] 지도 줌 컨트롤이 trip 제목과 겹치지 않음
- [ ] Gmaps import 에 좌표만 있는 핀이 섞인 데이터로 import → DMS 좌표 이름이 사라짐
