### PR TITLE
feat(ux): #233 페이지 전환 즉시 피드백 (top progress + nav pending + skeleton)

### DIFF
--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from '@/components/UI/Skeleton'
+
+/**
+ * 대시보드 (여행 목록) SSR Supabase 조회까지의 skeleton (#233).
+ */
+export default function DashboardLoading() {
+  return (
+    <div className="min-h-screen bg-bg text-fg" aria-busy="true">
+      <header className="border-b border-border bg-bg-elevated">
+        <div className="max-w-5xl mx-auto px-4 md:px-8 py-4 flex items-center gap-3">
+          <Skeleton className="h-5 w-32 rounded" />
+          <div className="ml-auto flex items-center gap-2">
+            <Skeleton className="h-8 w-20 rounded-lg" />
+            <Skeleton className="h-8 w-24 rounded-lg" />
+          </div>
+        </div>
+      </header>
+      <main className="max-w-5xl mx-auto px-4 md:px-8 py-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-border bg-bg-elevated p-5 space-y-3"
+            >
+              <Skeleton className="h-5 w-3/4 rounded" />
+              <Skeleton className="h-3 w-1/2 rounded" />
+              <Skeleton className="h-3 w-2/3 rounded" />
+              <div className="flex gap-2 pt-2">
+                <Skeleton className="h-6 w-16 rounded-full" />
+                <Skeleton className="h-6 w-12 rounded-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,11 +1,13 @@
 'use client'
 
+import { Suspense } from 'react'
 import { SWRProvider } from '@/lib/providers/SWRProvider'
 import { ToastProvider } from '@/components/UI/Toast'
 import { ConfirmProvider } from '@/components/UI/ConfirmDialog'
 import { ThemeProvider } from '@/components/Theme/ThemeProvider'
 import OfflineBanner from '@/components/UI/OfflineBanner'
 import AuthStateSync from '@/components/Auth/AuthStateSync'
+import TopProgressBar from '@/components/Layout/TopProgressBar'
 
 export default function Providers({
   children,
@@ -22,6 +24,11 @@ export default function Providers({
         <AuthStateSync initialUserId={userId} />
         <ToastProvider>
           <ConfirmProvider>
+            {/* Suspense boundary 는 TopProgressBar 가 향후 useSearchParams 등을
+                추가할 때 정적 렌더링 bail-out 을 막기 위한 안전 장치. */}
+            <Suspense fallback={null}>
+              <TopProgressBar />
+            </Suspense>
             <OfflineBanner />
             {children}
           </ConfirmProvider>

--- a/app/trip/[tripId]/loading.tsx
+++ b/app/trip/[tripId]/loading.tsx
@@ -1,0 +1,35 @@
+import { Skeleton } from '@/components/UI/Skeleton'
+
+/**
+ * trip 진입 시 layout (Supabase 접근 체크 + 메타 조회) 응답까지의 skeleton.
+ * pathname 자체가 바뀌었으니 이전 페이지가 그대로 남는 인상을 막는다 (#233).
+ */
+export default function TripLoading() {
+  return (
+    <div className="min-h-screen bg-bg text-fg pb-24 md:pb-0 md:pl-44" aria-busy="true">
+      <header className="px-4 md:px-8 pt-4">
+        <div className="flex items-center justify-between mb-4 gap-3">
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-5 w-40 rounded" />
+            <Skeleton className="h-3 w-24 rounded" />
+          </div>
+          <Skeleton className="h-8 w-20 rounded-lg" />
+        </div>
+      </header>
+      <main className="px-4 md:px-8 py-4 space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-start gap-3 p-4 border border-border rounded-lg bg-bg-elevated"
+          >
+            <Skeleton className="size-9 rounded-full shrink-0" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-2/3 rounded" />
+              <Skeleton className="h-3 w-1/2 rounded" />
+            </div>
+          </div>
+        ))}
+      </main>
+    </div>
+  )
+}

--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { ArrowLeft, List, Map, CalendarDays, Download, LogOut, MoreHorizontal, User } from 'lucide-react'
+import { ArrowLeft, List, Map, CalendarDays, Download, LogOut, MoreHorizontal, User, Loader2 } from 'lucide-react'
 import ThemeToggle from '@/components/Theme/ThemeToggle'
 import Sheet, { SheetSection } from '@/components/UI/Sheet'
 import { cn } from '@/lib/cn'
@@ -32,6 +32,9 @@ export default function Navigation() {
   const pathname = usePathname()
   const tripId = useOptionalTripId()
   const [moreOpen, setMoreOpen] = useState(false)
+  // 클릭 직후 즉시 "눌림" 표시를 위한 지연된 활성 href.
+  // pathname 이 실제로 바뀌기 전까지 사용자에게 "이 항목으로 가고 있음" 을 표시한다 (#233).
+  const [pendingHref, setPendingHref] = useState<string | null>(null)
 
   const hrefFor = (sub: string): string =>
     tripId ? buildTripPath(tripId, sub) : legacyHref(sub)
@@ -39,6 +42,28 @@ export default function Navigation() {
   const isActive = (sub: string): boolean => {
     const href = hrefFor(sub)
     return pathname.startsWith(href)
+  }
+
+  // pathname 이 pending href 와 같은 prefix 가 되면 = 라우트 도달 → pending 해제
+  useEffect(() => {
+    if (pendingHref && pathname.startsWith(pendingHref)) {
+      setPendingHref(null)
+    }
+  }, [pathname, pendingHref])
+
+  // pendingHref 가 8초 넘게 유지되면 안전 폴백 — 라우트 변경 실패 시 무한 스피너 방지
+  useEffect(() => {
+    if (!pendingHref) return
+    const t = setTimeout(() => setPendingHref(null), 8000)
+    return () => clearTimeout(t)
+  }, [pendingHref])
+
+  const isPending = (sub: string): boolean => pendingHref === hrefFor(sub)
+
+  const handleNavClick = (href: string) => {
+    // 이미 같은 경로면 pending 표시 불필요
+    if (pathname.startsWith(href)) return
+    setPendingHref(href)
   }
 
   return (
@@ -55,19 +80,27 @@ export default function Navigation() {
         <ul className="flex">
           {NAV_ITEMS.map(({ sub, label, icon: Icon }) => {
             const active = isActive(sub)
+            const pending = isPending(sub)
+            const href = hrefFor(sub)
             return (
               <li key={sub} className="flex-1">
                 <Link
-                  href={hrefFor(sub)}
+                  href={href}
+                  onClick={() => handleNavClick(href)}
                   aria-current={active ? 'page' : undefined}
+                  aria-busy={pending || undefined}
                   className={cn(
                     'flex flex-col items-center justify-center gap-0.5 py-2.5 min-h-11',
                     'text-[11px] font-medium transition-colors duration-150',
                     'focus-visible:outline-2 focus-visible:outline-offset-[-4px] focus-visible:outline-accent rounded',
-                    active ? 'text-accent' : 'text-fg-subtle hover:text-fg-muted',
+                    active || pending ? 'text-accent' : 'text-fg-subtle hover:text-fg-muted',
                   )}
                 >
-                  <Icon className="size-5" aria-hidden="true" />
+                  {pending ? (
+                    <Loader2 className="size-5 animate-spin" aria-hidden="true" />
+                  ) : (
+                    <Icon className="size-5" aria-hidden="true" />
+                  )}
                   <span>{label}</span>
                 </Link>
               </li>
@@ -172,39 +205,63 @@ export default function Navigation() {
         <ul className="flex-1 space-y-0.5">
           {NAV_ITEMS.map(({ sub, label, icon: Icon }) => {
             const active = isActive(sub)
+            const pending = isPending(sub)
+            const href = hrefFor(sub)
             return (
               <li key={sub}>
                 <Link
-                  href={hrefFor(sub)}
+                  href={href}
+                  onClick={() => handleNavClick(href)}
                   aria-current={active ? 'page' : undefined}
+                  aria-busy={pending || undefined}
                   className={cn(
                     'flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium',
                     'transition-colors duration-150',
                     'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
                     active
                       ? 'bg-accent text-accent-fg'
-                      : 'text-fg-muted hover:bg-bg-subtle hover:text-fg',
+                      : pending
+                        ? 'bg-bg-subtle text-fg'
+                        : 'text-fg-muted hover:bg-bg-subtle hover:text-fg',
                   )}
                 >
-                  <Icon className="size-4 shrink-0" aria-hidden="true" />
+                  {pending ? (
+                    <Loader2 className="size-4 shrink-0 animate-spin" aria-hidden="true" />
+                  ) : (
+                    <Icon className="size-4 shrink-0" aria-hidden="true" />
+                  )}
                   <span>{label}</span>
                 </Link>
               </li>
             )
           })}
           <li>
-            <Link
-              href={hrefFor('gmaps-import')}
-              className={cn(
-                'flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium',
-                'transition-colors duration-150',
-                'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
-                'text-fg-muted hover:bg-bg-subtle hover:text-fg',
-              )}
-            >
-              <Download className="size-4 shrink-0" aria-hidden="true" />
-              <span>구글맵 가져오기</span>
-            </Link>
+            {(() => {
+              const href = hrefFor('gmaps-import')
+              const pending = pendingHref === href
+              return (
+                <Link
+                  href={href}
+                  onClick={() => handleNavClick(href)}
+                  aria-busy={pending || undefined}
+                  className={cn(
+                    'flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium',
+                    'transition-colors duration-150',
+                    'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+                    pending
+                      ? 'bg-bg-subtle text-fg'
+                      : 'text-fg-muted hover:bg-bg-subtle hover:text-fg',
+                  )}
+                >
+                  {pending ? (
+                    <Loader2 className="size-4 shrink-0 animate-spin" aria-hidden="true" />
+                  ) : (
+                    <Download className="size-4 shrink-0" aria-hidden="true" />
+                  )}
+                  <span>구글맵 가져오기</span>
+                </Link>
+              )
+            })()}
           </li>
         </ul>
         <div className="border-t border-border pt-3 mt-2 space-y-0.5">

--- a/components/Layout/TopProgressBar.tsx
+++ b/components/Layout/TopProgressBar.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { usePathname } from 'next/navigation'
+
+/**
+ * 라우트 전환 시 상단에 얇은 진행 막대를 표시한다 (#233).
+ *
+ * 문제: Next.js App Router 는 새 페이지를 그릴 준비가 될 때까지 이전 페이지를 그대로 유지한다.
+ * 사용자는 클릭이 먹혔는지 확신할 수 없다.
+ *
+ * 해결:
+ *  1. document 레벨에서 내부 링크 클릭을 캡처해 0ms 이내 진행 막대 노출
+ *  2. usePathname / useSearchParams 변경을 감지해 막대 완료 → 페이드아웃
+ *  3. 클릭 직후 200ms 안에 라우트가 바뀌어버리면(=빠른 전환) 막대를 보여주지 않는다.
+ *     너무 빠른 깜빡임이 오히려 노이즈가 되기 때문.
+ */
+export default function TopProgressBar() {
+  const pathname = usePathname()
+  const [progress, setProgress] = useState<number>(0)
+  const [visible, setVisible] = useState<boolean>(false)
+  const startTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const trickleTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const finishTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastPathRef = useRef<string>(pathname)
+  const startedRef = useRef<boolean>(false)
+
+  // 진행 시작 — start trickle to 90%, never reach 100 until finish().
+  function start() {
+    if (startedRef.current) return
+    startedRef.current = true
+    if (startTimerRef.current) clearTimeout(startTimerRef.current)
+    // 200ms 까지 빠른 전환이면 막대 자체를 띄우지 않는다.
+    startTimerRef.current = setTimeout(() => {
+      setVisible(true)
+      setProgress(10)
+      if (trickleTimerRef.current) clearInterval(trickleTimerRef.current)
+      trickleTimerRef.current = setInterval(() => {
+        setProgress((p) => {
+          if (p >= 90) return p
+          // 90% 까지 점진적으로 — 가까울수록 느리게 (지연 인상을 줄임)
+          const remaining = 90 - p
+          return p + Math.max(1, remaining * 0.08)
+        })
+      }, 180)
+    }, 200)
+  }
+
+  // 진행 완료 — 100% 채우고 페이드아웃.
+  function finish() {
+    if (!startedRef.current) return
+    startedRef.current = false
+    if (startTimerRef.current) {
+      clearTimeout(startTimerRef.current)
+      startTimerRef.current = null
+    }
+    if (trickleTimerRef.current) {
+      clearInterval(trickleTimerRef.current)
+      trickleTimerRef.current = null
+    }
+    setProgress(100)
+    if (finishTimerRef.current) clearTimeout(finishTimerRef.current)
+    finishTimerRef.current = setTimeout(() => {
+      setVisible(false)
+      setProgress(0)
+    }, 240)
+  }
+
+  // document 클릭 캡처 — 내부 링크면 진행 시작
+  useEffect(() => {
+    function shouldTrack(link: HTMLAnchorElement, event: MouseEvent): boolean {
+      const href = link.getAttribute('href')
+      if (!href) return false
+      // 외부·해시·새 탭·모디파이어 키 — 스킵
+      if (href.startsWith('#')) return false
+      if (href.startsWith('http://') || href.startsWith('https://')) {
+        try {
+          const url = new URL(href, window.location.origin)
+          if (url.origin !== window.location.origin) return false
+        } catch {
+          return false
+        }
+      }
+      if (link.target === '_blank' || link.hasAttribute('download')) return false
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return false
+      if (event.button !== 0) return false
+      // 동일 경로 — 진행 표시 불필요
+      try {
+        const url = new URL(href, window.location.origin)
+        if (url.pathname === window.location.pathname && url.search === window.location.search) {
+          return false
+        }
+      } catch {
+        // 무시
+      }
+      return true
+    }
+
+    function handleClick(e: MouseEvent) {
+      const target = e.target
+      if (!(target instanceof Element)) return
+      const link = target.closest('a')
+      if (!link) return
+      if (shouldTrack(link as HTMLAnchorElement, e)) start()
+    }
+
+    document.addEventListener('click', handleClick, true)
+    return () => document.removeEventListener('click', handleClick, true)
+  }, [])
+
+  // 경로 변경 = 새 라우트가 그려졌다는 신호 → finish
+  useEffect(() => {
+    if (lastPathRef.current !== pathname) {
+      lastPathRef.current = pathname
+      finish()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname])
+
+  // 언마운트 cleanup
+  useEffect(() => {
+    return () => {
+      if (startTimerRef.current) clearTimeout(startTimerRef.current)
+      if (trickleTimerRef.current) clearInterval(trickleTimerRef.current)
+      if (finishTimerRef.current) clearTimeout(finishTimerRef.current)
+    }
+  }, [])
+
+  if (!visible) return null
+  return (
+    <div
+      role="progressbar"
+      aria-label="페이지 전환 진행"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(progress)}
+      className="fixed top-0 inset-x-0 z-[100] h-0.5 pointer-events-none"
+    >
+      <div
+        className="h-full bg-accent shadow-[0_0_8px_var(--color-accent,#3b82f6)] transition-[width,opacity] duration-200 ease-out"
+        style={{
+          width: `${progress}%`,
+          opacity: progress >= 100 ? 0 : 1,
+        }}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## 관련 이슈

Closes #233

## 변경 이유

페이지 간 이동 시 새 페이지가 그려질 때까지 이전 페이지가 그대로 표시되어 사용자가 ‟클릭이 먹혔는지" 확신하지 못하는 문제. 본 PR은 ‟지각 속도" 트랙(즉시 시각 피드백). 자매 #234가 ‟실제 속도" 측정·최적화 담당.

## 변경 범위

### 1. Top Progress Bar (`components/Layout/TopProgressBar.tsx` 신규)

- document 레벨에서 내부 링크 클릭 캡처
- **200ms 빠른 전환은 막대를 띄우지 않음** — 깜빡임 노이즈 방지
- 클릭 후 200ms 경과 → 막대 노출, 90% 까지 점진 진행
- `usePathname()` 변경 = 진행 완료 → 100% 채우고 페이드아웃
- 외부 링크·해시·새 탭·모디파이어 키·동일 경로는 스킵
- `app/providers.tsx` 에 Suspense 경계로 마운트

### 2. Nav 항목 즉시 ‟눌림" 표시 (`components/Layout/Navigation.tsx`)

- 클릭 직후 0ms 안에 해당 nav 아이콘이 `Loader2` 스피너로 교체
- `pendingHref` state — `usePathname()` prefix 가 일치하면 자동 해제
- 8초 폴백 — 라우트 변경 실패 시 무한 스피너 방지
- 모바일 bottom nav · 데스크탑 sidebar 모두 적용 (구글맵 가져오기 포함)
- 동일 경로 클릭 시 pending 표시 안 함

### 3. `loading.tsx` 두 곳 신규

- `app/trip/[tripId]/loading.tsx` — trip layout 의 Supabase 접근 체크 + 메타 조회 동안 skeleton (header + 카드 리스트 형태)
- `app/dashboard/loading.tsx` — 대시보드 SSR 조회 동안 skeleton (헤더 + 카드 그리드)

## 검증

- `npx tsc --noEmit` 통과
- `npm run build` 통과 (모든 라우트 빌드 OK, dashboard/trip 신규 loading 보임)
- 수동 시나리오:
  - 데스크탑/모바일 nav 클릭 → 0ms 안에 아이콘이 스피너로 교체 확인
  - 느린 전환 시 상단에 얇은 progress bar 노출 확인
  - 매우 빠른 전환은 progress bar 깜빡이지 않음을 확인 (200ms 임계)
  - cmd/ctrl 클릭, 외부 링크, 동일 경로 — progress bar 트리거 안 됨 확인

## 남은 작업 / 리스크

- 본 PR은 ‟지각 속도" 만. ‟실제 속도" (prefetch, SWR cache warming, LCP/INP 측정) 는 #234 에서.
- `app/trip/[tripId]/{list,map,schedule}/loading.tsx` 는 본 PR 에 포함하지 않음. 클라이언트 컴포넌트라 parent `loading.tsx` 가 동일 효과를 주며, 세부 skeleton 은 데이터 형태 결정 후 별 PR 로.

## 자가검열 (basics-first)

- [x] 이 페이지·기능에 ‟지금 보고 있는 여행 이름" 이 보이는가? — 글로벌 UI 추가, 페이지 헤더 자체는 변경 없음
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — N/A (UX polish)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? — 신규 모달·시트 없음
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — N/A
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — TopProgressBar 는 글로벌, nav pending 은 양쪽 nav 에 모두 적용
