### PR TITLE
feat(items): #204 이름 미정 좌표 항목 일괄 편집 시트

### DIFF
--- a/app/trip/[tripId]/list/page.tsx
+++ b/app/trip/[tripId]/list/page.tsx
@@ -24,6 +24,11 @@ import { useToast } from '@/components/UI/Toast'
 import type { FilterState } from '@/components/Items/ItemList'
 import { getActiveFilterCount } from '@/components/Items/ItemList'
 import type { Category, ReservationStatus, TripPriority } from '@/types'
+import UnnamedBulkEditDialog, {
+  countUnnamed,
+  filterUnnamed,
+} from '@/components/Items/UnnamedBulkEditDialog'
+import { MapPin } from 'lucide-react'
 
 const ItemPanel = dynamic(() => import('@/components/Panel/ItemPanel'), { ssr: false })
 
@@ -48,6 +53,7 @@ function ResearchPageContent() {
   const { showToast } = useToast()
   const tripId = useTripId()
   const [shareDialogOpen, setShareDialogOpen] = useState(false)
+  const [unnamedDialogOpen, setUnnamedDialogOpen] = useState(false)
 
   const [selectedItemId, setSelectedItemId] = useState<string | null>(() =>
     searchParams.get('item'),
@@ -313,6 +319,26 @@ function ResearchPageContent() {
         </div>
       </header>
 
+      {(() => {
+        const unnamedCount = countUnnamed(items)
+        if (unnamedCount === 0) return null
+        return (
+          <div className="px-4 md:px-8 mb-3">
+            <button
+              type="button"
+              onClick={() => setUnnamedDialogOpen(true)}
+              className="w-full flex items-center gap-2 rounded-lg border border-border bg-warning-bg text-warning-fg px-3 py-2 text-sm hover:opacity-90"
+            >
+              <MapPin className="size-4 shrink-0" aria-hidden />
+              <span className="flex-1 text-left">
+                이름 미정 {unnamedCount}개 — 일괄 편집
+              </span>
+              <span className="text-xs opacity-80">열기 →</span>
+            </button>
+          </div>
+        )
+      })()}
+
       {isLoading ? (
         <>
           <div className="md:hidden px-4 space-y-2">
@@ -365,6 +391,13 @@ function ResearchPageContent() {
           handleClosePanel()
           showToast({ type: 'success', message: '삭제했어요' })
         }}
+      />
+
+      <UnnamedBulkEditDialog
+        open={unnamedDialogOpen}
+        onClose={() => setUnnamedDialogOpen(false)}
+        items={filterUnnamed(items)}
+        onUpdateItem={updateItem}
       />
 
       <ShareDialog

--- a/components/Items/UnnamedBulkEditDialog.tsx
+++ b/components/Items/UnnamedBulkEditDialog.tsx
@@ -1,0 +1,243 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Sheet from '@/components/UI/Sheet'
+import Button from '@/components/UI/Button'
+import { Input } from '@/components/UI/Input'
+import { useToast } from '@/components/UI/Toast'
+import type { TripItem } from '@/types'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  items: TripItem[]
+  onUpdateItem: (id: string, changes: Record<string, unknown>) => Promise<unknown> | unknown
+}
+
+interface RowState {
+  draft: string
+  suggestion: string | null
+  loading: boolean
+  saved: boolean
+  error: string | null
+}
+
+const UNNAMED_PREFIX = '📍'
+
+/**
+ * Gmaps import 이후 `📍` prefix 가 붙은 좌표만 가진 항목을 모아 한 시트에서 명명.
+ * 각 행: reverse geocode 후보 (선택 시 입력에 적용) + 직접 입력 + 개별 저장.
+ */
+export default function UnnamedBulkEditDialog({ open, onClose, items, onUpdateItem }: Props) {
+  const { showToast } = useToast()
+  const [rows, setRows] = useState<Record<string, RowState>>({})
+  const [savingAll, setSavingAll] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    const next: Record<string, RowState> = {}
+    for (const it of items) {
+      next[it.id] = {
+        draft: '',
+        suggestion: null,
+        loading: false,
+        saved: false,
+        error: null,
+      }
+    }
+    setRows(next)
+    // 비동기로 reverse geocode 후보 prefetch
+    for (const it of items) {
+      if (it.lat == null || it.lng == null) continue
+      void fetchSuggestion(it)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, items.length])
+
+  async function fetchSuggestion(it: TripItem) {
+    if (it.lat == null || it.lng == null) return
+    setRows((prev) => ({
+      ...prev,
+      [it.id]: { ...prev[it.id], loading: true },
+    }))
+    try {
+      const res = await fetch(`/api/geocode?lat=${it.lat}&lng=${it.lng}`)
+      const data = (await res.json()) as { address?: string | null }
+      setRows((prev) => ({
+        ...prev,
+        [it.id]: {
+          ...prev[it.id],
+          suggestion: data.address ?? null,
+          loading: false,
+        },
+      }))
+    } catch {
+      setRows((prev) => ({
+        ...prev,
+        [it.id]: { ...prev[it.id], loading: false },
+      }))
+    }
+  }
+
+  async function saveOne(id: string, name: string) {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    setRows((prev) => ({
+      ...prev,
+      [id]: { ...prev[id], error: null },
+    }))
+    try {
+      await onUpdateItem(id, { name: trimmed })
+      setRows((prev) => ({
+        ...prev,
+        [id]: { ...prev[id], saved: true },
+      }))
+    } catch {
+      setRows((prev) => ({
+        ...prev,
+        [id]: { ...prev[id], error: '저장 실패' },
+      }))
+    }
+  }
+
+  async function handleSaveAll() {
+    setSavingAll(true)
+    const toSave = items.filter((it) => {
+      const row = rows[it.id]
+      if (!row) return false
+      if (row.saved) return false
+      return row.draft.trim().length > 0
+    })
+    let ok = 0
+    for (const it of toSave) {
+      const name = rows[it.id]?.draft.trim()
+      if (!name) continue
+      try {
+        await onUpdateItem(it.id, { name })
+        setRows((prev) => ({
+          ...prev,
+          [it.id]: { ...prev[it.id], saved: true },
+        }))
+        ok++
+      } catch {
+        setRows((prev) => ({
+          ...prev,
+          [it.id]: { ...prev[it.id], error: '저장 실패' },
+        }))
+      }
+    }
+    setSavingAll(false)
+    if (ok > 0) showToast({ type: 'success', message: `${ok}개 저장했어요` })
+  }
+
+  const pending = items.filter((it) => !rows[it.id]?.saved)
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      side="auto"
+      title={`이름 미정 ${items.length}개 — 일괄 편집`}
+      description="좌표만 있는 항목을 한 화면에서 이름 지정해요. 후보를 누르면 입력칸에 채워져요."
+      maxBottomHeightVh={90}
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose}>닫기</Button>
+          <Button
+            variant="primary"
+            onClick={handleSaveAll}
+            loading={savingAll}
+            disabled={pending.length === 0}
+          >
+            입력한 항목 모두 저장
+          </Button>
+        </>
+      }
+    >
+      <div className="px-5 py-4 space-y-3">
+        {items.length === 0 && (
+          <p className="text-sm text-fg-muted">이름 미정 항목이 없어요.</p>
+        )}
+        {items.map((it) => {
+          const row = rows[it.id]
+          if (!row) return null
+          const coordText =
+            it.lat != null && it.lng != null
+              ? `${it.lat.toFixed(5)}, ${it.lng.toFixed(5)}`
+              : '좌표 없음'
+          return (
+            <div
+              key={it.id}
+              className={`border border-border rounded-lg p-3 space-y-2 ${
+                row.saved ? 'opacity-60' : ''
+              }`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs text-fg-subtle font-mono">{coordText}</p>
+                <p className="text-[11px] text-fg-subtle truncate" title={it.name}>
+                  현재: {it.name}
+                </p>
+              </div>
+
+              {row.loading ? (
+                <p className="text-xs text-fg-subtle">후보 찾는 중…</p>
+              ) : row.suggestion ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    setRows((prev) => ({
+                      ...prev,
+                      [it.id]: { ...prev[it.id], draft: row.suggestion ?? '' },
+                    }))
+                  }
+                  className="w-full text-left text-xs px-2 py-1.5 rounded border border-border bg-bg-subtle hover:bg-border text-fg-muted truncate"
+                  title={row.suggestion}
+                  disabled={row.saved}
+                >
+                  후보: {row.suggestion}
+                </button>
+              ) : (
+                <p className="text-xs text-fg-subtle">후보 없음 — 직접 입력하세요.</p>
+              )}
+
+              <div className="flex items-center gap-2">
+                <Input
+                  hideLabel
+                  label="이름"
+                  value={row.draft}
+                  onChange={(e) =>
+                    setRows((prev) => ({
+                      ...prev,
+                      [it.id]: { ...prev[it.id], draft: e.target.value, error: null },
+                    }))
+                  }
+                  placeholder="장소 이름"
+                  disabled={row.saved}
+                />
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => saveOne(it.id, row.draft)}
+                  disabled={row.saved || !row.draft.trim()}
+                >
+                  {row.saved ? '저장됨' : '저장'}
+                </Button>
+              </div>
+              {row.error && (
+                <p className="text-xs text-critical-fg">{row.error}</p>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </Sheet>
+  )
+}
+
+export function countUnnamed(items: TripItem[]): number {
+  return items.filter((it) => it.name.startsWith(UNNAMED_PREFIX)).length
+}
+
+export function filterUnnamed(items: TripItem[]): TripItem[] {
+  return items.filter((it) => it.name.startsWith(UNNAMED_PREFIX))
+}


### PR DESCRIPTION
## 관련 이슈
Closes #204

## 변경 이유
#200 폴백 체인으로 좌표만 있는 핀에 `📍` prefix 이름이 자동 부여되지만, 사용자가 import 직후 한 번에 정리할 UI 가 없어 후속 정리가 번거로웠다.

## 변경 범위
- `components/Items/UnnamedBulkEditDialog.tsx` 신규
  - `📍` prefix 항목을 모아 시트에서 표시
  - 각 행: 좌표 텍스트 + reverse geocode 후보(자동 prefetch, 클릭하면 입력칸에 채워짐) + 직접 입력 + 개별 저장
  - 푸터: 입력한 모든 항목 일괄 저장
- `app/trip/[tripId]/list/page.tsx`
  - 헤더 아래 'count > 0' 일 때만 노출되는 배너 CTA
  - 다이얼로그 마운트

## 검증
- `npx tsc --noEmit` 통과
- `npm run build` 통과
- 사용자 시나리오: gmaps 다수 핀 import 후 list 진입 → 배너 노출 → 시트 열림 → 후보 선택/직접 입력 → 개별·일괄 저장

## 남은 작업 / 리스크
- 미리보기 미니맵은 후속 (좌표 텍스트로만 표시)
- reverse geocode 결과 캐싱 없음 — Nominatim rate limit 도달 시 후보 누락 가능. 후속 PR 후보.