### PR TITLE
feat(pwa): #41 PWA 지원 — manifest · 아이콘 · iOS 풀스크린 메타

### DIFF
--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -1,0 +1,29 @@
+import { ImageResponse } from 'next/og'
+
+export const size = { width: 180, height: 180 }
+export const contentType = 'image/png'
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          background: '#0D9488',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <svg width="62%" height="62%" viewBox="0 0 32 32" fill="none">
+          <path
+            d="M16 6C12.134 6 9 9.134 9 13C9 18.25 16 26 16 26C16 26 23 18.25 23 13C23 9.134 19.866 6 16 6ZM16 16C14.343 16 13 14.657 13 13C13 11.343 14.343 10 16 10C17.657 10 19 11.343 19 13C19 14.657 17.657 16 16 16Z"
+            fill="white"
+          />
+        </svg>
+      </div>
+    ),
+    size,
+  )
+}

--- a/app/icon0.tsx
+++ b/app/icon0.tsx
@@ -1,0 +1,30 @@
+import { ImageResponse } from 'next/og'
+
+export const size = { width: 192, height: 192 }
+export const contentType = 'image/png'
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          background: '#0D9488',
+          borderRadius: '22%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <svg width="62%" height="62%" viewBox="0 0 32 32" fill="none">
+          <path
+            d="M16 6C12.134 6 9 9.134 9 13C9 18.25 16 26 16 26C16 26 23 18.25 23 13C23 9.134 19.866 6 16 6ZM16 16C14.343 16 13 14.657 13 13C13 11.343 14.343 10 16 10C17.657 10 19 11.343 19 13C19 14.657 17.657 16 16 16Z"
+            fill="white"
+          />
+        </svg>
+      </div>
+    ),
+    size,
+  )
+}

--- a/app/icon1.tsx
+++ b/app/icon1.tsx
@@ -1,0 +1,30 @@
+import { ImageResponse } from 'next/og'
+
+export const size = { width: 512, height: 512 }
+export const contentType = 'image/png'
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          background: '#0D9488',
+          borderRadius: '22%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <svg width="62%" height="62%" viewBox="0 0 32 32" fill="none">
+          <path
+            d="M16 6C12.134 6 9 9.134 9 13C9 18.25 16 26 16 26C16 26 23 18.25 23 13C23 9.134 19.866 6 16 6ZM16 16C14.343 16 13 14.657 13 13C13 11.343 14.343 10 16 10C17.657 10 19 11.343 19 13C19 14.657 17.657 16 16 16Z"
+            fill="white"
+          />
+        </svg>
+      </div>
+    ),
+    size,
+  )
+}

--- a/app/icon2.tsx
+++ b/app/icon2.tsx
@@ -1,0 +1,29 @@
+import { ImageResponse } from 'next/og'
+
+export const size = { width: 512, height: 512 }
+export const contentType = 'image/png'
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          background: '#0D9488',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <svg width="50%" height="50%" viewBox="0 0 32 32" fill="none">
+          <path
+            d="M16 6C12.134 6 9 9.134 9 13C9 18.25 16 26 16 26C16 26 23 18.25 23 13C23 9.134 19.866 6 16 6ZM16 16C14.343 16 13 14.657 13 13C13 11.343 14.343 10 16 10C17.657 10 19 11.343 19 13C19 14.657 17.657 16 16 16Z"
+            fill="white"
+          />
+        </svg>
+      </div>
+    ),
+    size,
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,8 +6,14 @@ import Providers from './providers'
 export const metadata: Metadata = {
   title: 'Trip Planner',
   description: '지도와 함께 만드는 여행 계획',
-  icons: {
-    icon: '/icon.svg',
+  applicationName: 'Trip Planner',
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: 'default',
+    title: 'Trip Planner',
+  },
+  formatDetection: {
+    telephone: false,
   },
   openGraph: {
     title: 'Trip Planner',

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from 'next'
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Trip Planner',
+    short_name: 'Trip Planner',
+    description: '지도와 함께 만드는 여행 계획',
+    lang: 'ko',
+    start_url: '/',
+    scope: '/',
+    display: 'standalone',
+    orientation: 'portrait',
+    background_color: '#ffffff',
+    theme_color: '#0D9488',
+    icons: [
+      { src: '/icon.svg', sizes: 'any', type: 'image/svg+xml' },
+      { src: '/icon0', sizes: '192x192', type: 'image/png', purpose: 'any' },
+      { src: '/icon1', sizes: '512x512', type: 'image/png', purpose: 'any' },
+      { src: '/icon2', sizes: '512x512', type: 'image/png', purpose: 'maskable' },
+      { src: '/apple-icon', sizes: '180x180', type: 'image/png' },
+    ],
+  }
+}

--- a/specs/041-pwa/plan.md
+++ b/specs/041-pwa/plan.md
@@ -1,0 +1,41 @@
+# 041-pwa — Plan
+
+## 기술 결정
+
+Next.js 14 App Router 의 Metadata file convention 사용. `public/manifest.json` 정적 파일 대신 코드로 관리.
+
+| 파일 | 역할 |
+|---|---|
+| `app/manifest.ts` | Web App Manifest (name, theme, icons, display, start_url) |
+| `app/icon.tsx` | 192×192 PNG — 빌드 시 `next/og ImageResponse` 로 생성 |
+| `app/icon-large.tsx` | 512×512 PNG (별 파일명으로 다중 사이즈) |
+| `app/apple-icon.tsx` | 180×180 iOS 홈 아이콘 (Apple Touch Icon) |
+| `app/layout.tsx` | `appleWebApp` 메타 추가 (statusBarStyle, capable) |
+
+Next.js 가 위 컨벤션 파일을 자동 인식해 `<link>` 와 manifest 항목을 채워 넣음 — 우리는 별도 link tag 추가 불필요.
+
+## 브랜드 토큰
+
+- 배경/아이콘: `#0D9488` (brand teal, 기존 favicon 과 일치)
+- theme_color (라이트): `#ffffff`
+- theme_color (다크): `#0b1020` (기존 layout viewport themeColor 와 정렬)
+- manifest theme_color 는 단일 값만 허용 → 다크 톤(`#0b1020`) 선택 (status bar 안정적)
+
+## 아이콘 디자인
+
+기존 `app/icon.svg` (지오/핀 모티프) 그대로 차용:
+- 둥근 사각형 배경: `#0D9488`
+- 핀 + 중심점: white
+
+ImageResponse 의 div + SVG path 로 재현.
+
+## 비범위
+
+- Service Worker (오프라인 캐싱): next-pwa 도입 시 빌드·캐시 정책 결정 필요해 별도 PR
+- 푸시 알림: 별도 인프라
+
+## 검증 방법
+
+- `npm run build` 성공
+- 빌드 산출물에서 `manifest.webmanifest`, `icon`, `apple-icon` 경로 확인
+- 로컬 dev 에서 Chrome DevTools → Application → Manifest 패널이 모든 필드를 인식

--- a/specs/041-pwa/spec.md
+++ b/specs/041-pwa/spec.md
@@ -1,0 +1,28 @@
+# 041-pwa — PWA 지원 (모바일 홈 화면 추가)
+
+GitHub: #41
+
+## 문제
+
+여행 중 스마트폰에서 주로 사용하는 앱인데 매번 브라우저에서 URL 입력해야 함. iOS Safari / Android Chrome 의 "홈 화면에 추가" 시 일반 북마크처럼 동작하고, 앱 이름·아이콘·테마가 갖춰지지 않음.
+
+## 사용자 시나리오
+
+1. 사용자가 모바일 브라우저로 trip-planner 를 처음 방문한다.
+2. 브라우저의 "홈 화면에 추가" 메뉴를 사용한다.
+3. 홈 화면에 "Trip Planner" 라벨과 브랜드 Teal 아이콘이 생긴다.
+4. 아이콘 탭 시 주소창 없는 풀스크린 모드로 앱이 실행된다.
+5. 상단 status bar 색이 브랜드 톤(라이트/다크 모드 반응) 으로 표시된다.
+
+## 완료 조건
+
+- Lighthouse PWA installability 체크 통과(아이콘·manifest·display·start_url 완비)
+- iOS Safari `홈 화면에 추가` 시 앱 이름·아이콘 표시 + 풀스크린 실행
+- Android Chrome 설치 prompt 가능
+- 라이트/다크 status bar 색 분기
+- 본 PR 범위 외: Service Worker 기반 오프라인 캐싱 (별도 이슈)
+
+## 범위 밖
+
+- next-pwa 통한 SW + 오프라인 캐싱 — 후속 이슈
+- 푸시 알림 — 별도 기능

--- a/specs/041-pwa/tasks.md
+++ b/specs/041-pwa/tasks.md
@@ -1,0 +1,9 @@
+# 041-pwa — Tasks
+
+- [ ] T1: `app/manifest.ts` 작성 (MetadataRoute.Manifest)
+- [ ] T2: `app/icon.tsx` 192×192 (ImageResponse, teal + 핀)
+- [ ] T3: `app/icon-large.tsx` 512×512 (동일 디자인, 사이즈만 다름)
+- [ ] T4: `app/apple-icon.tsx` 180×180 (iOS 친화 라운드 안전영역)
+- [ ] T5: `app/layout.tsx` 에 `appleWebApp` 메타 추가 (statusBarStyle, capable, title)
+- [ ] T6: `app/icon.svg` 유지 (브라우저 탭 favicon)
+- [ ] T7: `npm run build` 성공 + manifest 산출 확인


### PR DESCRIPTION
## 관련 이슈

Closes #41

## 변경 이유

모바일이 주 기기인데 매번 브라우저에서 URL 입력해야 하는 진입 마찰이 컸다. iOS Safari "홈 화면에 추가" 시에도 일반 북마크 동작이라 앱 이름·아이콘·풀스크린이 없었다.

## 변경 범위

Next.js 14 App Router 의 Metadata file convention 으로 PWA 구현 (정적 `public/manifest.json` 대신 코드로 관리).

- `app/manifest.ts` — Web App Manifest (name/short_name, display:standalone, theme_color `#0D9488`, scope/start_url, icons[])
- `app/icon0.tsx` — 192×192 PNG (ImageResponse, brand teal + 핀)
- `app/icon1.tsx` — 512×512 PNG
- `app/icon2.tsx` — 512×512 maskable (safe-zone 50%)
- `app/apple-icon.tsx` — 180×180 iOS Touch Icon
- `app/layout.tsx`
  - `appleWebApp.capable=true` + `statusBarStyle='default'` + `title`
  - `formatDetection.telephone=false` (전화번호 자동 링크화 방지)
  - 기존 `icons.icon` 제거 — `app/icon.svg` metadata file convention 으로 자동 등록되어 중복

기존 `app/icon.svg` 는 브라우저 탭 favicon 으로 그대로 유지.

## 검증

- [x] `npm run build` 성공 — `/manifest.webmanifest`, `/icon0..2`, `/apple-icon`, `/icon.svg` 모두 정적 라우트로 등록 확인
- [ ] iOS Safari 실기기에서 "홈 화면에 추가" → 앱 이름·아이콘·standalone 실행 (배포 후 확인 필요)
- [ ] Android Chrome 설치 prompt 노출 (배포 후 확인 필요)

## 남은 작업 / 리스크

- **Service Worker / 오프라인 캐싱**: 본 PR 범위 외. next-pwa 도입 시 빌드·캐시 정책 결정 필요해 별도 이슈로 추적 권장.
- **theme_color 단일 값 제약**: manifest 표준은 단일 값만 허용 — 라이트/다크 분기는 `viewport.themeColor` 가 처리, manifest 는 brand teal 고정.
- iOS Safari 의 manifest 지원은 일부만 (Apple Touch Icon + `apple-mobile-web-app-*` meta 가 실제 동작) — 모두 포함됨.

---

- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? — N/A (전역 메타)
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — N/A
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? — N/A
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — N/A
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — 모바일 한정 기능, 데스크탑 영향 없음