### PR TITLE
refactor(ui): #207 카테고리 이모지 → lucide 아이콘셋 통일

### DIFF
--- a/components/Items/GroupCard.tsx
+++ b/components/Items/GroupCard.tsx
@@ -39,7 +39,7 @@ export default function GroupCard({
     if (editingName !== null) inputRef.current?.select()
   }, [editingName])
 
-  const emoji = CATEGORY_META[visibleItems[0]?.category]?.emoji ?? '📌'
+  const HeaderIcon = CATEGORY_META[visibleItems[0]?.category]?.Icon
   const visibleCount = visibleItems.length
   const badgeLabel =
     visibleCount === totalCount ? `${totalCount}곳` : `${visibleCount}/${totalCount}곳`
@@ -88,9 +88,9 @@ export default function GroupCard({
         )}
       >
         <div className="flex items-center gap-2.5 min-w-0">
-          <span className="flex-shrink-0 text-base leading-none" aria-hidden="true">
-            {emoji}
-          </span>
+          {HeaderIcon ? (
+            <HeaderIcon size={16} className="flex-shrink-0 text-fg-muted" aria-hidden="true" />
+          ) : null}
           {editingName !== null ? (
             <input
               ref={inputRef}

--- a/components/Items/ItemCard.tsx
+++ b/components/Items/ItemCard.tsx
@@ -91,12 +91,12 @@ export default function ItemCard({
       />
       <div className="flex items-start justify-between gap-2 pl-2">
         <div className="flex items-center gap-2.5 min-w-0">
-          <span
-            className="flex-shrink-0 text-base leading-none"
-            aria-hidden="true"
-          >
-            {CATEGORY_META[item.category]?.emoji ?? '📌'}
-          </span>
+          {(() => {
+            const Icon = CATEGORY_META[item.category]?.Icon
+            return Icon ? (
+              <Icon size={16} className="flex-shrink-0 text-fg-muted" aria-hidden="true" />
+            ) : null
+          })()}
           <div className="min-w-0">
             {editingName !== null ? (
               <input

--- a/components/Map/MapSidePanel.tsx
+++ b/components/Map/MapSidePanel.tsx
@@ -310,7 +310,7 @@ function CandidatesView({
           {filtered.map((item) => {
             const active = item.id === selectedItemId
             const color = CATEGORY_META[item.category]?.color ?? '#cbd5e1'
-            const emoji = CATEGORY_META[item.category]?.emoji ?? '📌'
+            const Icon = CATEGORY_META[item.category]?.Icon
             const isConfirmed = item.trip_priority === '확정'
             return (
               <li key={item.id}>
@@ -335,9 +335,7 @@ function CandidatesView({
                   />
                   <span className="min-w-0 flex-1">
                     <span className="flex items-center gap-1.5">
-                      <span className="text-xs" aria-hidden="true">
-                        {emoji}
-                      </span>
+                      {Icon ? <Icon size={12} className="flex-shrink-0 text-fg-muted" aria-hidden="true" /> : null}
                       <span className="truncate text-xs font-semibold text-fg">
                         {item.name}
                       </span>

--- a/components/Map/ResearchMap.tsx
+++ b/components/Map/ResearchMap.tsx
@@ -2,14 +2,15 @@
 
 import { MapContainer, TileLayer, Marker, Tooltip, ZoomControl } from 'react-leaflet'
 import L from 'leaflet'
-import type { TripItem } from '@/types'
-import { CATEGORY_META } from '@/lib/itemOptions'
+import type { TripItem, Category } from '@/types'
+import { categoryIconSvg } from '@/lib/categoryIcon'
 import MapInitialCenter from './MapInitialCenter'
 import { useOptionalTrip } from '@/lib/hooks/useTripContext'
 
-function createEmojiChipIcon(emoji: string) {
+function createCategoryChipIcon(category: Category) {
+  const svg = categoryIconSvg(category, { size: 14, color: 'currentColor', strokeWidth: 2 })
   return L.divIcon({
-    html: `<div class="tp-chip-marker">${emoji}</div>`,
+    html: `<div class="tp-chip-marker">${svg}</div>`,
     className: '',
     iconSize: [28, 24],
     iconAnchor: [14, 12],
@@ -49,7 +50,7 @@ export default function ResearchMap({ items, onSelectItem }: ResearchMapProps) {
         <Marker
           key={item.id}
           position={[item.lat!, item.lng!]}
-          icon={createEmojiChipIcon(CATEGORY_META[item.category]?.emoji ?? '📌')}
+          icon={createCategoryChipIcon(item.category)}
           eventHandlers={
             onSelectItem
               ? {

--- a/components/Map/TripPlannerMap.tsx
+++ b/components/Map/TripPlannerMap.tsx
@@ -7,9 +7,10 @@ import MapInitialCenter from './MapInitialCenter'
 import SelectedItemPan from './SelectedItemPan'
 import L from 'leaflet'
 import type { TripItem } from '@/types'
-import { CATEGORY_META } from '@/lib/itemOptions'
+import { categoryIconSvg } from '@/lib/categoryIcon'
 import { getEndLodging, getStartLodging, isStayItem } from '@/lib/lodging'
 import { useOptionalTrip } from '@/lib/hooks/useTripContext'
+import type { Category } from '@/types'
 
 interface TripPlannerMapProps {
   items: TripItem[]
@@ -18,7 +19,7 @@ interface TripPlannerMapProps {
   onSelectItem: (id: string) => void
 }
 
-function chipIcon(emoji: string, opts: { dim?: boolean; selected?: boolean }) {
+function chipIcon(category: Category, opts: { dim?: boolean; selected?: boolean }) {
   const cls = [
     'tp-chip-marker',
     opts.selected && 'is-selected',
@@ -26,8 +27,9 @@ function chipIcon(emoji: string, opts: { dim?: boolean; selected?: boolean }) {
   ]
     .filter(Boolean)
     .join(' ')
+  const svg = categoryIconSvg(category, { size: 14, color: 'currentColor', strokeWidth: 2 })
   return L.divIcon({
-    html: `<div class="${cls}">${emoji}</div>`,
+    html: `<div class="${cls}">${svg}</div>`,
     className: '',
     iconSize: [28, 24],
     iconAnchor: [14, 12],
@@ -156,7 +158,7 @@ export default function TripPlannerMap({
           <Marker
             key={item.id}
             position={[item.lat!, item.lng!]}
-            icon={chipIcon(CATEGORY_META[item.category]?.emoji ?? '📌', {
+            icon={chipIcon(item.category, {
               dim: selectedDate !== null,
               selected: item.id === selectedItemId,
             })}

--- a/components/Schedule/DayTimeline.tsx
+++ b/components/Schedule/DayTimeline.tsx
@@ -38,7 +38,7 @@ export default function DayTimeline({ items, selectedItemId, onSelectItem }: Day
       {items.map((item, idx) => {
         const prev = idx > 0 ? items[idx - 1] : null
         const km = prev ? distance(prev, item) : null
-        const emoji = CATEGORY_META[item.category]?.emoji ?? '📌'
+        const Icon = CATEGORY_META[item.category]?.Icon
         const color = CATEGORY_META[item.category]?.color ?? '#cbd5e1'
         const active = item.id === selectedItemId
         return (
@@ -68,7 +68,7 @@ export default function DayTimeline({ items, selectedItemId, onSelectItem }: Day
                 </span>
                 <span className="min-w-0 flex-1">
                   <span className="flex items-center gap-1.5">
-                    <span className="text-xs">{emoji}</span>
+                    {Icon ? <Icon size={12} className="flex-shrink-0 text-fg-muted" /> : null}
                     <span className="truncate text-xs font-semibold text-fg">
                       {item.name}
                     </span>

--- a/components/Schedule/ScheduleTable.tsx
+++ b/components/Schedule/ScheduleTable.tsx
@@ -124,7 +124,7 @@ function MobileScheduleItemCard({
   const status = getStatusMeta(item.reservation_status)
   const budget = formatBudget(item.budget, trip?.currency ?? 'KRW')
   const time = formatTimeRange(item)
-  const emoji = CATEGORY_META[item.category]?.emoji ?? '📌'
+  const Icon = CATEGORY_META[item.category]?.Icon
   const { setNodeRef, listeners, attributes, isDragging } = useDraggable({
     id: `drag:item:${item.id}`,
     data: { itemId: item.id, sourceDate: item.date ?? null },
@@ -138,8 +138,8 @@ function MobileScheduleItemCard({
         className="w-full rounded-2xl border border-border bg-bg-elevated p-4 pl-10 text-left shadow-sm transition-all hover:border-border-strong hover:shadow-md active:scale-[0.99]"
       >
         <div className="flex items-start gap-3">
-          <span className="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl bg-bg-subtle text-lg">
-            {emoji}
+          <span className="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl bg-bg-subtle text-fg-muted">
+            {Icon ? <Icon size={18} /> : null}
           </span>
           <div className="min-w-0 flex-1">
             <div className="flex items-start justify-between gap-3">
@@ -177,13 +177,13 @@ function MobileScheduleItemCard({
 
 function DragPreviewCard({ item }: { item: TripItem }) {
   const trip = useOptionalTrip()
-  const emoji = CATEGORY_META[item.category]?.emoji ?? '📌'
+  const Icon = CATEGORY_META[item.category]?.Icon
   const budget = formatBudget(item.budget, trip?.currency ?? 'KRW')
   return (
     <div className="pointer-events-none w-72 rounded-2xl border border-accent bg-bg-elevated p-3 shadow-2xl rotate-1">
       <div className="flex items-center gap-2">
-        <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-xl bg-bg-subtle text-base">
-          {emoji}
+        <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-xl bg-bg-subtle text-fg-muted">
+          {Icon ? <Icon size={16} /> : null}
         </span>
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-semibold text-fg">{item.name}</p>

--- a/components/Schedule/cells/CategoryCell.tsx
+++ b/components/Schedule/cells/CategoryCell.tsx
@@ -60,7 +60,7 @@ export default function CategoryCell({
     }
   }, [position])
 
-  const emoji = CATEGORY_META[value]?.emoji ?? '🔖'
+  const CurrentIcon = CATEGORY_META[value]?.Icon
 
   return (
     <>
@@ -68,10 +68,11 @@ export default function CategoryCell({
         ref={buttonRef}
         type="button"
         onClick={onClick}
-        className="text-base leading-none select-none cursor-pointer hover:opacity-70 transition-opacity"
+        className="inline-flex items-center justify-center leading-none select-none cursor-pointer text-fg-muted hover:text-fg transition-colors"
         title={value}
+        aria-label={value}
       >
-        {emoji}
+        {CurrentIcon ? <CurrentIcon size={16} /> : null}
       </button>
 
       {isEditing &&
@@ -84,22 +85,25 @@ export default function CategoryCell({
             style={{ top: position.top, left: position.left }}
           >
             <div className="grid grid-cols-4 gap-1">
-              {CATEGORY_OPTIONS.map(cat => (
-                <button
-                  key={cat}
-                  type="button"
-                  onClick={() => {
-                    onSelect(cat)
-                  }}
-                  title={cat}
-                  className={`flex flex-col items-center gap-0.5 p-2 rounded-lg hover:bg-bg-subtle transition-colors text-xs ${
-                    cat === value ? 'bg-bg-subtle ring-1 ring-border-strong' : ''
-                  }`}
-                >
-                  <span className="text-base">{CATEGORY_META[cat].emoji}</span>
-                  <span className="text-fg-muted whitespace-nowrap">{cat}</span>
-                </button>
-              ))}
+              {CATEGORY_OPTIONS.map(cat => {
+                const ItemIcon = CATEGORY_META[cat].Icon
+                return (
+                  <button
+                    key={cat}
+                    type="button"
+                    onClick={() => {
+                      onSelect(cat)
+                    }}
+                    title={cat}
+                    className={`flex flex-col items-center gap-1 p-2 rounded-lg hover:bg-bg-subtle transition-colors text-xs ${
+                      cat === value ? 'bg-bg-subtle ring-1 ring-border-strong' : ''
+                    }`}
+                  >
+                    <ItemIcon size={18} className="text-fg-muted" />
+                    <span className="text-fg-muted whitespace-nowrap">{cat}</span>
+                  </button>
+                )
+              })}
             </div>
           </div>,
           document.body

--- a/components/Share/SharedItemCard.tsx
+++ b/components/Share/SharedItemCard.tsx
@@ -10,7 +10,7 @@ function formatTimeRange(item: TripItem): string | null {
 }
 
 export default function SharedItemCard({ item }: Props) {
-  const meta = CATEGORY_META[item.category]
+  const Icon = CATEGORY_META[item.category]?.Icon
   const time = formatTimeRange(item)
 
   return (
@@ -19,7 +19,7 @@ export default function SharedItemCard({ item }: Props) {
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 mb-1">
             <span className="inline-flex items-center gap-1 rounded-full border border-border bg-bg px-2 py-0.5 text-xs font-medium text-fg-subtle">
-              <span aria-hidden="true">{meta?.emoji}</span>
+              {Icon ? <Icon size={12} aria-hidden="true" /> : null}
               {item.category}
             </span>
             {time && <span className="text-xs text-fg-subtle tabular">{time}</span>}

--- a/components/UI/ItemMetadataChips.tsx
+++ b/components/UI/ItemMetadataChips.tsx
@@ -25,7 +25,7 @@ function PlaceholderChip({ label }: { label: string }) {
 
 function CategoryChip({ category }: { category: TripItem['category'] | undefined }) {
   if (!category) return <PlaceholderChip label={PLACEHOLDER_LABELS.category} />
-  const emoji = CATEGORY_META[category]?.emoji
+  const Icon = CATEGORY_META[category]?.Icon
   return (
     <span
       className={cn(
@@ -33,7 +33,7 @@ function CategoryChip({ category }: { category: TripItem['category'] | undefined
         CHIP_TONE,
       )}
     >
-      <span aria-hidden="true">{emoji}</span>
+      {Icon ? <Icon size={12} aria-hidden="true" className="flex-shrink-0" /> : null}
       {category}
     </span>
   )

--- a/lib/categoryIcon.ts
+++ b/lib/categoryIcon.ts
@@ -1,0 +1,30 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { Category } from '@/types'
+import { CATEGORY_META } from './itemOptions'
+
+interface IconSvgOptions {
+  size?: number
+  color?: string
+  strokeWidth?: number
+}
+
+const cache = new Map<string, string>()
+
+export function categoryIconSvg(
+  category: Category,
+  opts: IconSvgOptions = {},
+): string {
+  const size = opts.size ?? 16
+  const color = opts.color ?? 'currentColor'
+  const strokeWidth = opts.strokeWidth ?? 2
+  const key = `${category}:${size}:${color}:${strokeWidth}`
+  const hit = cache.get(key)
+  if (hit) return hit
+  const { Icon } = CATEGORY_META[category]
+  const svg = renderToStaticMarkup(
+    createElement(Icon, { size, color, strokeWidth }),
+  )
+  cache.set(key, svg)
+  return svg
+}

--- a/lib/itemOptions.ts
+++ b/lib/itemOptions.ts
@@ -1,4 +1,18 @@
 import type { Category, ReservationStatus, TripItem, TripPriority } from '@/types'
+import {
+  Bus,
+  Hotel,
+  Landmark,
+  UtensilsCrossed,
+  Coffee,
+  ShoppingBag,
+  Palette,
+  Drama,
+  Target,
+  Palmtree,
+  Bookmark,
+  type LucideIcon,
+} from 'lucide-react'
 
 export const CATEGORY_OPTIONS: Category[] = [
   '교통',
@@ -49,18 +63,18 @@ export const CHIP_BASE_TONE = 'bg-bg-elevated border border-border'
 export const CHIP_TONE = `${CHIP_BASE_TONE} text-fg-muted`
 export const PLACEHOLDER_TONE = `${CHIP_BASE_TONE} text-fg-subtle`
 
-export const CATEGORY_META: Record<Category, { emoji: string; color: string }> = {
-  교통: { emoji: '🚌', color: '#94a3b8' },
-  숙박: { emoji: '🏨', color: '#0ea5e9' },
-  명소: { emoji: '🏛️', color: '#f97316' },
-  식당: { emoji: '🍽️', color: '#ef4444' },
-  카페: { emoji: '☕', color: '#a16207' },
-  쇼핑: { emoji: '🛍️', color: '#ec4899' },
-  문화시설: { emoji: '🎨', color: '#8b5cf6' },
-  '공연·스포츠': { emoji: '🎭', color: '#10b981' },
-  액티비티: { emoji: '🎯', color: '#f59e0b' },
-  휴양: { emoji: '🌴', color: '#22c55e' },
-  기타: { emoji: '🔖', color: '#cbd5e1' },
+export const CATEGORY_META: Record<Category, { Icon: LucideIcon; color: string }> = {
+  교통: { Icon: Bus, color: '#94a3b8' },
+  숙박: { Icon: Hotel, color: '#0ea5e9' },
+  명소: { Icon: Landmark, color: '#f97316' },
+  식당: { Icon: UtensilsCrossed, color: '#ef4444' },
+  카페: { Icon: Coffee, color: '#a16207' },
+  쇼핑: { Icon: ShoppingBag, color: '#ec4899' },
+  문화시설: { Icon: Palette, color: '#8b5cf6' },
+  '공연·스포츠': { Icon: Drama, color: '#10b981' },
+  액티비티: { Icon: Target, color: '#f59e0b' },
+  휴양: { Icon: Palmtree, color: '#22c55e' },
+  기타: { Icon: Bookmark, color: '#cbd5e1' },
 }
 
 interface PriorityMeta {

--- a/specs/207-lucide-category/plan.md
+++ b/specs/207-lucide-category/plan.md
@@ -1,0 +1,87 @@
+# 207-lucide-category — Plan
+
+## 아이콘 매핑
+
+| Category | lucide | 기존 emoji | 사유 |
+|---|---|---|---|
+| 교통 | `Bus` | 🚌 | 직관적 |
+| 숙박 | `Hotel` | 🏨 | 직관적 |
+| 명소 | `Landmark` | 🏛️ | 직관적 |
+| 식당 | `UtensilsCrossed` | 🍽️ | 식기 교차 |
+| 카페 | `Coffee` | ☕ | 직관적 |
+| 쇼핑 | `ShoppingBag` | 🛍️ | 직관적 |
+| 문화시설 | `Palette` | 🎨 | 미술·전시 톤 |
+| 공연·스포츠 | `Drama` | 🎭 | 무대 마스크 |
+| 액티비티 | `Target` | 🎯 | 직관적 |
+| 휴양 | `Palmtree` | 🌴 | 직관적 |
+| 기타 | `Bookmark` | 🔖 | 직관적 |
+
+색상은 기존 brand 컬러 유지 (#208 칩 정리 단계에서 재검토).
+
+## `CATEGORY_META` 새 시그니처
+
+```ts
+import type { LucideIcon } from 'lucide-react'
+
+export const CATEGORY_META: Record<Category, { Icon: LucideIcon; color: string }> = {
+  교통: { Icon: Bus, color: '#94a3b8' },
+  // ...
+}
+```
+
+기존 `.emoji` 사용 지점은 컴파일 에러로 모두 검출 → 일괄 교체.
+
+## 지도 마커 처리 (Leaflet divIcon)
+
+Leaflet 은 SVG/HTML 문자열을 받는다. lucide React 컴포넌트를 직접 못 박으니, `react-dom/server` 의 `renderToStaticMarkup` 으로 SSR-style 렌더 → SVG 문자열 추출.
+
+```ts
+// lib/categoryIcon.ts
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createElement } from 'react'
+
+const cache = new Map<string, string>()
+export function categoryIconSvg(
+  category: Category,
+  opts: { size?: number; color?: string; strokeWidth?: number } = {},
+): string {
+  const key = `${category}:${opts.size ?? 16}:${opts.color ?? 'currentColor'}:${opts.strokeWidth ?? 2}`
+  const hit = cache.get(key)
+  if (hit) return hit
+  const { Icon } = CATEGORY_META[category]
+  const svg = renderToStaticMarkup(
+    createElement(Icon, { size: opts.size ?? 16, color: opts.color ?? 'currentColor', strokeWidth: opts.strokeWidth ?? 2 }),
+  )
+  cache.set(key, svg)
+  return svg
+}
+```
+
+`renderToStaticMarkup` 은 React 18 의 일반 server export — 클라이언트 번들에서도 import 가능. 호출 한 번에 SVG 문자열 + 캐시. 11개 카테고리 × (마커 사이즈) 만큼만 캐시되므로 비용 무시 가능.
+
+지도 마커 함수(`chipIcon`, `createEmojiChipIcon`) 가 emoji 자리에 `categoryIconSvg(category, { size, color: 'white' })` 결과를 HTML 안에 임베드.
+
+## 영향 범위 (grep `CATEGORY_META\|\.emoji` 결과)
+
+- `components/UI/ReservationStatusBadge.tsx` (status emoji — 본 PR 범위 외, 카테고리 무관)
+- `components/UI/ItemMetadataChips.tsx`
+- `components/UI/TripPriorityBadge.tsx` (priority emoji — 본 PR 범위 외)
+- `components/Schedule/CategoryStackBar.tsx`
+- `components/Schedule/ScheduleTable.tsx` (MobileScheduleItemCard + DragPreviewCard)
+- `components/Schedule/DayTimeline.tsx`
+- `components/Schedule/cells/CategoryCell.tsx`
+- `components/Schedule/cells/PriorityCell.tsx` (priority — 범위 외)
+- `components/Map/TripPlannerMap.tsx`
+- `components/Map/ResearchMap.tsx`
+- `components/Map/MapSidePanel.tsx`
+- `components/Items/ItemCard.tsx`
+- `components/Items/GroupCard.tsx`
+- `components/Share/SharedItemCard.tsx`
+
+위 중 카테고리 emoji 만 교체. 우선순위/예약상태 emoji 는 본 PR 범위 외.
+
+## 검증
+
+- `npm run build` + `npm run lint`
+- 컴파일 에러로 누락 사용처 없음 확인
+- 지도 페이지에서 마커 lucide 표시

--- a/specs/207-lucide-category/spec.md
+++ b/specs/207-lucide-category/spec.md
@@ -1,0 +1,21 @@
+# 207-lucide-category — 카테고리 아이콘셋 lucide 통일
+
+GitHub: #207 (부모 #205)
+
+## 문제
+
+`lib/itemOptions.ts` 의 `CATEGORY_META` 가 이모지(`🚌 🏨 🏛️ …`) 를 사용. 플랫폼별 렌더링 차이가 크고("페르소나 테스트: 'AI 디자인 같다' 인상의 1차 원인"), 다크모드에서 톤 깨짐.
+
+## 완료 조건
+
+- `CATEGORY_META` 의 `emoji` 필드 제거, `Icon: LucideIcon` 으로 교체
+- 카테고리를 표시하는 모든 React 컴포넌트가 lucide 아이콘 사용
+- 지도 마커도 동일 lucide 아이콘으로 표시 (이모지/SVG 혼재 회피)
+- 빌드·lint 통과
+
+## 범위 밖
+
+- 칩 컴포넌트 variant 통합 (`#208`)
+- 빈 상태 톤 통일 (`#209`)
+- 디자인 가이드 문서 보강 (`#210`)
+- `TRIP_PRIORITY_META.emoji`, `RESERVATION_STATUS_META.emoji` — 본 PR 범위 외 (카테고리 한정). 다음 audit 라운드에서 정리.


### PR DESCRIPTION
## 관련 이슈

Closes #207 (부모 #205)

## 변경 이유

`CATEGORY_META` 가 이모지(`🚌 🏨 🏛️ …`) 를 사용해 플랫폼별 렌더링 차이가 크고, 페르소나 테스트의 "AI 디자인 같다 / 초보 디자이너" 인상의 1차 원인이었다.

## 변경 범위

### 1) `CATEGORY_META` 시그니처 변경

`{ emoji: string; color: string }` → `{ Icon: LucideIcon; color: string }`. 컴파일러로 모든 사용처를 강제 노출.

| Category | lucide |
|---|---|
| 교통 | `Bus` |
| 숙박 | `Hotel` |
| 명소 | `Landmark` |
| 식당 | `UtensilsCrossed` |
| 카페 | `Coffee` |
| 쇼핑 | `ShoppingBag` |
| 문화시설 | `Palette` |
| 공연·스포츠 | `Drama` |
| 액티비티 | `Target` |
| 휴양 | `Palmtree` |
| 기타 | `Bookmark` |

색상은 기존 brand 컬러 유지 (#208 칩 variant 정리 단계에서 재검토).

### 2) 지도 마커 일관성

`lib/categoryIcon.ts` 신규 — `react-dom/server.renderToStaticMarkup` 으로 lucide 컴포넌트를 SVG 문자열화 + 캐시. 결과를 Leaflet `divIcon` HTML 에 임베드.

`TripPlannerMap.chipIcon`, `ResearchMap.createCategoryChipIcon` 모두 동일 SVG 사용. 마커 색은 `tp-chip-marker` CSS 의 `color: rgb(var(--fg))` 가 `currentColor` 로 자연 적용.

### 3) 모든 사용처 교체

11 개 컴포넌트:

- `components/UI/ItemMetadataChips.tsx`
- `components/Schedule/DayTimeline.tsx`
- `components/Schedule/ScheduleTable.tsx` (MobileScheduleItemCard + DragPreviewCard)
- `components/Schedule/cells/CategoryCell.tsx` (현재 카테고리 버튼 + dropdown 옵션 그리드)
- `components/Map/TripPlannerMap.tsx`, `ResearchMap.tsx`, `MapSidePanel.tsx`
- `components/Items/ItemCard.tsx`, `GroupCard.tsx`
- `components/Share/SharedItemCard.tsx`

React 컴포넌트는 `<Icon size={N} className="text-fg-muted" />` 형태로 적용 (사이즈 12-18, 화면 위치에 맞춰).

## 검증

- [x] `npm run build` 성공 — 모든 라우트 정상 빌드
- [x] `npm run lint` — warning/error 0
- [x] `grep CATEGORY_META.*emoji` 결과 0 (잔재 없음)
- [ ] 지도 마커 lucide SVG 표시 (배포 후 시각 확인 권장)

## 남은 작업 / 리스크

- **`TRIP_PRIORITY_META.emoji`, `RESERVATION_STATUS_META.emoji`** — 본 PR 은 카테고리 한정. 우선순위·예약상태 emoji 는 다음 audit 라운드(#208 또는 별도)에서 정리.
- **`react-dom/server` 클라이언트 번들 포함** — Next.js 가 schedule 페이지에 6.9 → 8.0 kB 정도 증가시킴 (캐시 1회 호출 후 무비용). 실측 list 페이지 15.9, schedule 22.7 kB 로 dnd-kit + categoryIcon 합산.
- 카테고리 색상 다이어트는 #208 에서.

---

- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? — TripPageHeader 영향 없음
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — N/A (시각 변경)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? — N/A
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — N/A
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — 양쪽 모두 동일 아이콘 (이전 이모지 플랫폼 차이가 오히려 해소)