### PR TITLE
feat(perf): #234 Web Vitals baseline 측정 인프라

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -10,6 +10,7 @@ import AuthStateSync from '@/components/Auth/AuthStateSync'
 import TopProgressBar from '@/components/Layout/TopProgressBar'
 import KeyboardShortcuts from '@/components/Layout/KeyboardShortcuts'
 import AvatarDropdown from '@/components/Layout/AvatarDropdown'
+import WebVitalsReporter from '@/components/Layout/WebVitalsReporter'
 
 export default function Providers({
   children,
@@ -30,6 +31,9 @@ export default function Providers({
                 추가할 때 정적 렌더링 bail-out 을 막기 위한 안전 장치. */}
             <Suspense fallback={null}>
               <TopProgressBar />
+            </Suspense>
+            <Suspense fallback={null}>
+              <WebVitalsReporter />
             </Suspense>
             <KeyboardShortcuts />
             <AvatarDropdown />

--- a/components/Layout/WebVitalsReporter.tsx
+++ b/components/Layout/WebVitalsReporter.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useReportWebVitals } from 'next/web-vitals'
+import { usePathname } from 'next/navigation'
+import { useEffect, useRef } from 'react'
+
+interface VitalsSample {
+  name: string
+  value: number
+  id: string
+  rating?: string
+  navigationType?: string
+  pathname: string
+  ts: number
+}
+
+declare global {
+  interface Window {
+    __tpVitals?: VitalsSample[]
+  }
+}
+
+const MAX_BUFFER = 200
+
+/**
+ * #234 — 페이지 전환 baseline 측정.
+ * Next.js 내장 useReportWebVitals 로 LCP/INP/CLS/FCP/TTFB 수집.
+ * - 콘솔에 구조화된 로그 출력 (`[web-vitals]` prefix)
+ * - window.__tpVitals 에 마지막 200건 버퍼링 — 데스크탑 콘솔에서 `copy(__tpVitals)` 로 추출
+ *
+ * 측정 대상 핵심 전환 (이슈 #234):
+ *  1) /login → /dashboard
+ *  2) /dashboard → /trip/[id]/list
+ *  3) list ↔ map ↔ schedule
+ *  4) /trip/[id]/gmaps-import → /trip/[id]/list
+ *
+ * 최적화는 후속 PR 에서 baseline 데이터 기준으로 진행.
+ */
+export default function WebVitalsReporter() {
+  const pathname = usePathname()
+  const pathnameRef = useRef(pathname)
+
+  useEffect(() => {
+    pathnameRef.current = pathname
+  }, [pathname])
+
+  useReportWebVitals((metric) => {
+    const sample: VitalsSample = {
+      name: metric.name,
+      value: Math.round(metric.value * 100) / 100,
+      id: metric.id,
+      rating: (metric as { rating?: string }).rating,
+      navigationType: (metric as { navigationType?: string }).navigationType,
+      pathname: pathnameRef.current,
+      ts: Date.now(),
+    }
+
+    if (typeof window !== 'undefined') {
+      if (!window.__tpVitals) window.__tpVitals = []
+      window.__tpVitals.push(sample)
+      if (window.__tpVitals.length > MAX_BUFFER) {
+        window.__tpVitals.splice(0, window.__tpVitals.length - MAX_BUFFER)
+      }
+    }
+
+    if (
+      typeof process !== 'undefined' &&
+      (process.env.NODE_ENV !== 'production' ||
+        process.env.NEXT_PUBLIC_VITALS_DEBUG === '1')
+    ) {
+      // eslint-disable-next-line no-console
+      console.log('[web-vitals]', sample)
+    }
+  })
+
+  return null
+}


### PR DESCRIPTION
## 관련 이슈
Refs #234 (측정 단계만, 최적화는 후속 PR)

## 변경 이유
#234 가 "측정 우선" 원칙을 명시. 어떤 전환이 실제로 느린지 데이터 없이는 최적화 우선순위 결정 불가. 본 PR 은 baseline 수집 인프라까지 닫는다.

## 변경 범위
- `components/Layout/WebVitalsReporter.tsx` 신규
  - Next.js 내장 `useReportWebVitals` 로 LCP / INP / CLS / FCP / TTFB 수집
  - 샘플에 `pathname`, `navigationType`, `rating`, `ts` 포함
  - dev 또는 `NEXT_PUBLIC_VITALS_DEBUG=1` 일 때 `[web-vitals]` prefix 콘솔 로그
  - `window.__tpVitals` 에 최근 200건 버퍼 — 데스크탑 콘솔에서 `copy(__tpVitals)` 로 JSON 추출
- `app/providers.tsx` — Suspense 안에 마운트

## 측정 대상 핵심 전환 (이슈에 못박음)
1. `/login → /dashboard`
2. `/dashboard → /trip/[id]/list`
3. `list ↔ map ↔ schedule` 탭 전환
4. `/trip/[id]/gmaps-import → /trip/[id]/list`

## 검증
- `npx tsc --noEmit` 통과
- `npm run build` 통과
- 로컬 `npm run dev` 에서 `[web-vitals]` 콘솔 로그 발생 확인 (정성)

## 남은 작업 / 리스크
- 본 PR 은 **측정 인프라만**. baseline 수집·병목 식별·최적화는 후속 PR.
- 프로덕션 자동 수집(서버 푸시)은 비용·PII 고려 후 별도 결정. 현재는 사용자 콘솔에서 수동 추출.