### PR TITLE
refactor(ui): #209 빈 상태 톤 통일 — 이모지 단독 제거

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from 'react'
 import useSWR from 'swr'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { LogOut, MapPin, MoreVertical, Plus, Search, Trash2, User } from 'lucide-react'
+import { Compass, LogOut, MapPin, MoreVertical, Plus, Search, SearchX, Trash2, User } from 'lucide-react'
 import ThemeToggle from '@/components/Theme/ThemeToggle'
 import { Input } from '@/components/UI/Input'
 import Button from '@/components/UI/Button'
@@ -196,6 +196,7 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
         {trips.length === 0 ? (
           <div className="py-12">
             <EmptyState
+              icon={<Compass className="size-10" aria-hidden="true" />}
               title="아직 여행이 없어요"
               description="첫 여행을 만들어 일정을 정리해 보세요."
               action={
@@ -211,6 +212,7 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
         ) : visibleTrips.length === 0 ? (
           <div className="py-12">
             <EmptyState
+              icon={<SearchX className="size-10" aria-hidden="true" />}
               title="검색 결과가 없어요"
               description="다른 키워드로 검색해 보세요."
             />

--- a/app/share/[token]/page.tsx
+++ b/app/share/[token]/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { ExternalLink, Compass } from 'lucide-react'
+import { ExternalLink, Compass, CalendarRange } from 'lucide-react'
 import { fetchSharedTrip, type SharedTripPayload } from '@/lib/sharedTrip'
 import SharedItemCard from '@/components/Share/SharedItemCard'
+import EmptyState from '@/components/UI/EmptyState'
 import type { TripItem } from '@/types'
 
 type Props = { params: { token: string } }
@@ -138,8 +139,11 @@ export default async function SharePage({ params }: Props) {
       </header>
 
       {items.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-border bg-bg-elevated p-8 text-center text-sm text-fg-subtle">
-          아직 추가된 일정이 없어요.
+        <div className="rounded-lg border border-dashed border-border bg-bg-elevated">
+          <EmptyState
+            icon={<CalendarRange className="size-10" aria-hidden="true" />}
+            title="아직 추가된 일정이 없어요"
+          />
         </div>
       ) : (
         <section className="space-y-6">

--- a/components/Research/ResearchTable.tsx
+++ b/components/Research/ResearchTable.tsx
@@ -1,8 +1,11 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { MapPin, Plus, SearchX } from 'lucide-react'
 import type { TripItem, TripPriority } from '@/types'
 import { compareReservationStatus, compareTripPriority } from '@/lib/itemOptions'
+import EmptyState from '@/components/UI/EmptyState'
+import Button from '@/components/UI/Button'
 import NameCell from '@/components/Schedule/cells/NameCell'
 import CategoryCell from '@/components/Schedule/cells/CategoryCell'
 import PriorityCell from '@/components/Schedule/cells/PriorityCell'
@@ -181,27 +184,25 @@ export default function ResearchTable({
 
   if (items.length === 0 && !addingRow) {
     return (
-      <div className="flex flex-col items-center justify-center py-20 text-center">
-        <div className="text-4xl mb-3">{hasActiveSearch ? '🔍' : '📍'}</div>
-        <p className="text-sm font-medium text-fg mb-1">
-          {hasActiveSearch ? '검색 결과가 없어요' : '아직 등록된 항목이 없어요'}
-        </p>
-        <p className="text-xs text-fg-subtle mb-4">
-          {hasActiveSearch ? '필터 조건을 바꿔보세요' : '항목을 추가하면 여기에 표시됩니다'}
-        </p>
-        {!hasActiveSearch && (
-          <button
-            type="button"
-            onClick={() => { setAddingRow(true); setNewItemName('') }}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-accent text-accent-fg px-4 py-2 text-sm font-medium hover:bg-accent-hover transition-colors"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
-            </svg>
-            새 항목 추가
-          </button>
-        )}
-      </div>
+      <EmptyState
+        icon={
+          hasActiveSearch ? (
+            <SearchX className="size-10" aria-hidden="true" />
+          ) : (
+            <MapPin className="size-10" aria-hidden="true" />
+          )
+        }
+        title={hasActiveSearch ? '검색 결과가 없어요' : '아직 등록된 항목이 없어요'}
+        description={hasActiveSearch ? '필터 조건을 바꿔보세요' : '항목을 추가하면 여기에 표시됩니다'}
+        action={
+          !hasActiveSearch ? (
+            <Button onClick={() => { setAddingRow(true); setNewItemName('') }}>
+              <Plus className="size-4 mr-1" aria-hidden="true" />
+              새 항목 추가
+            </Button>
+          ) : undefined
+        }
+      />
     )
   }
 

--- a/components/Schedule/ScheduleTable.tsx
+++ b/components/Schedule/ScheduleTable.tsx
@@ -11,7 +11,11 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from '@dnd-kit/core'
+import { CalendarRange, Plus } from 'lucide-react'
 import type { ReservationStatus, TripItem } from '@/types'
+import EmptyState from '@/components/UI/EmptyState'
+import Button from '@/components/UI/Button'
+import Link from 'next/link'
 import { CATEGORY_META, RESERVATION_STATUS_META } from '@/lib/itemOptions'
 import { haversineKm } from '@/lib/distance'
 import { getLodgingForDate, isLodgingMidStay } from '@/lib/lodging'
@@ -533,22 +537,21 @@ export default function ScheduleTable({
 
   if (items.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-20 text-center">
-        <div className="text-4xl mb-3">🗓️</div>
-        <p className="text-sm font-medium text-fg mb-1">아직 등록된 항목이 없어요</p>
-        <p className="text-xs text-fg-subtle mb-4">장소를 추가하면 여기에 날짜별로 표시됩니다</p>
-        {tripId && (
-          <a
-            href={`/trip/${tripId}/items/new`}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-accent text-accent-fg px-4 py-2 text-sm font-medium hover:bg-accent-hover transition-colors"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
-            </svg>
-            새 항목 추가
-          </a>
-        )}
-      </div>
+      <EmptyState
+        icon={<CalendarRange className="size-10" aria-hidden="true" />}
+        title="아직 등록된 항목이 없어요"
+        description="장소를 추가하면 여기에 날짜별로 표시됩니다"
+        action={
+          tripId ? (
+            <Link href={`/trip/${tripId}/items/new`}>
+              <Button>
+                <Plus className="size-4 mr-1" aria-hidden="true" />
+                새 항목 추가
+              </Button>
+            </Link>
+          ) : undefined
+        }
+      />
     )
   }
 

--- a/components/Share/ShareDialog.tsx
+++ b/components/Share/ShareDialog.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Copy, Plus, Trash2, Check, AlertCircle } from 'lucide-react'
+import { Copy, Plus, Trash2, Check, AlertCircle, Link2Off } from 'lucide-react'
 import Sheet from '@/components/UI/Sheet'
 import Button from '@/components/UI/Button'
+import EmptyState from '@/components/UI/EmptyState'
 import { useToast } from '@/components/UI/Toast'
 import { useConfirm } from '@/components/UI/ConfirmDialog'
 import type { Share } from '@/lib/share'
@@ -130,7 +131,12 @@ export default function ShareDialog({ open, onClose, tripId }: Props) {
           {loading && !shares ? (
             <p className="text-sm text-fg-subtle">불러오는 중…</p>
           ) : activeShares.length === 0 ? (
-            <p className="text-sm text-fg-subtle">아직 발급된 활성 링크가 없어요.</p>
+            <EmptyState
+              size="inline"
+              icon={<Link2Off className="size-7" aria-hidden="true" />}
+              title="활성 링크가 없어요"
+              description="새 공유 링크를 만들어 일행에게 보내세요."
+            />
           ) : (
             <ul className="space-y-2">
               {activeShares.map((s) => {

--- a/specs/209-empty-state/spec.md
+++ b/specs/209-empty-state/spec.md
@@ -1,0 +1,21 @@
+# 209-empty-state — 빈 상태 톤 통일
+
+GitHub: #209 (부모 #205)
+
+## 문제
+
+빈 상태가 두 패턴으로 분기:
+- A) `<EmptyState icon={<Lucide />}>` — DashboardClient(icon 누락), ItemList, MapSidePanel
+- B) 인라인 `text-4xl` 이모지 (📍 🔍 🗓️) + 직접 마크업 — ResearchTable, ScheduleTable, ShareDialog, share/[token]/page
+
+## 완료 조건
+
+- 모든 빈 상태가 `EmptyState` 컴포넌트 사용
+- 이모지 단독 0건
+- icon = lucide, color = `text-fg-subtle` (neutral)
+- 빌드·lint 통과
+
+## 범위 밖
+
+- TripPriority / Reservation 의 이모지 (별도 라운드)
+- `#210` 디자인 가이드 보강


### PR DESCRIPTION
## 관련 이슈

Closes #209 (부모 #205)

## 변경 이유

빈 상태가 두 패턴으로 분기되어 있었음:
- A) `EmptyState` 컴포넌트 + lucide (DashboardClient·ItemList·MapSidePanel)
- B) 인라인 `text-4xl` 이모지(📍🔍🗓️) + 직접 마크업 (ResearchTable·ScheduleTable·ShareDialog·share/[token])

#207/#208 의 시각 통일 흐름 마무리.

## 변경 범위

- `components/Research/ResearchTable.tsx` — 인라인 이모지 빈 상태 → `EmptyState` (MapPin/SearchX)
- `components/Schedule/ScheduleTable.tsx` — 동일 패턴 → `EmptyState` (CalendarRange)
- `app/dashboard/DashboardClient.tsx` — 기존 EmptyState 두 곳에 icon 추가 (Compass / SearchX)
- `components/Share/ShareDialog.tsx` — 활성 링크 빈 상태 → `EmptyState` (Link2Off)
- `app/share/[token]/page.tsx` — 빈 일정 → `EmptyState` (CalendarRange)

## 검증

- [x] `npm run build` 성공
- [x] `npm run lint` 0
- [x] `grep '🗓️\|📍\|🔍\|text-4xl mb-3'` 결과 0

## 남은 작업 / 리스크

- `TRIP_PRIORITY_META.emoji` · `RESERVATION_STATUS_META.emoji` 의 lucide 화 — 별도 라운드
- #210 디자인 가이드에서 EmptyState 사용 규약 명시 예정

---

- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? — TripPageHeader 영향 없음
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — N/A
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? — N/A
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — N/A
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — EmptyState 공용