### PR TITLE
feat(map): 중심점 UX 개선 — 생성 미니맵 picker + 지도 오버플로 메뉴

### DIFF
--- a/app/dashboard/new/NewTripWizard.tsx
+++ b/app/dashboard/new/NewTripWizard.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from 'react'
 import Link from 'next/link'
+import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
 import { mutate as globalMutate } from 'swr'
 import { ArrowLeft, Check } from 'lucide-react'
@@ -12,6 +13,14 @@ import { cn } from '@/lib/cn'
 import { SUPPORTED_CURRENCIES, type CurrencyCode } from '@/lib/currency'
 import { useIsTouchDevice } from '@/lib/hooks/useIsTouchDevice'
 import { resolveRegionCenter, resolutionToCenter } from '@/lib/resolveRegionCenter'
+import type { CenterValue } from '@/components/Map/CenterPicker'
+
+const CenterPicker = dynamic(() => import('@/components/Map/CenterPicker'), {
+  ssr: false,
+  loading: () => (
+    <div className="h-44 animate-pulse rounded-lg border border-border bg-bg-subtle" />
+  ),
+})
 
 type Step = 1 | 2 | 3 | 4 | 5
 
@@ -31,6 +40,7 @@ export default function NewTripWizard() {
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
   const [region, setRegion] = useState('')
+  const [center, setCenter] = useState<CenterValue | null>(null)
   const [basecamp, setBasecamp] = useState('')
   const [basecampSkipped, setBasecampSkipped] = useState(false)
   const [currency, setCurrency] = useState<CurrencyCode>('KRW')
@@ -85,24 +95,27 @@ export default function NewTripWizard() {
         throw new Error(data?.error ?? '여행 생성에 실패했습니다.')
       }
       const data = (await res.json()) as { tripId: string }
-      // region 좌표를 생성 시점에 1회 확보해 trip 에 저장(US2). 이후 지도 로드는 외부 호출 0회.
-      // preset 매칭은 즉시, 미수록 도시는 지오코딩 1회. 실패 시 좌표는 비운 채 둔다(지도 로드 시 preset/폴백).
+      // 지도 중심 좌표를 생성 시점에 저장(US2). 이후 지도 로드는 외부 호출 0회.
+      // 미리보기(CenterPicker)에서 확보한 좌표를 우선 쓰고, 디바운스 레이스로 비어 있으면
+      // region 으로 1회 재확보한다. 실패 시 좌표는 비운 채 둔다(지도 로드 시 preset/폴백).
+      let resolved: { lat: number; lng: number; zoom: number; source: 'auto' | 'manual' } | null =
+        center
       const trimmedRegion = region.trim()
-      if (trimmedRegion) {
-        const resolution = await resolveRegionCenter(trimmedRegion)
-        const center = resolutionToCenter(resolution)
-        if (center) {
-          await fetch(`/api/trips/${data.tripId}`, {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              center_lat: center.lat,
-              center_lng: center.lng,
-              default_zoom: center.zoom,
-              center_source: 'auto',
-            }),
-          }).catch(() => {})
-        }
+      if (!resolved && trimmedRegion) {
+        const c = resolutionToCenter(await resolveRegionCenter(trimmedRegion))
+        if (c) resolved = { ...c, source: 'auto' }
+      }
+      if (resolved) {
+        await fetch(`/api/trips/${data.tripId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            center_lat: resolved.lat,
+            center_lng: resolved.lng,
+            default_zoom: resolved.zoom,
+            center_source: resolved.source,
+          }),
+        }).catch(() => {})
       }
       // 대시보드 SWR 캐시를 즉시 갱신해 두면, 사용자가 뒤로가서 목록으로 돌아왔을 때
       // 새 trip 이 0.3-0.5s 후 "팝업" 되는 대신 처음부터 보인다.
@@ -177,7 +190,7 @@ export default function NewTripWizard() {
             />
           )}
           {step === 3 && (
-            <Step3 region={region} setRegion={setRegion} />
+            <Step3 region={region} setRegion={setRegion} center={center} setCenter={setCenter} />
           )}
           {step === 4 && (
             <Step4
@@ -195,6 +208,7 @@ export default function NewTripWizard() {
           {step === 5 && (
             <Step5
               summary={{ title, startDate, endDate, region, basecamp, currency }}
+              centerManual={center?.source === 'manual'}
               basecampSkipped={basecampSkipped && !basecamp.trim()}
               onEdit={jumpToStep}
             />
@@ -289,9 +303,13 @@ function Step2({
 function Step3({
   region,
   setRegion,
+  center,
+  setCenter,
 }: {
   region: string
   setRegion: (v: string) => void
+  center: CenterValue | null
+  setCenter: (v: CenterValue | null) => void
 }) {
   const isTouch = useIsTouchDevice()
   return (
@@ -304,6 +322,7 @@ function Step3({
         autoFocus={!isTouch}
       />
       <p className="text-xs text-fg-subtle">국가·도시·테마 등 자유롭게.</p>
+      <CenterPicker region={region} value={center} onChange={setCenter} />
     </div>
   )
 }
@@ -373,10 +392,12 @@ function Step4({
 
 function Step5({
   summary,
+  centerManual,
   basecampSkipped,
   onEdit,
 }: {
   summary: { title: string; startDate: string; endDate: string; region: string; basecamp: string; currency: CurrencyCode }
+  centerManual: boolean
   basecampSkipped: boolean
   onEdit: (step: Step) => void
 }) {
@@ -403,7 +424,9 @@ function Step5({
         />
         <SummaryEditRow
           label="지역"
-          value={summary.region || '미설정'}
+          value={
+            (summary.region || '미설정') + (centerManual ? ' · 중심 직접 지정' : '')
+          }
           onEdit={() => onEdit(3)}
         />
         <SummaryEditRow

--- a/components/Map/CenterPicker.tsx
+++ b/components/Map/CenterPicker.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { MapContainer, TileLayer, Marker, useMap, useMapEvents } from 'react-leaflet'
+import L from 'leaflet'
+import { MapPin } from 'lucide-react'
+import {
+  resolveRegionCenter,
+  resolutionToCenter,
+  type RegionResolution,
+} from '@/lib/resolveRegionCenter'
+
+export interface CenterValue {
+  lat: number
+  lng: number
+  zoom: number
+  source: 'auto' | 'manual'
+}
+
+interface CenterPickerProps {
+  region: string
+  value: CenterValue | null
+  onChange: (v: CenterValue | null) => void
+}
+
+const pinIcon = L.divIcon({
+  html: `<div class="tp-basecamp-marker">📍</div>`,
+  className: '',
+  iconSize: [32, 32],
+  iconAnchor: [16, 30],
+})
+
+const WORLD_CENTER: [number, number] = [20, 0]
+
+/** 자동 해석 결과를 지도에 반영(수동 핀 조정 중에는 재중심 안 함). */
+function ApplyAutoView({ value }: { value: CenterValue | null }) {
+  const map = useMap()
+  const lastKey = useRef('')
+  useEffect(() => {
+    if (!value || value.source !== 'auto') return
+    const key = `${value.lat.toFixed(4)},${value.lng.toFixed(4)},${value.zoom}`
+    if (key === lastKey.current) return
+    lastKey.current = key
+    map.setView([value.lat, value.lng], value.zoom, { animate: false })
+  }, [value, map])
+  return null
+}
+
+/** 마운트 직후 컨테이너 크기 보정 + 지도 클릭 = 수동 지정. */
+function MapBehaviors({
+  onReady,
+  onPick,
+}: {
+  onReady: (m: L.Map) => void
+  onPick: (lat: number, lng: number) => void
+}) {
+  const map = useMapEvents({
+    click(e) {
+      onPick(e.latlng.lat, e.latlng.lng)
+    },
+  })
+  useEffect(() => {
+    onReady(map)
+    const t = setTimeout(() => map.invalidateSize(), 0)
+    return () => clearTimeout(t)
+  }, [map, onReady])
+  return null
+}
+
+/**
+ * region 텍스트의 지도 중심 미니맵. 자동 해석 핀을 보여주고, 핀 드래그/지도 클릭으로
+ * 직접 조정(manual)할 수 있다. 생성 마법사·설정에서 공통 사용한다.
+ */
+export default function CenterPicker({ region, value, onChange }: CenterPickerProps) {
+  const [resolution, setResolution] = useState<RegionResolution | null>(null)
+  const [resolving, setResolving] = useState(false)
+  const mapRef = useRef<L.Map | null>(null)
+
+  // onChange 정체성이 매 렌더 바뀌어도 effect 가 재실행되지 않도록 ref 로 고정.
+  const onChangeRef = useRef(onChange)
+  onChangeRef.current = onChange
+
+  // region 변경 시 디바운스 후 자동 해석. 수동 핀은 region 이 다시 바뀌면 자동으로 덮인다.
+  useEffect(() => {
+    const trimmed = region.trim()
+    if (!trimmed) {
+      setResolution(null)
+      onChangeRef.current(null)
+      return
+    }
+    let cancelled = false
+    setResolving(true)
+    const t = setTimeout(async () => {
+      const res = await resolveRegionCenter(trimmed)
+      if (cancelled) return
+      setResolution(res)
+      setResolving(false)
+      const c = resolutionToCenter(res)
+      if (c) onChangeRef.current({ lat: c.lat, lng: c.lng, zoom: c.zoom, source: 'auto' })
+    }, 500)
+    return () => {
+      cancelled = true
+      clearTimeout(t)
+    }
+  }, [region])
+
+  function pickManual(lat: number, lng: number) {
+    const zoom = mapRef.current?.getZoom() ?? value?.zoom ?? 11
+    onChangeRef.current({ lat, lng, zoom, source: 'manual' })
+  }
+
+  const manual = value?.source === 'manual'
+
+  return (
+    <div className="space-y-1.5">
+      <div className="h-44 overflow-hidden rounded-lg border border-border">
+        <MapContainer
+          center={value ? [value.lat, value.lng] : WORLD_CENTER}
+          zoom={value?.zoom ?? 2}
+          zoomControl={false}
+          attributionControl={false}
+          style={{ height: '100%', width: '100%' }}
+          className="touch-none"
+        >
+          <TileLayer url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png" />
+          <ApplyAutoView value={value} />
+          <MapBehaviors
+            onReady={(m) => {
+              mapRef.current = m
+            }}
+            onPick={pickManual}
+          />
+          {value && (
+            <Marker
+              position={[value.lat, value.lng]}
+              icon={pinIcon}
+              draggable
+              eventHandlers={{
+                dragend(e) {
+                  const ll = (e.target as L.Marker).getLatLng()
+                  pickManual(ll.lat, ll.lng)
+                },
+              }}
+            />
+          )}
+        </MapContainer>
+      </div>
+      <CenterPickerHint manual={manual} resolving={resolving} resolution={resolution} region={region} />
+    </div>
+  )
+}
+
+function CenterPickerHint({
+  manual,
+  resolving,
+  resolution,
+  region,
+}: {
+  manual: boolean
+  resolving: boolean
+  resolution: RegionResolution | null
+  region: string
+}) {
+  if (manual) {
+    return (
+      <p className="flex items-center gap-1 text-xs text-accent">
+        <MapPin className="size-3" aria-hidden />
+        직접 지정한 위치 · 핀을 끌어 조정
+      </p>
+    )
+  }
+  if (resolving) return <p className="text-xs text-fg-subtle">위치 확인 중…</p>
+  if (!resolution || !region.trim()) {
+    return <p className="text-xs text-fg-subtle">지역을 입력하면 중심점을 표시해요. 핀을 끌거나 지도를 눌러 직접 정할 수도 있어요.</p>
+  }
+  if (resolution.status === 'preset') {
+    return (
+      <p className="flex items-center gap-1 text-xs text-accent">
+        <MapPin className="size-3" aria-hidden />
+        {resolution.name}로 인식됨 · 핀을 끌어 조정
+      </p>
+    )
+  }
+  if (resolution.status === 'geocoded') {
+    return (
+      <p className="flex items-center gap-1 text-xs text-accent">
+        <MapPin className="size-3" aria-hidden />
+        좌표 확보 · 핀을 끌어 조정
+      </p>
+    )
+  }
+  if (resolution.status === 'notfound') {
+    return (
+      <p className="text-xs text-critical-fg">
+        「{region.trim()}」 위치를 찾지 못했어요. 지도를 눌러 직접 지정하세요.
+      </p>
+    )
+  }
+  return (
+    <p className="text-xs text-critical-fg">
+      위치 검색이 일시적으로 실패했어요. 지도를 눌러 직접 지정하세요.
+    </p>
+  )
+}

--- a/components/Map/ManualCenterControl.tsx
+++ b/components/Map/ManualCenterControl.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useMap } from 'react-leaflet'
 import { useRouter } from 'next/navigation'
 import { mutate as globalMutate } from 'swr'
@@ -28,7 +28,9 @@ interface BannerProps {
 }
 
 /**
- * 명시 좌표 상태 배너 + "여기를 중심으로"/"자동으로 되돌리기"(FR-027/028).
+ * 지도 중심점 오버플로 메뉴(FR-027/028).
+ * 상시 텍스트 배너 대신 디스크릿 아이콘 버튼 + 팝오버로 지도뷰 chrome 을 최소화한다.
+ * manual 상태일 때만 버튼에 점 배지로 상태를 노출한다.
  * MapContainer 형제로 배치하는 오버레이라 leaflet 인스턴스를 prop 으로 받는다.
  */
 export default function ManualCenterBanner({ map, items, basecampCoord, region }: BannerProps) {
@@ -36,6 +38,24 @@ export default function ManualCenterBanner({ map, items, basecampCoord, region }
   const router = useRouter()
   const { showToast } = useToast()
   const [busy, setBusy] = useState(false)
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function onDown(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    function onEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onEsc)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onEsc)
+    }
+  }, [open])
 
   if (!trip || trip.role === 'viewer' || !map) return null
 
@@ -75,6 +95,7 @@ export default function ManualCenterBanner({ map, items, basecampCoord, region }
       default_zoom: Math.round(map.getZoom()),
       center_source: 'manual',
     })
+    setOpen(false)
     if (ok) showToast({ message: '현재 화면을 중심점으로 고정했어요.', type: 'success' })
   }
 
@@ -85,6 +106,7 @@ export default function ManualCenterBanner({ map, items, basecampCoord, region }
       default_zoom: null,
       center_source: null,
     })
+    setOpen(false)
     if (ok && map) {
       applyAutoView(map, { items, basecampCoord, region })
       showToast({ message: '자동 중심으로 되돌렸어요.', type: 'success' })
@@ -92,37 +114,47 @@ export default function ManualCenterBanner({ map, items, basecampCoord, region }
   }
 
   return (
-    <div className="pointer-events-none absolute bottom-3 left-1/2 z-[600] -translate-x-1/2">
-      {manualActive ? (
-        <div className="pointer-events-auto flex items-center gap-2 rounded-full bg-bg-elevated/95 px-3 py-1.5 text-xs shadow-md backdrop-blur">
-          <span className="inline-flex items-center gap-1 font-medium text-fg">
-            <MapPin className="size-3.5 text-accent" aria-hidden />
-            직접 지정한 중심점 사용 중
-          </span>
-          <span className="text-fg-subtle" aria-hidden>
-            ·
-          </span>
+    <div ref={ref} className="absolute bottom-3 left-3 z-[600]">
+      {open && (
+        <div className="absolute bottom-full mb-2 left-0 w-44 rounded-lg border border-border bg-bg-elevated p-1 shadow-lg">
+          <p className="px-2 py-1 text-[11px] font-medium text-fg-subtle">지도 중심점</p>
           <button
             type="button"
-            onClick={revertAuto}
+            onClick={pinHere}
             disabled={busy}
-            className="inline-flex items-center gap-1 font-medium text-accent hover:underline disabled:opacity-50"
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-fg hover:bg-bg-subtle disabled:opacity-50"
           >
-            <RotateCcw className="size-3.5" aria-hidden />
-            자동으로 되돌리기
+            <MapPin className="size-3.5 text-accent" aria-hidden />
+            여기를 중심으로
           </button>
+          {manualActive && (
+            <button
+              type="button"
+              onClick={revertAuto}
+              disabled={busy}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-fg hover:bg-bg-subtle disabled:opacity-50"
+            >
+              <RotateCcw className="size-3.5" aria-hidden />
+              자동으로 되돌리기
+            </button>
+          )}
+          {manualActive && (
+            <p className="px-2 pt-1 text-[11px] text-fg-subtle">직접 지정한 중심점 사용 중</p>
+          )}
         </div>
-      ) : (
-        <button
-          type="button"
-          onClick={pinHere}
-          disabled={busy}
-          className="pointer-events-auto inline-flex items-center gap-1.5 rounded-full bg-bg-elevated/95 px-3 py-1.5 text-xs font-medium text-fg shadow-md backdrop-blur hover:text-accent disabled:opacity-50"
-        >
-          <MapPin className="size-3.5" aria-hidden />
-          여기를 중심으로
-        </button>
       )}
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-label="지도 중심점 설정"
+        aria-expanded={open}
+        className="relative inline-flex size-9 items-center justify-center rounded-full bg-bg-elevated/95 text-fg shadow-md backdrop-blur hover:text-accent"
+      >
+        <MapPin className="size-4" aria-hidden />
+        {manualActive && (
+          <span className="absolute right-1 top-1 size-2 rounded-full bg-accent ring-2 ring-bg-elevated" />
+        )}
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## 원본 요구사항

병합된 #221(trip 중심점) 실사용 피드백 2건:
> - 중심점 설정을 한두 번 하면 안 바꿀 텐데 지도뷰에서 항상 표시됨
> - 여행 최초 생성 시점에 어디가 중심점이 될지 명시적으로 보거나 수정할 수 없음

## 변경 이유

- 명시 좌표 상태 배너가 지도 상단을 상시 점유 → 한번 설정 후 노이즈.
- 생성 마법사는 region 텍스트만 받고 좌표는 뒤에서 자동 PATCH → 유저가 중심점을 보거나 조정할 수 없었다(명시성 부족).

## 변경 범위

- **CenterPicker 미니맵**(`components/Map/CenterPicker.tsx`, 신규): 마법사 지역 스텝에 삽입. region 입력을 디바운스 해석해 인식 핀을 즉시 표시. 핀 드래그 또는 지도 클릭으로 중심점 직접 지정(`center_source='manual'`). 인식 칩("도쿄로 인식됨")·실패 메시지 노출. 생성 전 명시 확인·수정 가능.
- **마법사 배선**(`NewTripWizard.tsx`): `center` 상태 추가, 확인 스텝 요약에 "중심 직접 지정" 표기. 제출 시 picker 좌표 우선 사용(디바운스 레이스 시 region 으로 1회 재확보 폴백).
- **지도 오버플로 메뉴**(`ManualCenterControl.tsx`): 상시 텍스트 배너 제거 → 좌하단 디스크릿 아이콘 버튼 + 팝오버 메뉴(여기를 중심으로 / 자동으로 되돌리기)로 전환. manual 상태는 버튼 점 배지로만 노출. 클릭아웃/Esc 닫기.

## 검증

- `npm run build` 통과(타입체크 포함).
- `npm run lint` — 변경 파일 0 errors. 기존 `services/gmaps/resolver.ts` 2 errors 는 무관한 선행 이슈.
- 데이터 모델·API·마이그레이션 변경 없음(기존 center_* 컬럼 재사용).

## 남은 작업 / 리스크

- 설정시트(TripSettingsSheet)는 기존 inline region 피드백 칩 유지 — CenterPicker 미적용. 추후 일원화 가능.
- US8(viewport 밖 핀 인디케이터)는 여전히 미구현(별도 이슈).

## Basics-First 체크

- [x] "지금 보고 있는 여행 이름" 표시 유지(TripContextLabel).
- [x] 중심점 C/R/U/D — 생성(picker)·수정/되돌리기(지도 메뉴)·비우기 모두 UI 로 가능.
- [x] 모달·시트 콘텐츠 적응형 유지.
- [x] 카피 약속 동작 실제 구현(핀 드래그/지도 클릭/여기를 중심으로/되돌리기).
- [x] 모바일·데스크탑 동등 — picker·메뉴 공통 컴포넌트.
