### PR TITLE
feat(ux): #42 키보드 단축키 (n / / / ⌘+K / ?)

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -167,6 +167,7 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
                 onChange={e => setQuery(e.target.value)}
                 placeholder="이름·지역으로 검색"
                 leading={<Search className="size-4" aria-hidden="true" />}
+                data-shortcut="search"
               />
             </div>
             <div className="flex items-center gap-2">

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from '@/components/Theme/ThemeProvider'
 import OfflineBanner from '@/components/UI/OfflineBanner'
 import AuthStateSync from '@/components/Auth/AuthStateSync'
 import TopProgressBar from '@/components/Layout/TopProgressBar'
+import KeyboardShortcuts from '@/components/Layout/KeyboardShortcuts'
 
 export default function Providers({
   children,
@@ -29,6 +30,7 @@ export default function Providers({
             <Suspense fallback={null}>
               <TopProgressBar />
             </Suspense>
+            <KeyboardShortcuts />
             <OfflineBanner />
             {children}
           </ConfirmProvider>

--- a/app/trip/[tripId]/list/page.tsx
+++ b/app/trip/[tripId]/list/page.tsx
@@ -286,6 +286,7 @@ function ResearchPageContent() {
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder="이름·주소·메모로 검색"
                 leading={<Search className="size-4" aria-hidden="true" />}
+                data-shortcut="search"
               />
             </div>
             <div className="relative flex items-center gap-1.5 flex-shrink-0">

--- a/components/Items/ItemList.tsx
+++ b/components/Items/ItemList.tsx
@@ -258,6 +258,7 @@ export default function ItemList({
             onChange={(e) => setQuery(e.target.value)}
             placeholder="이름·주소·메모로 검색"
             leading={<Search className="size-4" aria-hidden="true" />}
+            data-shortcut="search"
           />
         </div>
         <div className="relative flex items-center gap-1.5 flex-shrink-0">

--- a/components/Layout/KeyboardShortcuts.tsx
+++ b/components/Layout/KeyboardShortcuts.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useRouter, usePathname } from 'next/navigation'
+import Sheet from '@/components/UI/Sheet'
+
+/**
+ * 전역 키보드 단축키 (#42).
+ *
+ * 단축키:
+ *  - `n`       → 현재 컨텍스트에 맞는 "새 항목 추가"
+ *                · /trip/[tripId]/** → 그 trip 에 새 item 추가
+ *                · /dashboard       → 새 여행 만들기
+ *  - `/`, `Ctrl+K` / `⌘+K` → 현재 페이지의 검색 입력에 포커스
+ *  - `?`       → 단축키 도움말 시트 열기
+ *  - `Esc`     → 도움말 시트 닫기 (다른 패널은 각자 처리)
+ *
+ * 안전:
+ *  - 입력 필드(input/textarea/select/contenteditable) 안에서는 단축키 무시
+ *    단, `/` 키만은 ‟Esc + /" 흐름을 막지 않게 inputs 에서도 동작 안 함
+ *  - 모디파이어(Ctrl/Meta) 없는 단일 키는 IME composition 중일 때 무시
+ *  - data-shortcut="search" 가 페이지에 있을 때만 검색 단축키 활성
+ */
+export default function KeyboardShortcuts() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const [helpOpen, setHelpOpen] = useState(false)
+
+  const triggerNewItem = useCallback(() => {
+    const tripMatch = pathname.match(/^\/trip\/([0-9a-fA-F-]{36})/)
+    if (tripMatch) {
+      router.push(`/trip/${tripMatch[1]}/items/new`)
+      return
+    }
+    if (pathname.startsWith('/dashboard')) {
+      router.push('/dashboard/new')
+      return
+    }
+    // 그 외 페이지(/login, /me 등) 에서는 무동작
+  }, [pathname, router])
+
+  const focusSearch = useCallback(() => {
+    // 명시적 마커 우선
+    const explicit = document.querySelector<HTMLInputElement>(
+      '[data-shortcut="search"]',
+    )
+    if (explicit) {
+      explicit.focus()
+      explicit.select()
+      return true
+    }
+    return false
+  }, [])
+
+  useEffect(() => {
+    function isTypingTarget(target: EventTarget | null): boolean {
+      if (!(target instanceof HTMLElement)) return false
+      const tag = target.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+      if (target.isContentEditable) return true
+      return false
+    }
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.defaultPrevented) return
+      // IME composition 중에는 단축키 비활성 (한글 입력 충돌 방지)
+      if (e.isComposing) return
+
+      const cmdK = (e.ctrlKey || e.metaKey) && (e.key === 'k' || e.key === 'K')
+
+      // Ctrl/⌘+K 는 입력 필드 안에서도 동작 (검색 포커스 전환)
+      if (cmdK) {
+        if (focusSearch()) {
+          e.preventDefault()
+        }
+        return
+      }
+
+      // 입력 필드 포커스 중에는 단일 키 단축키 비활성
+      if (isTypingTarget(e.target)) return
+
+      // 모디파이어 없는 단일 키만 처리
+      if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+        // `?` 는 보통 Shift+/ 이므로 shift 는 허용
+        if (!(e.shiftKey && e.key === '?')) return
+      }
+
+      switch (e.key) {
+        case 'n':
+        case 'N':
+          triggerNewItem()
+          e.preventDefault()
+          break
+        case '/':
+          if (focusSearch()) e.preventDefault()
+          break
+        case '?':
+          setHelpOpen((v) => !v)
+          e.preventDefault()
+          break
+        default:
+          break
+      }
+    }
+
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [triggerNewItem, focusSearch])
+
+  return (
+    <Sheet
+      open={helpOpen}
+      onClose={() => setHelpOpen(false)}
+      side="bottom"
+      title="키보드 단축키"
+    >
+      <dl className="divide-y divide-border rounded-lg border border-border overflow-hidden">
+        <ShortcutRow keys={['n']} label="새 항목 추가 (이 여행 / 새 여행)" />
+        <ShortcutRow keys={['/']} label="검색 포커스" />
+        <ShortcutRow keys={['Ctrl', 'K']} altKeys={['⌘', 'K']} label="검색 포커스" />
+        <ShortcutRow keys={['Esc']} label="패널·시트 닫기" />
+        <ShortcutRow keys={['?']} label="이 도움말 열기·닫기" />
+      </dl>
+      <p className="text-xs text-fg-subtle mt-3 px-1">
+        입력 중에는 일부 단축키가 비활성화돼요. 검색은 입력 중에도 ⌘/Ctrl+K 로 이동할 수 있어요.
+      </p>
+    </Sheet>
+  )
+}
+
+function ShortcutRow({
+  keys,
+  altKeys,
+  label,
+}: {
+  keys: string[]
+  altKeys?: string[]
+  label: string
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 px-3 py-2.5 bg-bg-elevated">
+      <dt className="text-sm text-fg">{label}</dt>
+      <dd className="flex items-center gap-1.5 text-xs">
+        <KeyCluster keys={keys} />
+        {altKeys && (
+          <>
+            <span className="text-fg-subtle">또는</span>
+            <KeyCluster keys={altKeys} />
+          </>
+        )}
+      </dd>
+    </div>
+  )
+}
+
+function KeyCluster({ keys }: { keys: string[] }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      {keys.map((k, i) => (
+        <kbd
+          key={i}
+          className="px-1.5 py-0.5 rounded border border-border bg-bg text-fg-muted font-mono text-[11px] min-w-6 text-center"
+        >
+          {k}
+        </kbd>
+      ))}
+    </span>
+  )
+}

--- a/components/Map/MapSidePanel.tsx
+++ b/components/Map/MapSidePanel.tsx
@@ -264,6 +264,7 @@ function CandidatesView({
           onChange={(e) => setQuery(e.target.value)}
           placeholder="이름·주소·메모로 검색"
           leading={<Search className="size-4" aria-hidden="true" />}
+          data-shortcut="search"
         />
         <div className="flex flex-wrap gap-1">
           <CategoryFilterChip


### PR DESCRIPTION
## 관련 이슈

Closes #42

## 변경 이유

데스크탑에서 빠르게 조작할 수 있는 키보드 단축키가 부재. 핵심 동선(새 항목 추가, 검색 포커스) 을 마우스 없이 도달 가능하게 함.

## 변경 범위

### 1. 글로벌 단축키 컴포넌트 (`components/Layout/KeyboardShortcuts.tsx` 신규)

| 단축키 | 동작 |
|--------|------|
| `n` | 컨텍스트별 ‟새 항목 추가" (/trip/[tripId]/** → 새 item, /dashboard → 새 trip, 그 외 무동작) |
| `/` | 현재 페이지의 검색 입력에 포커스 |
| `Ctrl+K` / `⌘+K` | 검색 포커스 (입력 필드 안에서도 동작) |
| `?` | 단축키 도움말 시트 열기·닫기 |
| `Esc` | 도움말 시트 닫기 (Sheet 컴포넌트 기본 동작) |

### 2. 안전 가드

- input/textarea/select/contenteditable 포커스 중에는 단일 키 단축키 비활성 — 텍스트 입력과 충돌 방지
- IME composition 중 (한글 입력) 에는 단축키 무시
- `Ctrl+K` / `⌘+K` 만 입력 필드 안에서도 동작 — 검색으로 즉시 전환 가능

### 3. 검색 입력 마커

검색 단축키가 페이지마다 다른 검색 입력을 찾도록 `data-shortcut="search"` 속성 추가:
- `app/dashboard/DashboardClient.tsx` (여행 검색)
- `app/trip/[tripId]/list/page.tsx` (목록 검색)
- `components/Items/ItemList.tsx` (사이드패널 검색)
- `components/Map/MapSidePanel.tsx` (지도 사이드 검색)

### 4. 마운트

- `app/providers.tsx` 에 `<KeyboardShortcuts />` 추가 — 모든 라우트에서 활성

## 검증

- `npx tsc --noEmit` 통과
- `npm run build` 통과
- 수동 시나리오:
  - dashboard 에서 `n` → /dashboard/new 로 이동 확인
  - trip 페이지에서 `n` → /trip/[id]/items/new 로 이동 확인
  - `/` → 검색 입력에 포커스 + 텍스트 선택됨 확인
  - input 안에서 `n` 타이핑 → 글자 입력됨 (단축키 비활성 확인)
  - input 안에서 `⌘+K` → 검색으로 포커스 전환 확인
  - `?` → 도움말 시트 토글 확인
  - 한글 입력 중 `n` → 한글 입력 보존 (composition 가드)

## 남은 작업 / 리스크

없음. 추후 단축키 확장(예: `g d` → 대시보드, `g m` → 지도) 가능하나 본 이슈 범위 밖.

## 자가검열 (basics-first)

- [x] 이 페이지·기능에 ‟지금 보고 있는 여행 이름" 이 보이는가? — 글로벌 UI, 해당 없음
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — `n` 단축키가 Create 동선을 보조
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? — 도움말 시트는 Sheet 의 콘텐츠 적응형 기본 모드 사용
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — 도움말 시트의 모든 단축키 실제 동작
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — 키보드 단축키는 데스크탑 한정 폴리시. 모바일에서는 키보드 미사용이라 N/A. 모바일은 nav·FAB 으로 이미 동등 동선 보장.
