### PR TITLE
fix(mobile): iOS 인풋 자동 줌인 + 마법사 자동 포커스 키보드 팝업 방지

### DIFF
--- a/app/dashboard/new/NewTripWizard.tsx
+++ b/app/dashboard/new/NewTripWizard.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/UI/Input'
 import { useToast } from '@/components/UI/Toast'
 import { cn } from '@/lib/cn'
 import { SUPPORTED_CURRENCIES, type CurrencyCode } from '@/lib/currency'
+import { useIsTouchDevice } from '@/lib/hooks/useIsTouchDevice'
 
 type Step = 1 | 2 | 3 | 4 | 5
 
@@ -206,6 +207,7 @@ function Step1({
   title: string
   setTitle: (v: string) => void
 }) {
+  const isTouch = useIsTouchDevice()
   return (
     <div className="space-y-3">
       <Input
@@ -213,7 +215,7 @@ function Step1({
         value={title}
         onChange={(e) => setTitle(e.target.value)}
         placeholder="예: 오사카 가을 여행"
-        autoFocus
+        autoFocus={!isTouch}
         required
       />
       <p className="text-xs text-fg-subtle">
@@ -267,6 +269,7 @@ function Step3({
   region: string
   setRegion: (v: string) => void
 }) {
+  const isTouch = useIsTouchDevice()
   return (
     <div className="space-y-3">
       <Input
@@ -274,7 +277,7 @@ function Step3({
         value={region}
         onChange={(e) => setRegion(e.target.value)}
         placeholder="예: 일본 오사카"
-        autoFocus
+        autoFocus={!isTouch}
       />
       <p className="text-xs text-fg-subtle">국가·도시·테마 등 자유롭게.</p>
     </div>
@@ -296,6 +299,7 @@ function Step4({
   currency: CurrencyCode
   setCurrency: (c: CurrencyCode) => void
 }) {
+  const isTouch = useIsTouchDevice()
   return (
     <div className="space-y-4">
       <div>
@@ -304,7 +308,7 @@ function Step4({
           value={basecamp}
           onChange={(e) => setBasecamp(e.target.value)}
           placeholder="예: 난바 인근 호텔"
-          autoFocus
+          autoFocus={!isTouch}
         />
         <p className="text-xs text-fg-subtle mt-1">
           선택사항. 동선의 기준점이 돼요. 보통은 숙소 주소를 적어요.

--- a/app/globals.css
+++ b/app/globals.css
@@ -326,6 +326,20 @@
 }
 
 /* ============================================================
+ * iOS Safari 자동 줌인 방지
+ * - 인풋 font-size 가 16px 미만이면 포커스 시 자동으로 줌인된다.
+ * - 데스크탑 밀도는 유지하고 모바일 viewport 에서만 16px 이상을 보장한다.
+ * - color/checkbox/radio/range 처럼 텍스트가 없는 타입은 제외.
+ * ========================================================== */
+@media (max-width: 640px) {
+  input:not([type='checkbox']):not([type='radio']):not([type='range']):not([type='color']):not([type='file']),
+  select,
+  textarea {
+    font-size: 16px;
+  }
+}
+
+/* ============================================================
  * Reduced motion
  * ========================================================== */
 @media (prefers-reduced-motion: reduce) {

--- a/lib/hooks/useIsTouchDevice.ts
+++ b/lib/hooks/useIsTouchDevice.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * 터치(=마우스 hover 없음, 거친 포인터) 디바이스 여부.
+ *
+ * - SSR/초기 렌더에서는 false 를 반환해 데스크탑 동작을 기본값으로 둔다.
+ * - autoFocus 등 모바일에서 키보드를 갑작스럽게 띄우는 동작을 끄는 데 사용한다.
+ *   (사용자가 직접 탭해서 진입한 인라인 편집에는 사용하지 않는다 — 그건 의도된 포커스다.)
+ */
+export function useIsTouchDevice(): boolean {
+  const [isTouch, setIsTouch] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    const mq = window.matchMedia('(hover: none) and (pointer: coarse)')
+    setIsTouch(mq.matches)
+    const handler = (e: MediaQueryListEvent) => setIsTouch(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  return isTouch
+}


### PR DESCRIPTION
## Summary

사용자 제보(iPhone 15 Pro Safari 추정) 기반 모바일 인풋 UX 2종 수정.

- **iOS 자동 줌인**: `text-sm`(14px) 인풋에 포커스 시 iOS Safari 가 자동으로 확대됨. `app/globals.css` 에 `@media (max-width: 640px)` 규칙 추가로 `input`/`select`/`textarea` font-size 를 16px 이상으로 강제. 데스크탑 밀도는 유지.
- **자동 포커스로 인한 키보드 팝업**: `NewTripWizard` Step1/3/4 의 `autoFocus` 가 모바일에서 페이지·스텝 진입 즉시 키보드를 띄움. `useIsTouchDevice` 훅을 새로 만들고 `autoFocus={!isTouch}` 로 전환.
- `ItemPanel` 인라인 편집의 `autoFocus` 6곳은 사용자가 직접 필드를 탭한 결과의 포커스 전이라 유지.

## Why

- 모든 raw `<input>`(Schedule cells, Panel forms, Research table, GmapsImport 등)에도 전역 CSS 한 줄로 일괄 적용 → 향후 추가될 인풋도 자동 보호.
- `autoFocus` 일괄 제거가 아닌 터치 감지 기반 분기로, 데스크탑 키보드 흐름(Tab/Enter)은 그대로 유지.

## Test plan

재현 환경이 없어 단말 검증 미실시. 머지 전 다음 확인 부탁:

- [ ] iPhone Safari: `/dashboard/new` 진입 → 1단계 진입 시 키보드가 자동으로 올라오지 않는다
- [ ] iPhone Safari: 1단계 인풋 탭 → 확대(줌인)되지 않는다
- [ ] iPhone Safari: ItemPanel "이름" 등 인라인 편집 필드 탭 → 편집 진입 시 자동으로 포커스되어 바로 타이핑 가능 (회귀 없음)
- [ ] Android Chrome: 동일 시나리오 정상
- [ ] 데스크탑: 마법사 진입 시 첫 인풋에 자동 포커스 유지

## 셀프 체크 (CLAUDE.md Basics-First)

- [x] 컨텍스트 표시 — UI 외 변경 없음
- [x] CRUD 대칭 — 해당 없음 (스타일/UX only)
- [x] 카피 정직성 — 카피 변경 없음
- [x] 진입점 일관성 — 변경 없음
- [x] 모달·시트 사이징 — 변경 없음
- [x] 키보드·접근성 — 데스크탑 Tab 흐름 보존, 모바일은 키보드 강제 팝업 제거
- [x] 단일-trip 시대 잔재 금지 — 해당 없음
