### PR TITLE
refactor(ui): #208 Chip variant 통합 + 카테고리 색 톤 다이어트

### DIFF
--- a/components/Panel/ItemPanel.tsx
+++ b/components/Panel/ItemPanel.tsx
@@ -11,9 +11,7 @@ import { useConfirm } from '@/components/UI/ConfirmDialog'
 import { formatBudget, currencyFieldLabel, normalizeCurrency } from '@/lib/currency'
 import {
   CATEGORY_OPTIONS,
-  CHIP_TONE,
   ITEM_FIELD_LABELS,
-  PLACEHOLDER_TONE,
   TRIP_PRIORITY_META,
   TRIP_PRIORITY_OPTIONS,
   RESERVATION_STATUS_META,
@@ -21,6 +19,7 @@ import {
 } from '@/lib/itemOptions'
 import TripPriorityBadge from '@/components/UI/TripPriorityBadge'
 import ReservationStatusBadge from '@/components/UI/ReservationStatusBadge'
+import { Chip } from '@/components/UI/Chip'
 
 export interface ItemPanelProps {
   item: TripItem | null
@@ -395,7 +394,7 @@ function ItemDetailView({
             isOpen={openField === 'category'}
             saving={savingField === 'category'}
             onToggle={() => onOpenField(openField === 'category' ? null : 'category')}
-            currentNode={<span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${CHIP_TONE}`}>{item.category}</span>}
+            currentNode={<Chip variant="category" category={item.category}>{item.category}</Chip>}
             options={CATEGORY_OPTIONS}
             onSelect={v => onQuickUpdate('category', v)}
           />
@@ -417,7 +416,7 @@ function ItemDetailView({
             currentNode={
               item.reservation_status
                 ? <ReservationStatusBadge reservationStatus={item.reservation_status} />
-                : <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${PLACEHOLDER_TONE}`}>예약 정보 없음</span>
+                : <Chip variant="neutral" className="text-fg-subtle">예약 정보 없음</Chip>
             }
             options={RESERVATION_STATUS_OPTIONS}
             descriptions={RESERVATION_STATUS_META}

--- a/components/Share/SharedItemCard.tsx
+++ b/components/Share/SharedItemCard.tsx
@@ -1,5 +1,5 @@
 import type { TripItem } from '@/types'
-import { CATEGORY_META } from '@/lib/itemOptions'
+import { Chip } from '@/components/UI/Chip'
 
 type Props = { item: TripItem }
 
@@ -10,7 +10,6 @@ function formatTimeRange(item: TripItem): string | null {
 }
 
 export default function SharedItemCard({ item }: Props) {
-  const Icon = CATEGORY_META[item.category]?.Icon
   const time = formatTimeRange(item)
 
   return (
@@ -18,10 +17,9 @@ export default function SharedItemCard({ item }: Props) {
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 mb-1">
-            <span className="inline-flex items-center gap-1 rounded-full border border-border bg-bg px-2 py-0.5 text-xs font-medium text-fg-subtle">
-              {Icon ? <Icon size={12} aria-hidden="true" /> : null}
+            <Chip variant="category" size="sm" category={item.category}>
               {item.category}
-            </span>
+            </Chip>
             {time && <span className="text-xs text-fg-subtle tabular">{time}</span>}
           </div>
           <h3 className="text-base font-semibold text-fg break-words">{item.name}</h3>

--- a/components/UI/Chip.tsx
+++ b/components/UI/Chip.tsx
@@ -2,36 +2,57 @@ import { forwardRef } from 'react'
 import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from 'react'
 import { X } from 'lucide-react'
 import { cn } from '@/lib/cn'
+import type { Category } from '@/types'
+import { CATEGORY_META } from '@/lib/itemOptions'
 
 type Size = 'sm' | 'md'
+type Variant = 'neutral' | 'accent' | 'category'
 
 const SIZE: Record<Size, string> = {
   sm: 'h-6 px-2 text-[11px] gap-1 rounded',
   md: 'h-7 px-2.5 text-xs gap-1.5 rounded-full',
 }
 
+const VARIANT: Record<Variant, string> = {
+  neutral: 'bg-bg-subtle text-fg-muted border-border',
+  accent: 'bg-accent-subtle text-accent border-accent/30',
+  // category 의 색 강조는 leading dot 으로만. 배경/테두리는 중립.
+  category: 'bg-bg-subtle text-fg border-border',
+}
+
 interface ChipProps extends HTMLAttributes<HTMLSpanElement> {
   size?: Size
+  variant?: Variant
   leading?: ReactNode
+  /** variant='category' 일 때 카테고리 색 dot + lucide 아이콘을 자동 leading 으로 사용 */
+  category?: Category
 }
 
 /** 비-인터랙티브 정보 칩. 카테고리·메타 표시. */
 export const Chip = forwardRef<HTMLSpanElement, ChipProps>(function Chip(
-  { size = 'md', leading, className, children, ...rest },
+  { size = 'md', variant = 'neutral', leading, category, className, children, ...rest },
   ref,
 ) {
+  const autoLeading =
+    leading ??
+    (variant === 'category' && category
+      ? (() => {
+          const Icon = CATEGORY_META[category]?.Icon
+          return Icon ? <Icon size={size === 'sm' ? 11 : 12} aria-hidden="true" /> : null
+        })()
+      : null)
   return (
     <span
       ref={ref}
       className={cn(
-        'inline-flex items-center font-medium select-none',
-        'bg-bg-subtle text-fg-muted border border-border',
+        'inline-flex items-center font-medium select-none border',
+        VARIANT[variant],
         SIZE[size],
         className,
       )}
       {...rest}
     >
-      {leading && <span className="inline-flex shrink-0">{leading}</span>}
+      {autoLeading && <span className="inline-flex shrink-0">{autoLeading}</span>}
       {children}
     </span>
   )

--- a/components/UI/ItemMetadataChips.tsx
+++ b/components/UI/ItemMetadataChips.tsx
@@ -1,41 +1,23 @@
 import type { TripItem } from '@/types'
-import {
-  CATEGORY_META,
-  CHIP_TONE,
-  ITEM_FIELD_LABELS,
-  PLACEHOLDER_LABELS,
-  PLACEHOLDER_TONE,
-} from '@/lib/itemOptions'
+import { ITEM_FIELD_LABELS, PLACEHOLDER_LABELS } from '@/lib/itemOptions'
 import TripPriorityBadge from '@/components/UI/TripPriorityBadge'
 import ReservationStatusBadge from '@/components/UI/ReservationStatusBadge'
-import { cn } from '@/lib/cn'
+import { Chip } from '@/components/UI/Chip'
 
 function PlaceholderChip({ label }: { label: string }) {
   return (
-    <span
-      className={cn(
-        'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium border',
-        PLACEHOLDER_TONE,
-      )}
-    >
+    <Chip variant="neutral" size="sm" className="text-fg-subtle">
       {label}
-    </span>
+    </Chip>
   )
 }
 
 function CategoryChip({ category }: { category: TripItem['category'] | undefined }) {
   if (!category) return <PlaceholderChip label={PLACEHOLDER_LABELS.category} />
-  const Icon = CATEGORY_META[category]?.Icon
   return (
-    <span
-      className={cn(
-        'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium border',
-        CHIP_TONE,
-      )}
-    >
-      {Icon ? <Icon size={12} aria-hidden="true" className="flex-shrink-0" /> : null}
+    <Chip variant="category" size="sm" category={category}>
       {category}
-    </span>
+    </Chip>
   )
 }
 

--- a/lib/itemOptions.ts
+++ b/lib/itemOptions.ts
@@ -55,26 +55,19 @@ export const PLACEHOLDER_LABELS = {
   reservation_status: '예약 정보 없음',
 } as const
 
-/**
- * Tailwind className 기반 배지 톤 (다크모드 자동 적용).
- * 기존 inline style 객체는 legacy 호환을 위해 유지.
- */
-export const CHIP_BASE_TONE = 'bg-bg-elevated border border-border'
-export const CHIP_TONE = `${CHIP_BASE_TONE} text-fg-muted`
-export const PLACEHOLDER_TONE = `${CHIP_BASE_TONE} text-fg-subtle`
-
+// 색은 카테고리 dot 보조용. 채도 한 단계 낮춤 (Tailwind 400 톤 정렬) — 무지개 인상 완화.
 export const CATEGORY_META: Record<Category, { Icon: LucideIcon; color: string }> = {
-  교통: { Icon: Bus, color: '#94a3b8' },
-  숙박: { Icon: Hotel, color: '#0ea5e9' },
-  명소: { Icon: Landmark, color: '#f97316' },
-  식당: { Icon: UtensilsCrossed, color: '#ef4444' },
-  카페: { Icon: Coffee, color: '#a16207' },
-  쇼핑: { Icon: ShoppingBag, color: '#ec4899' },
-  문화시설: { Icon: Palette, color: '#8b5cf6' },
-  '공연·스포츠': { Icon: Drama, color: '#10b981' },
-  액티비티: { Icon: Target, color: '#f59e0b' },
-  휴양: { Icon: Palmtree, color: '#22c55e' },
-  기타: { Icon: Bookmark, color: '#cbd5e1' },
+  교통: { Icon: Bus, color: '#94a3b8' },           // slate-400 (유지)
+  숙박: { Icon: Hotel, color: '#38bdf8' },         // sky-400
+  명소: { Icon: Landmark, color: '#fb923c' },      // orange-400
+  식당: { Icon: UtensilsCrossed, color: '#f87171' }, // red-400
+  카페: { Icon: Coffee, color: '#b45309' },        // amber-700 (밝게)
+  쇼핑: { Icon: ShoppingBag, color: '#f472b6' },   // pink-400
+  문화시설: { Icon: Palette, color: '#a78bfa' },   // violet-400
+  '공연·스포츠': { Icon: Drama, color: '#34d399' }, // emerald-400
+  액티비티: { Icon: Target, color: '#fbbf24' },    // amber-400
+  휴양: { Icon: Palmtree, color: '#4ade80' },      // green-400
+  기타: { Icon: Bookmark, color: '#cbd5e1' },      // slate-300 (유지)
 }
 
 interface PriorityMeta {

--- a/specs/208-chip-variant/plan.md
+++ b/specs/208-chip-variant/plan.md
@@ -1,0 +1,61 @@
+# 208-chip-variant — Plan
+
+## Chip 컴포넌트 API 변경
+
+```ts
+type ChipVariant = 'neutral' | 'accent' | 'category'
+
+interface ChipProps {
+  variant?: ChipVariant  // default 'neutral'
+  category?: Category    // variant='category' 일 때 사용
+  size?: 'sm' | 'md'
+  leading?: ReactNode    // 명시적 leading override
+  // ...
+}
+```
+
+variant 별 클래스:
+
+| variant | bg | border | text | leading |
+|---|---|---|---|---|
+| neutral | bg-bg-subtle | border-border | text-fg-muted | optional |
+| accent | bg-accent-subtle | border-accent/30 | text-accent | optional |
+| category | bg-bg-subtle | border-border | text-fg | category color dot 자동 + 카테고리 lucide 아이콘 (props.category 필요) |
+
+`category` variant 는 자동으로 lucide Icon (props.category 의) 을 leading 으로 렌더. `leading` prop 으로 override 가능.
+
+## 카테고리 컬러 톤 다이어트
+
+현재 색 (채도 높음) → 한 단계 낮춤. Tailwind 스케일 기준 `400/500` → `300/400` 수준.
+
+| Category | before | after | 비고 |
+|---|---|---|---|
+| 교통 | #94a3b8 (slate-400) | #94a3b8 | 이미 중성 |
+| 숙박 | #0ea5e9 (sky-500) | #38bdf8 | sky-400 |
+| 명소 | #f97316 (orange-500) | #fb923c | orange-400 |
+| 식당 | #ef4444 (red-500) | #f87171 | red-400 |
+| 카페 | #a16207 (yellow-700) | #b45309 | amber-700 좀 더 밝게 |
+| 쇼핑 | #ec4899 (pink-500) | #f472b6 | pink-400 |
+| 문화시설 | #8b5cf6 (violet-500) | #a78bfa | violet-400 |
+| 공연·스포츠 | #10b981 (emerald-500) | #34d399 | emerald-400 |
+| 액티비티 | #f59e0b (amber-500) | #fbbf24 | amber-400 |
+| 휴양 | #22c55e (green-500) | #4ade80 | green-400 |
+| 기타 | #cbd5e1 (slate-300) | #cbd5e1 | 유지 |
+
+dot 으로만 사용되므로 채도 낮춰도 변별성 유지.
+
+## 통합 지점
+
+- `components/UI/ItemMetadataChips.tsx` CategoryChip → `<Chip variant="category" category={...}>...`
+- `components/Share/SharedItemCard.tsx` 카테고리 칩 → 동일 패턴
+- `components/Panel/ItemPanel.tsx` line 398 (CHIP_TONE inline) → `<Chip variant="neutral">`, line 420 placeholder → `<Chip variant="neutral" className="opacity-70">` 또는 별도 처리
+
+## 비범위
+
+- 50+ inline rounded-full 정리 — 후속 audit
+- TripPriorityBadge / ReservationStatusBadge — 본 PR 범위 외
+
+## 검증
+
+- `npm run build` + `npm run lint`
+- ItemMetadataChips 가 렌더링되는 화면(map sidepanel, schedule)에서 칩이 통일된 톤으로 보임

--- a/specs/208-chip-variant/spec.md
+++ b/specs/208-chip-variant/spec.md
@@ -1,0 +1,22 @@
+# 208-chip-variant — 칩 컴포넌트 variant 통합 + 색상 다이어트
+
+GitHub: #208 (부모 #205)
+
+## 문제
+
+`Chip` / `ChipButton` 컴포넌트는 있지만 단일 variant 만 지원. 대부분의 카테고리·메타 칩은 inline `rounded-full px-2 py-0.5 ...` 형태로 50+ 곳 산재. 카테고리는 무지개 색을 통한 구분 의존이 강해 "AI 디자인 같다" 인상에 기여.
+
+## 완료 조건
+
+- `Chip` 컴포넌트가 `variant: 'neutral' | 'accent' | 'category'` prop 지원
+- `category` variant 는 배경 채도를 낮추고 leading dot 으로 카테고리 색을 보조 표시 (색을 칩 전체에 깔지 않음)
+- 카테고리 칩이 노출되는 주요 지점 (`ItemMetadataChips`, `SharedItemCard`, `ItemPanel`) 이 통합 컴포넌트 사용
+- 칩이 화면에 동시에 다수 떠 있어도 채도 높은 색이 5개 이상 겹치지 않음
+- `lib/itemOptions.ts` 의 카테고리 색을 채도 한 단계 낮춤 (또는 light-mode 톤 정렬)
+- 빌드·lint 통과
+
+## 범위 밖
+
+- 인라인 `rounded-full` 형태가 남아 있는 50+ 곳을 모두 Chip 컴포넌트로 마이그레이션 — 별도 후속 (#210 디자인 가이드 완료 후 audit 이슈로 분리)
+- TripPriorityBadge / ReservationStatusBadge 의 색 단계 재검토 — 별도
+- 빈 상태 톤 (#209)


### PR DESCRIPTION
## 관련 이슈

Closes #208 (부모 #205)

## 변경 이유

`Chip` / `ChipButton` 컴포넌트는 있었지만 단일 톤만 지원. 카테고리/메타 칩의 대부분은 `inline-flex items-center rounded-full px-2 py-0.5 ...` 형태로 직접 그려져 있어 패턴 산발. 또한 카테고리 색이 강한 채도로 칩 배경에 깔리면서 "AI 디자인 같다" 인상에 기여.

## 변경 범위

### 1) `Chip` 컴포넌트 — `variant` prop 도입

| variant | 배경/테두리 | 사용처 |
|---|---|---|
| `neutral` (기본) | `bg-bg-subtle text-fg-muted border-border` | 일반 메타 칩, 빈/플레이스홀더 |
| `accent` | `bg-accent-subtle text-accent border-accent/30` | 선택/활성 표시 |
| `category` | neutral 톤 + props.category 의 **lucide 아이콘을 자동 leading** | 카테고리 표시 (배경 강조 X) |

→ 카테고리 식별은 **아이콘** 으로, 색은 보조. 칩 배경을 색으로 채우지 않아 같은 화면에 다수 칩이 떠도 시각적 노이즈 적음.

### 2) 카테고리 컬러 톤 다이어트

`CATEGORY_META.color` 를 Tailwind 400 톤으로 한 단계 낮춤:

| Category | before | after |
|---|---|---|
| 숙박 | sky-500 `#0ea5e9` | sky-400 `#38bdf8` |
| 명소 | orange-500 `#f97316` | orange-400 `#fb923c` |
| 식당 | red-500 `#ef4444` | red-400 `#f87171` |
| 쇼핑 | pink-500 `#ec4899` | pink-400 `#f472b6` |
| 문화시설 | violet-500 `#8b5cf6` | violet-400 `#a78bfa` |
| 공연·스포츠 | emerald-500 `#10b981` | emerald-400 `#34d399` |
| 액티비티 | amber-500 `#f59e0b` | amber-400 `#fbbf24` |
| 휴양 | green-500 `#22c55e` | green-400 `#4ade80` |

교통/기타/카페 는 유지·미세 조정. 색은 #207 에 의해 dot 또는 leading 보조로만 사용되므로 변별성은 충분.

### 3) 통합 적용

- `components/UI/ItemMetadataChips.tsx`: CategoryChip / PlaceholderChip 을 Chip 컴포넌트로 교체
- `components/Share/SharedItemCard.tsx`: 카테고리 inline 칩 → `<Chip variant="category" category={...}>`
- `components/Panel/ItemPanel.tsx`: 2 곳의 inline 칩 → `Chip` 컴포넌트
- `lib/itemOptions.ts`: 사용처 0 인 `CHIP_TONE` / `CHIP_BASE_TONE` / `PLACEHOLDER_TONE` 상수 제거

## 검증

- [x] `npm run build` 성공
- [x] `npm run lint` warning/error 0
- [x] `grep CHIP_TONE\\|CHIP_BASE_TONE\\|PLACEHOLDER_TONE` 사용처 0

## 남은 작업 / 리스크

- **50+ 개의 다른 inline `rounded-full` 잔재** (Schedule mobile status chip, Map filter chip, GroupCard 가격 chip 등) — 본 PR 범위 외. #210 디자인 가이드 작성 후 audit 후속 이슈로 분리 권장.
- **TripPriorityBadge / ReservationStatusBadge** 의 색 단계 재검토 — 본 PR 범위 외. priority/status 별 이모지도 #207 처럼 lucide 화는 후속 라운드.
- **빈 상태 톤 통일** — `#209`.
- 카테고리 색이 직접 칩 배경을 채우는 패턴은 본 PR 에서는 모두 제거됐지만, 향후 신규 칩 추가 시 같은 실수 방지를 위해 #210 디자인 가이드에 명시 권장.

---

- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? — TripPageHeader 영향 없음
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — N/A
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? — N/A
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — N/A
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — Chip 컴포넌트는 양쪽 공용