### PR TITLE
feat(wizard): #227 지역·베이스캠프 입력 자동완성 (Nominatim)

### DIFF
--- a/app/dashboard/new/NewTripWizard.tsx
+++ b/app/dashboard/new/NewTripWizard.tsx
@@ -8,6 +8,7 @@ import { mutate as globalMutate } from 'swr'
 import { ArrowLeft, Check } from 'lucide-react'
 import Button from '@/components/UI/Button'
 import { Input } from '@/components/UI/Input'
+import LocationAutocompleteInput from '@/components/UI/LocationAutocompleteInput'
 import { useToast } from '@/components/UI/Toast'
 import { cn } from '@/lib/cn'
 import { SUPPORTED_CURRENCIES, type CurrencyCode } from '@/lib/currency'
@@ -316,14 +317,17 @@ function Step3({
   const isTouch = useIsTouchDevice()
   return (
     <div className="space-y-3">
-      <Input
+      <LocationAutocompleteInput
         label="지역"
         value={region}
-        onChange={(e) => setRegion(e.target.value)}
+        onChange={setRegion}
+        onSelectCandidate={(c) => {
+          setCenter({ lat: c.lat, lng: c.lng, zoom: center?.zoom ?? 11, source: 'auto' })
+        }}
         placeholder="예: 일본 오사카"
         autoFocus={!isTouch}
       />
-      <p className="text-xs text-fg-subtle">국가·도시·테마 등 자유롭게.</p>
+      <p className="text-xs text-fg-subtle">국가·도시·테마 등 자유롭게. 인식되지 않아도 진행할 수 있어요.</p>
       <CenterPicker region={region} value={center} onChange={setCenter} />
     </div>
   )
@@ -348,10 +352,10 @@ function Step4({
   return (
     <div className="space-y-4">
       <div>
-        <Input
+        <LocationAutocompleteInput
           label="베이스캠프 (숙소)"
           value={basecamp}
-          onChange={(e) => setBasecamp(e.target.value)}
+          onChange={setBasecamp}
           placeholder="예: 난바 인근 호텔"
           autoFocus={!isTouch}
         />

--- a/components/UI/LocationAutocompleteInput.tsx
+++ b/components/UI/LocationAutocompleteInput.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Input } from './Input'
+
+export interface LocationCandidate {
+  display: string
+  lat: number
+  lng: number
+}
+
+interface Props {
+  label: string
+  value: string
+  onChange: (next: string) => void
+  /** 후보 선택 시 좌표까지 전달. */
+  onSelectCandidate?: (c: LocationCandidate) => void
+  placeholder?: string
+  hint?: string
+  autoFocus?: boolean
+  /** 디바운스 ms. 기본 300. */
+  debounceMs?: number
+  /** 최소 입력 길이. 기본 2. */
+  minChars?: number
+}
+
+interface NominatimResult {
+  display_name?: string
+  lat?: string
+  lon?: string
+}
+
+/**
+ * Nominatim 기반 위치 자동완성 입력.
+ * 입력 도중 후보를 노출해 "인식되는 표현" 가시화. 0건이면 명시적 안내.
+ * 후보 선택은 선택사항 — 입력 자체는 자유 텍스트로 유지된다.
+ */
+export default function LocationAutocompleteInput({
+  label,
+  value,
+  onChange,
+  onSelectCandidate,
+  placeholder,
+  hint,
+  autoFocus,
+  debounceMs = 300,
+  minChars = 2,
+}: Props) {
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [candidates, setCandidates] = useState<LocationCandidate[]>([])
+  const [searched, setSearched] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const trimmed = useMemo(() => value.trim(), [value])
+
+  useEffect(() => {
+    if (!open) return
+    if (trimmed.length < minChars) {
+      setCandidates([])
+      setSearched(false)
+      return
+    }
+    const handle = window.setTimeout(async () => {
+      abortRef.current?.abort()
+      const ctrl = new AbortController()
+      abortRef.current = ctrl
+      setLoading(true)
+      try {
+        const url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(
+          trimmed,
+        )}&format=json&limit=5&accept-language=ko`
+        const res = await fetch(url, {
+          signal: ctrl.signal,
+          headers: { Accept: 'application/json' },
+        })
+        if (!res.ok) throw new Error('nominatim error')
+        const data = (await res.json()) as NominatimResult[]
+        const next: LocationCandidate[] = data
+          .filter(
+            (r) =>
+              typeof r.display_name === 'string' &&
+              typeof r.lat === 'string' &&
+              typeof r.lon === 'string',
+          )
+          .map((r) => ({
+            display: r.display_name as string,
+            lat: parseFloat(r.lat as string),
+            lng: parseFloat(r.lon as string),
+          }))
+        setCandidates(next)
+        setSearched(true)
+      } catch (e) {
+        if ((e as Error).name !== 'AbortError') {
+          setCandidates([])
+          setSearched(true)
+        }
+      } finally {
+        setLoading(false)
+      }
+    }, debounceMs)
+    return () => window.clearTimeout(handle)
+  }, [trimmed, open, debounceMs, minChars])
+
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      const t = e.target as Node
+      if (containerRef.current && !containerRef.current.contains(t)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onDocClick)
+    return () => document.removeEventListener('mousedown', onDocClick)
+  }, [])
+
+  function pick(c: LocationCandidate) {
+    onChange(c.display)
+    onSelectCandidate?.(c)
+    setOpen(false)
+  }
+
+  const showList = open && trimmed.length >= minChars
+  const noResult = showList && !loading && searched && candidates.length === 0
+
+  return (
+    <div ref={containerRef} className="relative">
+      <Input
+        label={label}
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value)
+          setOpen(true)
+          setSearched(false)
+        }}
+        onFocus={() => setOpen(true)}
+        placeholder={placeholder}
+        hint={hint}
+        autoFocus={autoFocus}
+        autoComplete="off"
+      />
+      {showList && (
+        <div className="absolute z-30 mt-1 w-full rounded-lg border border-border bg-bg-elevated shadow-lg max-h-64 overflow-y-auto">
+          {loading && (
+            <p className="px-3 py-2 text-xs text-fg-subtle">후보 찾는 중…</p>
+          )}
+          {!loading && candidates.length > 0 && (
+            <ul role="listbox">
+              {candidates.map((c, i) => (
+                <li key={`${c.lat},${c.lng},${i}`} role="option" aria-selected="false">
+                  <button
+                    type="button"
+                    onClick={() => pick(c)}
+                    className="w-full text-left px-3 py-2 text-sm text-fg hover:bg-bg-subtle focus:bg-bg-subtle focus:outline-none"
+                  >
+                    <span className="block truncate">{c.display}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+          {noResult && (
+            <p className="px-3 py-2 text-xs text-warning-fg">
+              인식되는 이름이 없어요. 그대로 진행해도 돼요.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## 관련 이슈
Closes #227

## 변경 이유
새 여행 마법사 지역 입력은 자유 텍스트라 "어떤 이름이 인식되는지" 사용자가 알 수 없어 시도-실패 루프에 빠지기 쉬웠다. 입력 도중 후보를 노출해 가시화한다.

## 변경 범위
- `components/UI/LocationAutocompleteInput.tsx` 신규
  - Nominatim search?q=&limit=5, debounce 300ms, accept-language=ko
  - 입력 ≥2자에서 후보 드롭다운 노출
  - 후보 클릭 시 `onSelectCandidate({display, lat, lng})` 콜백
  - 0건일 때 "인식되는 이름이 없어요. 그대로 진행해도 돼요." 안내
  - 입력 자체는 자유 텍스트 유지 — 인식 실패해도 다음 단계 진행 가능
- `app/dashboard/new/NewTripWizard.tsx`
  - Step3 지역 → 새 컴포넌트로 교체, 후보 선택 시 CenterPicker center 자동 세팅
  - Step4 베이스캠프 → 동일 컴포넌트로 교체 (재사용)

## 검증
- `npx tsc --noEmit` 통과
- `npm run build` 통과
- 시나리오: 마법사 → 지역 입력 → 후보 노출 → 클릭 → 지도 핀 자동 이동. 의도적으로 인식 안 되는 입력("zzzzz") → 0건 안내 → 그대로 진행 가능.

## 남은 작업 / 리스크
- Nominatim 무료 공개 인스턴스 의존 — 대량 동시 요청 시 rate limit. debounce + minChars 로 완화하나 트래픽 증가 시 자체 프록시·캐시 필요.
- 키보드 네비게이션(↑/↓/Enter) 은 후속 polish (현재 클릭 only).