### PR TITLE
fix(map): 지도 상단 오버레이 충돌 해소 — 중심점 배너 하단 이동

### DIFF
--- a/components/Map/ManualCenterControl.tsx
+++ b/components/Map/ManualCenterControl.tsx
@@ -92,7 +92,7 @@ export default function ManualCenterBanner({ map, items, basecampCoord, region }
   }
 
   return (
-    <div className="pointer-events-none absolute top-3 left-1/2 z-[600] -translate-x-1/2">
+    <div className="pointer-events-none absolute bottom-3 left-1/2 z-[600] -translate-x-1/2">
       {manualActive ? (
         <div className="pointer-events-auto flex items-center gap-2 rounded-full bg-bg-elevated/95 px-3 py-1.5 text-xs shadow-md backdrop-blur">
           <span className="inline-flex items-center gap-1 font-medium text-fg">


### PR DESCRIPTION
## Summary

지도 뷰 상단 오버레이 3개가 같은 `top-3` 라인에 쌓여 좁은 뷰포트에서 겹치는 문제를 해소.

- `top-3 left-3` (max-w-[60%]) — `TripContextLabel` chip
- `top-3 left-1/2` — `ManualCenterBanner` (수동 중심점 배너)
- `top-3 right-3` — "+ 새 항목" / `ThemeToggle`

수동 중심 모드일 때 배너 텍스트("직접 지정한 중심점 사용 중 · 자동으로 되돌리기")가 길어 chip 과 가운데에서 충돌, 텍스트가 두 줄로 깨졌음.

배너를 `bottom-3 left-1/2` 로 이동해 표준 지도 UI 컨벤션(보조 컨트롤은 하단)을 따르고, 상단 라인은 chip + 우측 액션만 유지. FAB(우측 고정)와 좌-중-우로 분리되어 추가 충돌 없음.

## Test plan

- [ ] 데스크탑 `/trip/[id]/map` — 수동 중심 모드 진입 후 배너가 하단 중앙에 표시, 상단 chip 과 겹치지 않음
- [ ] 모바일 `/trip/[id]/map` — 배너가 바텀 드로어 핸들 바로 위에 표시, FAB(우하단)와 겹치지 않음
- [ ] 미수동 모드 ("여기를 중심으로" pill) 도 하단 중앙에 정상 표시
- [ ] viewer 권한 / `useOptionalTrip` 없는 컨텍스트에서 배너 미렌더(기존 동작 유지)

## Checklist (Basics-First)

- [x] 이 페이지에 "지금 보고 있는 여행 이름"이 보이는가? (상단 chip 그대로 유지)
- [x] CRUD 대칭? (UI 전용 위치 수정, API 영향 없음)
- [x] 모달·시트 사이징? (해당 없음)
- [x] 카피 약속 일치? (배너 카피 변경 없음)
- [x] 모바일·데스크탑 동등? (양쪽 모두 하단 중앙)
