### PR TITLE
fix(wizard): #226 '나중에 정하기' 가 통화 입력 스킵하는 버그

### DIFF
--- a/app/dashboard/new/NewTripWizard.tsx
+++ b/app/dashboard/new/NewTripWizard.tsx
@@ -65,9 +65,11 @@ export default function NewTripWizard() {
   }
 
   function skipBasecamp() {
+    // 베이스캠프 입력만 비우는 액션이다. 스텝을 넘기지 않는다.
+    // 같은 step 의 통화 등 다른 필드 입력을 보존해야 함 (#226).
+    // 사용자는 통화 등 나머지 필드를 마저 채우고 "다음" 으로 step 5 에 진입한다.
     setBasecamp('')
     setBasecampSkipped(true)
-    if (step === 4) setStep(5)
   }
 
   function jumpToStep(target: Step) {


### PR DESCRIPTION
## 관련 이슈

Closes #226

## 변경 이유

새 여행 마법사 ‟베이스캠프" 스텝의 ‟나중에 정하기" 버튼이 곧바로 마지막 ‟확인" 스텝으로 점프시켰다. 같은 스텝 하단의 **통화 입력** 등 다른 필드를 채울 기회가 사라졌다. 카피("이 베이스캠프 필드만 비워두기" 처럼 들림)와 동작("스텝 전체 스킵") 이 어긋나는 basics-first 게이트 ‟카피 정직성" 위반.

## 변경 범위

- `app/dashboard/new/NewTripWizard.tsx`
  - `skipBasecamp()` 에서 `setStep(5)` 제거
  - 베이스캠프 입력만 비우는 액션이 되도록 의미 축소
  - `basecampSkipped` 플래그는 그대로 유지 (Step5 요약에서 ‟나중에 정하기" 표기 용도)
- 사용자는 통화 등 나머지 필드를 마저 채우고 ‟다음" 버튼으로 step 5 에 진입한다.

## 검증

- `npx tsc --noEmit` 통과
- ESLint: 본 PR 변경 파일에 새 에러 없음 (저장소에 preexisting `resolver.ts` 에러만 잔존, main 과 동일)
- 수동 동선 시나리오:
  1. 새 여행 만들기 → step 4 진입
  2. ‟나중에 정하기" 클릭
  3. 통화 select 가 사라지지 않고 그대로 노출됨을 확인
  4. 통화 변경 후 ‟다음" → step 5 요약에서 베이스캠프 ‟나중에 정하기" + 선택한 통화 모두 반영

## 남은 작업 / 리스크

없음. UI 동작 1줄 수정.

## 자가검열 (basics-first)

- [x] 이 페이지·기능에 ‟지금 보고 있는 여행 이름" 이 보이는가? — 마법사는 생성 전이라 N/A
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — N/A (마법사는 Create 전용)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? — 모달·시트 없음
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — ‟나중에 정하기" 카피가 실제 동작(필드만 비우기)과 일치하도록 정렬
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — 동일 컴포넌트
