### PR TITLE
feat(layout): #206 데스크탑 우상단 아바타 드롭다운 (user-scope 분리)

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -9,6 +9,7 @@ import OfflineBanner from '@/components/UI/OfflineBanner'
 import AuthStateSync from '@/components/Auth/AuthStateSync'
 import TopProgressBar from '@/components/Layout/TopProgressBar'
 import KeyboardShortcuts from '@/components/Layout/KeyboardShortcuts'
+import AvatarDropdown from '@/components/Layout/AvatarDropdown'
 
 export default function Providers({
   children,
@@ -31,6 +32,7 @@ export default function Providers({
               <TopProgressBar />
             </Suspense>
             <KeyboardShortcuts />
+            <AvatarDropdown />
             <OfflineBanner />
             {children}
           </ConfirmProvider>

--- a/components/Layout/AvatarDropdown.tsx
+++ b/components/Layout/AvatarDropdown.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { ArrowLeft, LogOut, User } from 'lucide-react'
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
+import { getBrowserSupabase } from '@/lib/supabase-browser'
+import { logout } from '@/lib/auth-client'
+import ThemeToggle from '@/components/Theme/ThemeToggle'
+import { cn } from '@/lib/cn'
+
+/**
+ * 데스크탑 우상단 아바타 드롭다운 (#206).
+ *
+ * 목적: user-scope (프로필·테마·로그아웃) 와 trip-scope (목록·지도·일정) 의 IA 완전 분리.
+ * 사이드바는 trip-scope 만 남기고 user-scope 는 여기로.
+ *
+ * - 데스크탑(md+) 만 렌더. 모바일은 기존 더보기 시트 사용.
+ * - 글로벌 위치 (fixed top-right) — 페이지 전환과 무관.
+ * - 로그인 상태가 아니면 렌더 안 함.
+ * - trip 컨텍스트 안에선 ‟내 여행 목록" 도 메뉴에 포함 — 사이드바에서 옮긴 진입점.
+ */
+export default function AvatarDropdown() {
+  const pathname = usePathname()
+  const [email, setEmail] = useState<string | null>(null)
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  // 클라이언트에서 사용자 이메일 한 번 읽기 — 인증 상태 표시용
+  useEffect(() => {
+    let cancelled = false
+    const supabase = getBrowserSupabase()
+    supabase.auth.getUser().then(({ data }: { data: { user: { email?: string | null } | null } }) => {
+      if (cancelled) return
+      setEmail(data.user?.email ?? null)
+    })
+    const { data: sub } = supabase.auth.onAuthStateChange(
+      (_event: AuthChangeEvent, session: Session | null) => {
+        if (cancelled) return
+        setEmail(session?.user?.email ?? null)
+      },
+    )
+    return () => {
+      cancelled = true
+      sub.subscription.unsubscribe()
+    }
+  }, [])
+
+  // 바깥 클릭 / Esc 로 닫기
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e: MouseEvent) {
+      if (!rootRef.current) return
+      if (!rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open])
+
+  // 페이지 이동 시 자동 닫기
+  useEffect(() => {
+    setOpen(false)
+  }, [pathname])
+
+  // 로그인 상태 아니면 렌더 안 함 (e.g. /login, /signup)
+  if (!email) return null
+
+  // 인증 전용 라우트에서는 노출 안 함
+  const HIDE_ON = ['/login', '/signup', '/forgot', '/auth/']
+  if (HIDE_ON.some((p) => pathname.startsWith(p))) return null
+
+  const inTripContext = /^\/trip\/[0-9a-fA-F-]{36}/.test(pathname)
+  const initial = (email[0] ?? '?').toUpperCase()
+
+  return (
+    <div
+      ref={rootRef}
+      className="hidden md:block fixed top-3 right-4 z-40"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label={`내 계정 메뉴 (${email})`}
+        className={cn(
+          'inline-flex items-center justify-center size-9 rounded-full',
+          'bg-bg-elevated border border-border text-sm font-semibold text-fg',
+          'hover:bg-bg-subtle transition-colors',
+          'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+        )}
+      >
+        {initial}
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className={cn(
+            'absolute right-0 mt-2 w-64 rounded-xl border border-border bg-bg-elevated shadow-lg',
+            'p-2 space-y-0.5',
+          )}
+        >
+          <div className="px-3 py-2 border-b border-border mb-1">
+            <p className="text-[11px] text-fg-subtle">로그인됨</p>
+            <p className="text-sm text-fg truncate" title={email}>
+              {email}
+            </p>
+          </div>
+          {inTripContext && (
+            <Link
+              role="menuitem"
+              href="/dashboard"
+              onClick={() => setOpen(false)}
+              className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-fg hover:bg-bg-subtle transition-colors"
+            >
+              <ArrowLeft className="size-4 shrink-0" aria-hidden="true" />
+              <span>내 여행 목록</span>
+            </Link>
+          )}
+          <Link
+            role="menuitem"
+            href="/me"
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-fg hover:bg-bg-subtle transition-colors"
+          >
+            <User className="size-4 shrink-0" aria-hidden="true" />
+            <span>프로필</span>
+          </Link>
+          <div className="flex items-center justify-between px-3 py-2 rounded-lg text-sm text-fg">
+            <span>테마</span>
+            <ThemeToggle />
+          </div>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false)
+              logout()
+            }}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-critical-fg hover:bg-bg-subtle transition-colors w-full text-left"
+          >
+            <LogOut className="size-4 shrink-0" aria-hidden="true" />
+            <span>로그아웃</span>
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -264,36 +264,11 @@ export default function Navigation() {
             })()}
           </li>
         </ul>
-        <div className="border-t border-border pt-3 mt-2 space-y-0.5">
-          <p className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-fg-subtle">내 계정</p>
-          <div className="px-3 py-2 flex items-center justify-between gap-2">
-            <span className="text-xs text-fg-subtle whitespace-nowrap">테마</span>
-            <ThemeToggle />
-          </div>
-          <Link
-            href="/me"
-            className={cn(
-              'flex items-center gap-2 px-3 py-2 text-sm rounded-lg',
-              'text-fg-subtle hover:text-fg hover:bg-bg-subtle transition-colors duration-150',
-              'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
-            )}
-          >
-            <User className="size-4 shrink-0" aria-hidden="true" />
-            <span>프로필</span>
-          </Link>
-          <button
-            type="button"
-            onClick={handleLogout}
-            className={cn(
-              'flex items-center gap-2 px-3 py-2 text-sm rounded-lg w-full text-left',
-              'text-fg-subtle hover:text-fg hover:bg-bg-subtle transition-colors duration-150',
-              'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
-            )}
-          >
-            <LogOut className="size-4 shrink-0" aria-hidden="true" />
-            <span>로그아웃</span>
-          </button>
-        </div>
+        {/*
+          데스크탑 사이드바는 trip-scope (목록·지도·일정·구글맵 가져오기) 만 담는다.
+          user-scope (프로필·테마·로그아웃) 는 우상단 AvatarDropdown 으로 이동 (#206).
+          모바일은 기존 ‟더보기" 시트가 두 scope 모두 담는다.
+        */}
       </aside>
     </>
   )


### PR DESCRIPTION
## 관련 이슈

Closes #206

## 변경 이유

#196 에서 사이드바·더보기 시트에 ‟내 계정" 그룹 헤딩으로 user-scope 와 trip-scope 를 시각 분리했지만, 데스크탑 사이드바 안에 여전히 user 메뉴(프로필·로그아웃·테마) 가 남아 있어 IA 가 완전 분리되지 않았다.

## 변경 범위

### 1. `components/Layout/AvatarDropdown.tsx` 신규

- 데스크탑(md+) 우상단 fixed 위치, 모바일은 미렌더
- 클라이언트 Supabase (`getBrowserSupabase`) 로 이메일 조회 → 이니셜 아바타 표시
- 메뉴 항목:
  - 내 여행 목록 (trip 컨텍스트일 때만 — 사이드바에서 옮긴 진입점)
  - 프로필
  - 테마 (`ThemeToggle` 인라인)
  - 로그아웃
- 닫기 동작: 바깥 클릭, ESC, 페이지 이동 시 자동
- `onAuthStateChange` 구독 — 로그아웃 시 즉시 사라짐
- 인증 라우트 (`/login`, `/signup`, `/forgot`, `/auth/`) 에선 미렌더

### 2. `components/Layout/Navigation.tsx` 데스크탑 사이드바 정리

- ‟내 계정" 블록 (테마 토글, 프로필 링크, 로그아웃 버튼) 제거
- 사이드바는 **trip-scope 만**: 목록 · 지도 · 일정 · 구글맵 가져오기
- 모바일 ‟더보기" 시트는 변경 없음 — user-scope 진입점 모두 보존

### 3. `app/providers.tsx` 글로벌 마운트

- `<AvatarDropdown />` 추가 — 모든 라우트에서 활성 (인증·페이지 자가 가드)

## 검증

- `npx tsc --noEmit` 통과
- `npm run build` 통과
- 수동 시나리오:
  - 로그인 → 우상단 이니셜 아바타 노출
  - 아바타 클릭 → 드롭다운 열림, 이메일·메뉴 노출
  - trip 페이지에서 ‟내 여행 목록" 항목 노출, 대시보드/마이페이지에서는 미노출
  - 바깥 클릭 / ESC / 페이지 이동 시 닫힘
  - 로그아웃 → /login 으로 이동 + 아바타 사라짐
  - /login, /signup → 아바타 미노출 확인

## 남은 작업 / 리스크

- **시각 위치**: 데스크탑 페이지 헤더 우측에 액션 버튼(공유·새 항목)이 있을 때 fixed 아바타와 약간 겹칠 수 있음. 본 PR 은 우선순위 낮은 polish 라 위치 기본값으로 두고, 시각 충돌이 실제로 거슬리면 후속 PR 에서 페이지 헤더에 `md:pr-16` 예약 공간 추가 또는 AvatarDropdown 을 페이지 헤더 슬롯으로 흡수.

## 자가검열 (basics-first)

- [x] 컨텍스트 표시 — 드롭다운 안에 사용자 이메일 노출
- [x] CRUD — N/A (네비게이션 polish)
- [x] 모달 사이징 — 드롭다운 폭 w-64, 콘텐츠 양에 맞춰 자동 높이
- [x] 카피 정직성 — 모든 메뉴 항목 실제 동작
- [x] 모바일·데스크탑 동등 — 데스크탑 신규 진입점, 모바일은 기존 더보기 시트로 동등 동선 보장
