### PR TITLE
fix(cache): 멀티계정/멀티여행 SWR 캐시·권한 일관성 정비

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -61,7 +61,7 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
   const { data, mutate: mutateTrips } = useSWR<{ trips: TripSummary[] }>(
     '/api/trips',
     fetcher,
-    { fallbackData: { trips: initialTrips }, revalidateOnFocus: false },
+    { fallbackData: { trips: initialTrips } },
   )
   const trips = data?.trips ?? initialTrips
   // legacy state (탬플릿 호환). 실제 보존은 SWR 캐시.
@@ -94,6 +94,7 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
       }
       setTrips((prev) => prev.filter((t) => t.id !== trip.id))
       showToast({ message: '여행을 삭제했어요.', type: 'success' })
+      mutateTrips()
       router.refresh()
     } catch {
       showToast({ message: '네트워크 오류가 발생했습니다.', type: 'error' })

--- a/app/dashboard/new/NewTripWizard.tsx
+++ b/app/dashboard/new/NewTripWizard.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
+import { mutate as globalMutate } from 'swr'
 import { ArrowLeft, Check } from 'lucide-react'
 import Button from '@/components/UI/Button'
 import { Input } from '@/components/UI/Input'
@@ -83,6 +84,9 @@ export default function NewTripWizard() {
         throw new Error(data?.error ?? '여행 생성에 실패했습니다.')
       }
       const data = (await res.json()) as { tripId: string }
+      // 대시보드 SWR 캐시를 즉시 갱신해 두면, 사용자가 뒤로가서 목록으로 돌아왔을 때
+      // 새 trip 이 0.3-0.5s 후 "팝업" 되는 대신 처음부터 보인다.
+      await globalMutate('/api/trips')
       router.push(`/trip/${data.tripId}/map`)
     } catch (e) {
       const msg = e instanceof Error ? e.message : '여행 생성에 실패했습니다.'

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import './globals.css'
 import 'leaflet/dist/leaflet.css'
 import Providers from './providers'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 
 export const metadata: Metadata = {
   title: 'Trip Planner',
@@ -46,14 +47,25 @@ const themeInitScript = `
 })();
 `
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  // 클라이언트 SWR 캐시를 user-scope 로 격리하기 위해 root 에서 user id 를 1회 읽어
+  // Providers 에 prop 으로 내려준다. 인증되지 않은 경로(/login, /signup 등) 도 안전.
+  let userId: string | null = null
+  try {
+    const client = createRouteHandlerSupabase()
+    const { data } = await client.auth.getUser()
+    userId = data.user?.id ?? null
+  } catch {
+    userId = null
+  }
+
   return (
     <html lang="ko" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>
       <body className="bg-bg text-fg font-sans antialiased">
-        <Providers>{children}</Providers>
+        <Providers userId={userId}>{children}</Providers>
       </body>
     </html>
   )

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -5,11 +5,21 @@ import { ToastProvider } from '@/components/UI/Toast'
 import { ConfirmProvider } from '@/components/UI/ConfirmDialog'
 import { ThemeProvider } from '@/components/Theme/ThemeProvider'
 import OfflineBanner from '@/components/UI/OfflineBanner'
+import AuthStateSync from '@/components/Auth/AuthStateSync'
 
-export default function Providers({ children }: { children: React.ReactNode }) {
+export default function Providers({
+  children,
+  userId,
+}: {
+  children: React.ReactNode
+  userId: string | null
+}) {
   return (
     <ThemeProvider>
-      <SWRProvider>
+      {/* key 에 userId 를 박아 사용자 전환 시 SWRProvider 가 리마운트되며
+          새 cache provider 가 만들어진다 — 이전 user 의 in-memory 캐시는 폐기. */}
+      <SWRProvider key={userId ?? 'anon'} userId={userId}>
+        <AuthStateSync initialUserId={userId} />
         <ToastProvider>
           <ConfirmProvider>
             <OfflineBanner />

--- a/app/trip/[tripId]/layout.tsx
+++ b/app/trip/[tripId]/layout.tsx
@@ -44,6 +44,25 @@ export default async function TripLayout({
     .eq('trip_members.user_id', userData.user.id)
     .maybeSingle<TripRow>()
 
+  if (error) {
+    // 진단용: forbidden 화면이 뜬 실제 원인 (스키마 컬럼 누락 42703, RLS 거부, 타임아웃 등) 을 가린다.
+    // 운영 환경에서 한 번 재현해 어느 가설(컬럼 누락 / RLS race / 세션 race) 인지 확정 후
+    // 진짜 fix 적용. 본 PR 은 진단 로그만 추가.
+    console.error('[TripLayout] supabase trip lookup failed', {
+      tripId,
+      userId: userData.user.id,
+      code: error.code,
+      message: error.message,
+      details: error.details,
+      hint: error.hint,
+    })
+  } else if (!data) {
+    console.warn('[TripLayout] trip row not visible to user (RLS or not-found)', {
+      tripId,
+      userId: userData.user.id,
+    })
+  }
+
   if (error || !data) {
     return <TripAccessDenied reason="forbidden" />
   }

--- a/components/Auth/AuthStateSync.tsx
+++ b/components/Auth/AuthStateSync.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import { mutate } from 'swr'
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
+import { getBrowserSupabase } from '@/lib/supabase-browser'
+import { clearAppCache } from '@/lib/clearAppCache'
+
+/**
+ * Supabase 클라이언트 세션 변화와 SWR/localStorage 캐시 일관성을 잇는 글로벌 리스너.
+ *
+ * - SIGNED_OUT: 캐시 전체 폐기 후 /login 으로 하드 리로드.
+ * - SIGNED_IN / USER_UPDATED: 서버가 인식하는 user 와 클라이언트 세션이 다르면
+ *   (= 계정 전환) 캐시 폐기 + 페이지 새로고침으로 SSR 데이터 재페치.
+ *
+ * 매 이벤트마다 무조건 clear 하지 않는다 — 같은 user 의 TOKEN_REFRESHED 같은 정상 이벤트에서
+ * 캐시 폭파는 과잉 반응.
+ */
+export default function AuthStateSync({ initialUserId }: { initialUserId: string | null }) {
+  const router = useRouter()
+  const lastSeenUserId = useRef<string | null>(initialUserId)
+
+  useEffect(() => {
+    const supabase = getBrowserSupabase()
+    const { data: sub } = supabase.auth.onAuthStateChange((event: AuthChangeEvent, session: Session | null) => {
+      const nextUserId = session?.user?.id ?? null
+
+      if (event === 'SIGNED_OUT') {
+        if (lastSeenUserId.current !== null) {
+          clearAppCache()
+          // 모든 SWR 캐시 키 무효화 (서버 데이터 재페치 강제). second arg=undefined + revalidate=false 로 즉시 비움.
+          mutate(() => true, undefined, { revalidate: false })
+        }
+        lastSeenUserId.current = null
+        return
+      }
+
+      // SIGNED_IN, INITIAL_SESSION, USER_UPDATED, TOKEN_REFRESHED 등
+      if (nextUserId && nextUserId !== lastSeenUserId.current) {
+        // 사용자가 실제로 바뀐 경우에만 캐시 폐기 + 서버 컴포넌트 재페치.
+        if (lastSeenUserId.current !== null) {
+          clearAppCache()
+          mutate(() => true, undefined, { revalidate: false })
+          router.refresh()
+        }
+        lastSeenUserId.current = nextUserId
+      }
+    })
+
+    return () => {
+      sub.subscription.unsubscribe()
+    }
+  }, [router])
+
+  return null
+}

--- a/components/Trip/EditableTripTitle.tsx
+++ b/components/Trip/EditableTripTitle.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { mutate as globalMutate } from 'swr'
 import { MoreHorizontal } from 'lucide-react'
 import { useTrip } from '@/lib/hooks/useTripContext'
 import { useToast } from '@/components/UI/Toast'
@@ -63,6 +64,7 @@ export default function EditableTripTitle({ section }: { section: string }) {
         setDraft(trip.title)
       } else {
         showToast({ message: '제목을 저장했습니다.', type: 'success' })
+        globalMutate('/api/trips')
         router.refresh()
       }
     } catch {

--- a/components/Trip/TripSettingsSheet.tsx
+++ b/components/Trip/TripSettingsSheet.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { mutate as globalMutate } from 'swr'
 import Sheet, { SheetSection } from '@/components/UI/Sheet'
 import { Input } from '@/components/UI/Input'
 import Button from '@/components/UI/Button'
@@ -59,6 +60,7 @@ export default function TripSettingsSheet({ open, onClose }: Props) {
         return
       }
       showToast({ message: '여행 정보를 저장했습니다.', type: 'success' })
+      globalMutate('/api/trips')
       router.refresh()
       onClose()
     } catch {
@@ -89,6 +91,7 @@ export default function TripSettingsSheet({ open, onClose }: Props) {
         return
       }
       showToast({ message: '여행을 삭제했어요.', type: 'success' })
+      globalMutate('/api/trips')
       router.push('/dashboard')
     } catch {
       showToast({ message: '네트워크 오류가 발생했습니다.', type: 'error' })

--- a/lib/clearAppCache.ts
+++ b/lib/clearAppCache.ts
@@ -5,17 +5,67 @@
 // localStorage 에 다시 써넣으므로, 단순히 localStorage.removeItem 만으로는
 // navigation 직후 다시 채워진다. window 플래그로 핸들러를 무력화한 뒤 제거한다.
 
-export const SWR_CACHE_KEY = 'trip-planner-swr-cache'
-export const SWR_TIMESTAMP_KEY = 'trip-planner-swr-timestamp'
+// Legacy 전역 키 (이전 빌드에서 모든 사용자가 공유). 청소용으로만 참조한다.
+export const SWR_CACHE_KEY_LEGACY = 'trip-planner-swr-cache'
+export const SWR_TIMESTAMP_KEY_LEGACY = 'trip-planner-swr-timestamp'
+
+export const SWR_CACHE_KEY_PREFIX = 'trip-planner-swr-cache:'
+export const SWR_TIMESTAMP_KEY_PREFIX = 'trip-planner-swr-timestamp:'
 export const SKIP_PERSIST_FLAG = '__tripPlannerSkipSwrPersist'
 
+export function swrCacheKeyFor(userId: string | null): string {
+  return `${SWR_CACHE_KEY_PREFIX}${userId ?? 'anon'}`
+}
+
+export function swrTimestampKeyFor(userId: string | null): string {
+  return `${SWR_TIMESTAMP_KEY_PREFIX}${userId ?? 'anon'}`
+}
+
+/**
+ * 로그인/로그아웃/회원가입/계정 전환 시 호출.
+ * 모든 trip-planner-swr-cache* / -timestamp* 키 + legacy 전역 키 제거.
+ */
 export function clearAppCache(): void {
   if (typeof window === 'undefined') return
   ;(window as unknown as Record<string, unknown>)[SKIP_PERSIST_FLAG] = true
   try {
-    localStorage.removeItem(SWR_CACHE_KEY)
-    localStorage.removeItem(SWR_TIMESTAMP_KEY)
+    localStorage.removeItem(SWR_CACHE_KEY_LEGACY)
+    localStorage.removeItem(SWR_TIMESTAMP_KEY_LEGACY)
+    const toRemove: string[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i)
+      if (!k) continue
+      if (k.startsWith(SWR_CACHE_KEY_PREFIX) || k.startsWith(SWR_TIMESTAMP_KEY_PREFIX)) {
+        toRemove.push(k)
+      }
+    }
+    toRemove.forEach((k) => localStorage.removeItem(k))
   } catch {
     // storage unavailable
+  }
+}
+
+/**
+ * 현재 사용자(userId) 외의 다른 user 캐시 키만 정리한다.
+ * SWRProvider 가 마운트될 때 호출 — 계정 전환 시 이전 사용자의 잔재를 제거.
+ */
+export function pruneOtherUserSwrCaches(currentUserId: string | null): void {
+  if (typeof window === 'undefined') return
+  const keepCache = swrCacheKeyFor(currentUserId)
+  const keepTs = swrTimestampKeyFor(currentUserId)
+  try {
+    localStorage.removeItem(SWR_CACHE_KEY_LEGACY)
+    localStorage.removeItem(SWR_TIMESTAMP_KEY_LEGACY)
+    const toRemove: string[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i)
+      if (!k) continue
+      const isSwrKey =
+        k.startsWith(SWR_CACHE_KEY_PREFIX) || k.startsWith(SWR_TIMESTAMP_KEY_PREFIX)
+      if (isSwrKey && k !== keepCache && k !== keepTs) toRemove.push(k)
+    }
+    toRemove.forEach((k) => localStorage.removeItem(k))
+  } catch {
+    // ignore
   }
 }

--- a/lib/providers/SWRProvider.tsx
+++ b/lib/providers/SWRProvider.tsx
@@ -2,59 +2,80 @@
 
 import { ReactNode } from 'react'
 import { SWRConfig } from 'swr'
-import { SKIP_PERSIST_FLAG, SWR_CACHE_KEY as CACHE_KEY, SWR_TIMESTAMP_KEY as TIMESTAMP_KEY } from '@/lib/clearAppCache'
+import {
+  SKIP_PERSIST_FLAG,
+  pruneOtherUserSwrCaches,
+  swrCacheKeyFor,
+  swrTimestampKeyFor,
+} from '@/lib/clearAppCache'
 
 const TTL_MS = 24 * 60 * 60 * 1000
 
-function localStorageProvider() {
-  if (typeof window === 'undefined') return new Map()
+function makeLocalStorageProvider(userId: string | null) {
+  return function localStorageProvider() {
+    if (typeof window === 'undefined') return new Map()
 
-  const timestamp = localStorage.getItem(TIMESTAMP_KEY)
-  const cacheAge = timestamp ? Date.now() - parseInt(timestamp) : Infinity
+    // 마운트 시점에 다른 user 의 캐시 잔재 제거 — 계정 전환 후 첫 페인트 누수 방지.
+    pruneOtherUserSwrCaches(userId)
 
-  let map: Map<string, unknown>
-  if (cacheAge < TTL_MS) {
-    try {
-      const cached = localStorage.getItem(CACHE_KEY)
-      map = new Map(cached ? JSON.parse(cached) : [])
-    } catch {
-      map = new Map()
-    }
-  } else {
-    map = new Map()
-    localStorage.removeItem(CACHE_KEY)
-    localStorage.removeItem(TIMESTAMP_KEY)
-  }
+    const cacheKey = swrCacheKeyFor(userId)
+    const timestampKey = swrTimestampKeyFor(userId)
 
-  window.addEventListener('beforeunload', () => {
-    // clearAppCache() 가 로그인/로그아웃 직전에 이 플래그를 세우면 write 건너뜀.
-    // (그러지 않으면 in-memory map 이 다시 localStorage 로 흘러나가 이전 사용자의
-    // 데이터가 다음 사용자에게 노출됨)
-    if ((window as unknown as Record<string, unknown>)[SKIP_PERSIST_FLAG]) {
+    const timestamp = localStorage.getItem(timestampKey)
+    const cacheAge = timestamp ? Date.now() - parseInt(timestamp) : Infinity
+
+    let map: Map<string, unknown>
+    if (cacheAge < TTL_MS) {
       try {
-        localStorage.removeItem(CACHE_KEY)
-        localStorage.removeItem(TIMESTAMP_KEY)
+        const cached = localStorage.getItem(cacheKey)
+        map = new Map(cached ? JSON.parse(cached) : [])
       } catch {
-        // ignore
+        map = new Map()
       }
-      return
+    } else {
+      map = new Map()
+      localStorage.removeItem(cacheKey)
+      localStorage.removeItem(timestampKey)
     }
-    try {
-      localStorage.setItem(CACHE_KEY, JSON.stringify(Array.from(map.entries())))
-      localStorage.setItem(TIMESTAMP_KEY, Date.now().toString())
-    } catch {
-      // storage unavailable
-    }
-  })
 
-  return map
+    window.addEventListener('beforeunload', () => {
+      // clearAppCache() 가 로그인/로그아웃 직전에 이 플래그를 세우면 write 건너뜀.
+      // (그러지 않으면 in-memory map 이 다시 localStorage 로 흘러나가 이전 사용자의
+      // 데이터가 다음 사용자에게 노출됨)
+      if ((window as unknown as Record<string, unknown>)[SKIP_PERSIST_FLAG]) {
+        try {
+          localStorage.removeItem(cacheKey)
+          localStorage.removeItem(timestampKey)
+        } catch {
+          // ignore
+        }
+        return
+      }
+      try {
+        localStorage.setItem(cacheKey, JSON.stringify(Array.from(map.entries())))
+        localStorage.setItem(timestampKey, Date.now().toString())
+      } catch {
+        // storage unavailable
+      }
+    })
+
+    return map
+  }
 }
 
-export function SWRProvider({ children }: { children: ReactNode }) {
+export function SWRProvider({
+  children,
+  userId,
+}: {
+  children: ReactNode
+  userId: string | null
+}) {
   return (
     <SWRConfig
       value={{
-        provider: localStorageProvider,
+        // key 에 userId 를 박아 같은 SWRConfig 인스턴스가 사용자 전환 시 새 캐시 슬롯을 쓰게 한다.
+        // (SWRConfig 가 리마운트되면 provider 함수가 다시 호출됨)
+        provider: makeLocalStorageProvider(userId),
         revalidateOnFocus: true,
         focusThrottleInterval: 30_000,
         revalidateOnReconnect: true,

--- a/lib/supabase-browser.ts
+++ b/lib/supabase-browser.ts
@@ -1,0 +1,26 @@
+'use client'
+
+import { createBrowserClient } from '@supabase/ssr'
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+
+let cached: ReturnType<typeof createBrowserClient> | null = null
+
+/**
+ * 브라우저(클라이언트 컴포넌트) 전용 Supabase 클라이언트.
+ * - 같은 탭 안에서 한 번만 만들고 재사용 — onAuthStateChange 리스너 중복 방지.
+ * - 서버에서 호출되면 에러 (assert).
+ */
+export function getBrowserSupabase() {
+  if (typeof window === 'undefined') {
+    throw new Error('getBrowserSupabase() must only be called in the browser')
+  }
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY 가 설정되지 않았습니다.')
+  }
+  if (!cached) {
+    cached = createBrowserClient(SUPABASE_URL, SUPABASE_ANON_KEY)
+  }
+  return cached
+}


### PR DESCRIPTION
## Summary

멀티계정·멀티여행 백본이 들어온 뒤 데이터 페칭/캐시 레이어가 user-scope 가 아닌 채로 남아있어 발생한 두 가지 보고 증상 + 잠재 위생 이슈를 한 묶음으로 정비했다.

- **신규 trip 생성 → 대시보드 복귀 시 0.3–0.5s 후 “팝업”되며 보임** — `NewTripWizard` 가 POST 성공 후 `mutate('/api/trips')` 를 안 했고, `DashboardClient` 는 `revalidateOnFocus: false` 였음.
- **SWR localStorage 캐시가 모든 사용자가 공유하는 전역 키 (`trip-planner-swr-cache`)** — 명시적 로그아웃 동선만 보호되고, 탭 종료/세션 만료/다중 탭 경로에서 계정 전환 시 이전 사용자의 trips·items 가 첫 페인트에 노출 가능.
- **trip 진입 권한 오류 — 원인 진단 불가능** — `app/trip/[tripId]/layout.tsx` 가 `error || !data` 를 통째로 `forbidden` 화면으로 묶어 supabase error 객체를 로깅조차 안 함. 가설 3개(currency 컬럼 누락 / RLS race / 세션 쿠키 race) 중 어느 것인지 분간 불가.

## 변경

### P1 — Trip 생성/수정/삭제 후 SWR 캐시 mutate 보장
- `app/dashboard/new/NewTripWizard.tsx`: POST 성공 후 `globalMutate('/api/trips')` → 신규 trip 이 대시보드에 즉시 반영
- `app/dashboard/DashboardClient.tsx`: `revalidateOnFocus: false` 제거 (SWRProvider 기본값 사용) + 삭제 후 `mutateTrips()` 명시 호출
- `components/Trip/TripSettingsSheet.tsx`, `components/Trip/EditableTripTitle.tsx`: PATCH/DELETE 후 동일하게 mutate 호출

### P3 — SWR localStorage 캐시 user-scope 격리
- `lib/clearAppCache.ts`: 캐시 키를 `trip-planner-swr-cache:<userId>` 로 분리, legacy 전역 키 + 타 user 키 청소 헬퍼 추가
- `lib/providers/SWRProvider.tsx`: `userId` prop 으로 캐시 키 스코프; 마운트 시 `pruneOtherUserSwrCaches`
- `app/layout.tsx`: root server component 에서 `auth.getUser()` 1회로 user id 를 읽어 `Providers` 로 prop 전달
- `app/providers.tsx`: `SWRProvider` 에 `userId` 전달 + `key={userId}` 로 사용자 전환 시 리마운트

### P2 — onAuthStateChange 글로벌 동기화
- `lib/supabase-browser.ts` (신규): 캐시된 브라우저 Supabase 클라이언트
- `components/Auth/AuthStateSync.tsx` (신규): `SIGNED_OUT` 또는 사용자 변경 감지 시 `clearAppCache()` + 전체 SWR 키 invalidate + `router.refresh()`. 같은 user 의 `TOKEN_REFRESHED` 등 정상 이벤트엔 반응 안 함
- `app/providers.tsx`: `<AuthStateSync />` 마운트

### P4 — 권한 오류 진단 로깅 (진단만, fix 는 후속 PR)
- `app/trip/[tripId]/layout.tsx`: supabase error 객체(code/message/details/hint) 를 `console.error`. row 미발견은 `console.warn`. 운영에서 한 번 재현해 가설 확정 후 별도 PR 에서 진짜 fix.

## 후속 (별도 이슈/PR 분리)
- P4 진단 결과로 가설 확정 → `42703` (컬럼 없음) 이면 [supabase/migration_199_trips_currency.sql](supabase/migration_199_trips_currency.sql) 운영 DB 재적용
- P5: `create_trip_v2` 응답을 `{ id, role }` 로 확장해 클라이언트가 prefill — RLS/세션 race 가설 원인일 때만

## Test plan

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [ ] **R1 (목록 지연)**: 로그인 → 새 여행 만들기 → 대시보드 복귀 시 신규 trip 이 즉시 보이는지 (mutate 작동)
- [ ] **R1 보조**: trip 설정 시트에서 제목/기간 수정 → 대시보드에서 즉시 반영
- [ ] **R2 (멀티계정 격리)**: 계정 A 로그인 → 데이터 사용 → 로그아웃 없이 탭 닫기 → 같은 브라우저로 계정 B 로그인 → 대시보드 첫 페인트에 A 데이터 안 보이는지. DevTools localStorage 에 `trip-planner-swr-cache:<B-userId>` 만 있고 A 키는 정리됐는지
- [ ] **R2 보조**: 로그인/로그아웃 반복 → legacy 전역 키 `trip-planner-swr-cache` 가 다시 생성되지 않는지
- [ ] **R3 (권한 오류) 진단**: 신규 계정 가입 → 여행 생성 → 진입 시 권한 오류 재현되면 서버 콘솔 `[TripLayout] supabase trip lookup failed` 의 `code` 확인
- [ ] **회귀**: 기존 trip 진입 + 항목 CRUD 정상
- [ ] **회귀**: 모바일 Safari 에서 iOS 자동 줌/마법사 포커스 회귀 없음

## 기본기 게이트 (CLAUDE.md Basics-First Rule)

- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? — 변경 없음 (기존 EditableTripTitle 유지)
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — 변경 없음
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? — 변경 없음
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — 신규 trip 이 “즉시” 목록에 반영되는 약속이 이제 진짜 지켜짐
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — 캐시/리스너 레이어 변경이므로 동일하게 적용
