### PR TITLE
feat(schedule): #39 확정 일정 내보내기 — 텍스트 복사

### DIFF
--- a/app/trip/[tripId]/schedule/page.tsx
+++ b/app/trip/[tripId]/schedule/page.tsx
@@ -11,6 +11,9 @@ import { useItems } from '@/lib/hooks/useItems'
 import { useToast } from '@/components/UI/Toast'
 import TripPageHeader from '@/components/Layout/TripPageHeader'
 import StickyAddBar from '@/components/UI/StickyAddBar'
+import IconButton from '@/components/UI/IconButton'
+import { Share } from 'lucide-react'
+import ExportScheduleDialog from '@/components/Schedule/ExportScheduleDialog'
 
 const ItemPanel = dynamic(() => import('@/components/Panel/ItemPanel'), { ssr: false })
 
@@ -32,6 +35,7 @@ function SchedulePageContent() {
   const [selectedItemId, setSelectedItemId] = useState<string | null>(() =>
     searchParams.get('item'),
   )
+  const [exportOpen, setExportOpen] = useState(false)
 
   const selectedItem = items.find((i) => i.id === selectedItemId) ?? null
 
@@ -67,7 +71,18 @@ function SchedulePageContent() {
   return (
     <div className="md:pl-44 bg-bg text-fg min-h-screen">
       <div className="max-w-3xl mx-auto">
-        <TripPageHeader section="일정" />
+        <TripPageHeader
+          section="일정"
+          actions={
+            <IconButton
+              aria-label="일정 내보내기"
+              onClick={() => setExportOpen(true)}
+              title="일정 내보내기"
+            >
+              <Share className="size-5" />
+            </IconButton>
+          }
+        />
       </div>
 
       {isLoading ? (
@@ -100,6 +115,12 @@ function SchedulePageContent() {
           handleClosePanel()
           showToast({ type: 'success', message: '삭제했어요' })
         }}
+      />
+
+      <ExportScheduleDialog
+        open={exportOpen}
+        onClose={() => setExportOpen(false)}
+        items={items}
       />
     </div>
   )

--- a/components/Schedule/ExportScheduleDialog.tsx
+++ b/components/Schedule/ExportScheduleDialog.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Copy, Printer } from 'lucide-react'
+import Sheet from '@/components/UI/Sheet'
+import Button from '@/components/UI/Button'
+import { useToast } from '@/components/UI/Toast'
+import { useTrip } from '@/lib/hooks/useTripContext'
+import { buildScheduleText } from '@/lib/exportSchedule'
+import type { TripItem } from '@/types'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  items: TripItem[]
+}
+
+export default function ExportScheduleDialog({ open, onClose, items }: Props) {
+  const trip = useTrip()
+  const { showToast } = useToast()
+  const [copying, setCopying] = useState(false)
+
+  const text = useMemo(
+    () =>
+      buildScheduleText(items, {
+        tripTitle: trip.title,
+        startDate: trip.startDate,
+        endDate: trip.endDate,
+        currency: trip.currency,
+      }),
+    [items, trip.title, trip.startDate, trip.endDate, trip.currency],
+  )
+
+  async function handleCopy() {
+    setCopying(true)
+    try {
+      await navigator.clipboard.writeText(text)
+      showToast({ type: 'success', message: '클립보드에 복사했어요' })
+    } catch {
+      showToast({ type: 'error', message: '복사에 실패했어요' })
+    } finally {
+      setCopying(false)
+    }
+  }
+
+  function handlePrint() {
+    window.print()
+  }
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      side="auto"
+      title="일정 내보내기"
+      description="확정된 일정만 날짜순으로 정렬해 텍스트로 만들어요."
+      footer={
+        <>
+          <Button variant="secondary" onClick={handlePrint} leftIcon={<Printer size={16} />}>
+            인쇄
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleCopy}
+            loading={copying}
+            leftIcon={<Copy size={16} />}
+          >
+            복사
+          </Button>
+        </>
+      }
+    >
+      <div className="px-5 py-4">
+        <textarea
+          readOnly
+          value={text}
+          className="w-full min-h-[40vh] md:min-h-[50vh] resize-none bg-bg-subtle text-fg text-sm font-mono p-3 rounded border border-border focus:outline-none"
+        />
+      </div>
+    </Sheet>
+  )
+}

--- a/lib/exportSchedule.ts
+++ b/lib/exportSchedule.ts
@@ -1,0 +1,78 @@
+import type { TripItem } from '@/types'
+import { formatBudget, normalizeCurrency } from '@/lib/currency'
+
+interface BuildOpts {
+  tripTitle?: string
+  startDate?: string | null
+  endDate?: string | null
+  currency?: string
+}
+
+function dateKey(it: TripItem): string {
+  return it.date ?? ''
+}
+
+function formatTime(t?: string): string {
+  if (!t) return ''
+  return t.length >= 5 ? t.slice(0, 5) : t
+}
+
+function dayHeader(dateISO: string): string {
+  const d = new Date(dateISO + 'T00:00:00')
+  const weekday = ['일', '월', '화', '수', '목', '금', '토'][d.getDay()]
+  return `## ${dateISO} (${weekday})`
+}
+
+/**
+ * 확정(`trip_priority === '확정'`) + 날짜 있는 항목만 텍스트로 직렬화.
+ * 출력은 사람이 읽기 좋은 마크다운 가까운 평문.
+ */
+export function buildScheduleText(items: TripItem[], opts: BuildOpts = {}): string {
+  const currency = normalizeCurrency(opts.currency, 'KRW')
+  const confirmed = items
+    .filter((i) => i.trip_priority === '확정' && i.date)
+    .sort((a, b) => {
+      const ak = dateKey(a)
+      const bk = dateKey(b)
+      if (ak !== bk) return ak < bk ? -1 : 1
+      const at = a.time_start ?? ''
+      const bt = b.time_start ?? ''
+      return at < bt ? -1 : at > bt ? 1 : 0
+    })
+
+  const lines: string[] = []
+  if (opts.tripTitle) {
+    lines.push(`# ${opts.tripTitle}`)
+    if (opts.startDate && opts.endDate) {
+      lines.push(`${opts.startDate} – ${opts.endDate}`)
+    }
+    lines.push('')
+  }
+
+  if (confirmed.length === 0) {
+    lines.push('(확정된 일정이 없어요)')
+    return lines.join('\n')
+  }
+
+  let prevDate = ''
+  for (const it of confirmed) {
+    const d = it.date as string
+    if (d !== prevDate) {
+      if (prevDate) lines.push('')
+      lines.push(dayHeader(d))
+      prevDate = d
+    }
+    const time = formatTime(it.time_start)
+    const endTime = formatTime(it.time_end)
+    const timeStr = time ? (endTime ? `${time}–${endTime}` : time) : ''
+    const budget =
+      typeof it.budget === 'number' && it.budget > 0
+        ? ` (${formatBudget(it.budget, currency as never)})`
+        : ''
+    const where = it.address ? ` — ${it.address}` : ''
+    const head = timeStr ? `${timeStr} ${it.name}` : it.name
+    lines.push(`- ${head}${where}${budget}`)
+  }
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
## 관련 이슈
Closes #39

## 변경 이유
확정된 일정을 앱 밖(메신저·메모·인쇄)으로 가져갈 수단이 없었다. 텍스트 복사로 1차 채움.

## 변경 범위
- `lib/exportSchedule.ts` — `buildScheduleText(items, opts)` 추가. 확정 + 날짜 있는 항목을 날짜별로 정렬해 평문으로 직렬화. trip 통화 기준 예산 포맷.
- `components/Schedule/ExportScheduleDialog.tsx` — Sheet 기반 미리보기 + 클립보드 복사 + 인쇄(`window.print()`)
- `app/trip/[tripId]/schedule/page.tsx` — TripPageHeader `actions` 슬롯에 `Share` 아이콘 버튼

## 검증
- `npx tsc --noEmit` 통과 (0 errors)
- `npm run build` 통과
- 사전 존재 lint 오류(`services/gmaps/resolver.ts`)는 본 변경과 무관

## 남은 작업 / 리스크
- PDF 출력은 `window.print()` 기본 동작에 의존. 전용 print CSS 는 후속.
- 확정 외 다른 우선순위(`가고 싶음` 등) 포함 옵션은 사용자 요청 발생 시 추가 검토.