### PR TITLE
feat(items): #70 메모 풀스크린 편집 모드

### DIFF
--- a/components/Items/ItemForm.tsx
+++ b/components/Items/ItemForm.tsx
@@ -7,6 +7,7 @@ import { useItems } from '@/lib/hooks/useItems'
 import { useTrip, useTripPath } from '@/lib/hooks/useTripContext'
 import { currencyFieldLabel, normalizeCurrency } from '@/lib/currency'
 import { useConfirm } from '@/components/UI/ConfirmDialog'
+import MemoField from '@/components/UI/MemoField'
 import {
   CATEGORY_OPTIONS,
   ITEM_FIELD_LABELS,
@@ -374,7 +375,14 @@ export default function ItemForm({ mode, initialData, itemId }: ItemFormProps) {
 
       <section className="space-y-3">
         <h2 className="text-xs font-semibold text-fg-subtle uppercase tracking-wider">메모</h2>
-        <textarea ref={memoRef} value={form.memo} onChange={e => setField('memo', e.target.value)} className={`${inputClass} resize-none overflow-hidden`} rows={4} placeholder="자유롭게 메모..." />
+        <MemoField
+          inlineRef={memoRef}
+          value={form.memo}
+          onChange={v => setField('memo', v)}
+          className={`${inputClass} resize-none overflow-hidden`}
+          rows={4}
+          placeholder="자유롭게 메모..."
+        />
       </section>
 
       {error && <p className="text-sm text-critical-fg">{error}</p>}

--- a/components/Panel/PanelItemForm.tsx
+++ b/components/Panel/PanelItemForm.tsx
@@ -6,6 +6,7 @@ import { useItems } from '@/lib/hooks/useItems'
 import { useTrip } from '@/lib/hooks/useTripContext'
 import { currencyFieldLabel, normalizeCurrency } from '@/lib/currency'
 import CollapsibleSection from '@/components/UI/CollapsibleSection'
+import MemoField from '@/components/UI/MemoField'
 import {
   CATEGORY_OPTIONS,
   ITEM_FIELD_LABELS,
@@ -189,7 +190,14 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
 
         <section className="space-y-3">
           <h3 className="text-xs font-semibold text-fg-subtle uppercase tracking-wider">메모</h3>
-          <textarea ref={memoRef} value={form.memo} onChange={e => setField('memo', e.target.value)} className={`${inputClass} resize-none overflow-hidden`} rows={4} placeholder="자유롭게 메모..." />
+          <MemoField
+            inlineRef={memoRef}
+            value={form.memo}
+            onChange={v => setField('memo', v)}
+            className={`${inputClass} resize-none overflow-hidden`}
+            rows={4}
+            placeholder="자유롭게 메모..."
+          />
         </section>
 
         <CollapsibleSection title="일정" defaultOpen={scheduleHasValue}>

--- a/components/UI/MemoField.tsx
+++ b/components/UI/MemoField.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Maximize2, X, Check } from 'lucide-react'
+import { cn } from '@/lib/cn'
+
+interface MemoFieldProps {
+  value: string
+  onChange: (next: string) => void
+  placeholder?: string
+  /** 인라인 textarea 에 적용할 클래스 (테두리·패딩 등) */
+  className?: string
+  /** 인라인 textarea rows. 기본 4. */
+  rows?: number
+  /** 인라인 textarea 의 ref — 외부에서 자동 높이 측정 등에 사용 */
+  inlineRef?: React.Ref<HTMLTextAreaElement>
+  /** 풀스크린 오버레이 제목. 기본 '메모'. */
+  fullscreenTitle?: string
+}
+
+/**
+ * 인라인 메모 textarea + 풀스크린 편집 모드 (#70).
+ *
+ * - 우상단 ‟확장" 버튼으로 풀스크린 오버레이 진입
+ * - 오버레이: 거대한 textarea + 완료(Esc) / 닫기(X) 버튼
+ * - 입력은 항상 인라인 value 와 동기화 (오버레이 내에서도 onChange 즉시 반영)
+ * - 모바일에서 키보드가 올라온 상태에서도 충분한 입력 영역 확보 (h-full + safe-area)
+ */
+export default function MemoField({
+  value,
+  onChange,
+  placeholder,
+  className,
+  rows = 4,
+  inlineRef,
+  fullscreenTitle = '메모',
+}: MemoFieldProps) {
+  const [fullscreen, setFullscreen] = useState(false)
+  const fullscreenTextareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (!fullscreen) return
+    // 오버레이 열릴 때 textarea 포커스 + 커서 끝으로
+    const el = fullscreenTextareaRef.current
+    if (el) {
+      el.focus()
+      const len = el.value.length
+      el.setSelectionRange(len, len)
+    }
+    // body 스크롤 잠금
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setFullscreen(false)
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.body.style.overflow = prevOverflow
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [fullscreen])
+
+  return (
+    <div className="relative">
+      <textarea
+        ref={inlineRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={rows}
+        placeholder={placeholder}
+        className={cn(className, 'pr-10')}
+        aria-label={fullscreenTitle}
+      />
+      <button
+        type="button"
+        onClick={() => setFullscreen(true)}
+        aria-label="풀스크린으로 편집"
+        className={cn(
+          'absolute top-2 right-2 inline-flex items-center justify-center size-7 rounded-md',
+          'text-fg-subtle hover:text-fg hover:bg-bg-subtle transition-colors',
+          'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+        )}
+      >
+        <Maximize2 className="size-4" aria-hidden="true" />
+      </button>
+      {fullscreen && typeof document !== 'undefined'
+        ? createPortal(
+            <FullScreenMemoEditor
+              value={value}
+              onChange={onChange}
+              onClose={() => setFullscreen(false)}
+              title={fullscreenTitle}
+              placeholder={placeholder}
+              textareaRef={fullscreenTextareaRef}
+            />,
+            document.body,
+          )
+        : null}
+    </div>
+  )
+}
+
+function FullScreenMemoEditor({
+  value,
+  onChange,
+  onClose,
+  title,
+  placeholder,
+  textareaRef,
+}: {
+  value: string
+  onChange: (next: string) => void
+  onClose: () => void
+  title: string
+  placeholder?: string
+  textareaRef: React.Ref<HTMLTextAreaElement>
+}) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className="fixed inset-0 z-[100] bg-bg flex flex-col"
+      style={{
+        paddingTop: 'env(safe-area-inset-top)',
+        paddingBottom: 'env(safe-area-inset-bottom)',
+      }}
+    >
+      <header className="flex items-center justify-between px-3 py-2 border-b border-border bg-bg-elevated">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="닫기"
+          className={cn(
+            'inline-flex items-center justify-center size-10 rounded-md',
+            'text-fg-muted hover:text-fg hover:bg-bg-subtle transition-colors',
+            'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+          )}
+        >
+          <X className="size-5" aria-hidden="true" />
+        </button>
+        <h2 className="text-sm font-semibold text-fg">{title}</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className={cn(
+            'inline-flex items-center gap-1 px-3 py-2 rounded-md text-sm font-medium',
+            'text-accent hover:bg-bg-subtle transition-colors',
+            'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+          )}
+        >
+          <Check className="size-4" aria-hidden="true" />
+          완료
+        </button>
+      </header>
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className={cn(
+          'flex-1 w-full resize-none bg-bg text-fg placeholder:text-fg-subtle',
+          'px-4 py-3 text-base leading-relaxed',
+          'focus:outline-none',
+        )}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## 관련 이슈

Closes #70

## 변경 이유

긴 메모를 편집할 때 사이드패널·폼 안의 textarea 가 다른 필드와 함께 스크롤되어 불편함. 모바일에서 키보드가 올라온 상태에선 입력 영역이 더 좁아져 답답함.

## 변경 범위

### 1. `components/UI/MemoField.tsx` 신규

- 인라인 textarea + 우상단 ‟확장" 버튼 (Maximize2 아이콘) 결합
- 확장 클릭 → 풀스크린 오버레이 (viewport 전체)
  - 큰 textarea, 큰 글자, 여유 padding
  - safe-area-inset-top/bottom 반영 — 모바일 노치/홈 인디케이터 침범 방지
  - body scroll lock — 배경 스크롤 차단
  - ESC 키로 닫기
  - 헤더 좌측 X / 우측 ‟완료" 버튼
- 인라인 ↔ 풀스크린 모두 동일 value 와 onChange 즉시 동기화

### 2. 기존 두 곳을 교체

- components/Panel/PanelItemForm.tsx (사이드패널 인라인 편집)
- components/Items/ItemForm.tsx (전용 페이지 폼)
- 인라인 textarea ref(memoRef) 는 그대로 유지 — auto-expand 로직 호환

## 검증

- npx tsc --noEmit 통과
- npm run build 통과
- 수동 시나리오: 사이드패널 → 확장 → 풀스크린 입력 → 완료 → 인라인 반영, ESC 닫기

## 남은 작업 / 리스크

- 이슈 본문의 ‟메모 필드 탭 시 자동 풀스크린" 은 채택하지 않음. 데스크탑 의도치 않은 오버레이 침범 방지 위해 명시적 확장 버튼만으로 진입.

## 자가검열 (basics-first)

- [x] 컨텍스트 표시 — 부모 폼이 trip 컨텍스트 표시
- [x] CRUD — Update 동선의 보조 UI
- [x] 모달 사이징 — 풀스크린 오버레이는 viewport 전체, textarea flex-1
- [x] 카피 정직성 — N/A
- [x] 모바일·데스크탑 동등 — 동일 컴포넌트
