### PR TITLE
feat(ui): #240 카테고리 색상 제거 — 아이콘만으로 식별

### DIFF
--- a/components/Items/ItemCard.tsx
+++ b/components/Items/ItemCard.tsx
@@ -29,7 +29,6 @@ export default function ItemCard({
   const trip = useOptionalTrip()
   const tripCurrency = normalizeCurrency(trip?.currency)
   const scheduleLabel = formatScheduleLabel(item)
-  const accentColor = CATEGORY_META[item.category]?.color ?? '#cbd5e1'
 
   useEffect(() => {
     if (editingName !== null) inputRef.current?.select()
@@ -83,12 +82,6 @@ export default function ItemCard({
             : 'border-border hover:border-border-strong',
       )}
     >
-      {/* 카테고리 컬러바 */}
-      <span
-        aria-hidden="true"
-        className="absolute left-0 top-0 bottom-0 w-1"
-        style={{ backgroundColor: accentColor }}
-      />
       <div className="flex items-start justify-between gap-2 pl-2">
         <div className="flex items-center gap-2.5 min-w-0">
           {(() => {

--- a/components/Map/MapSidePanel.tsx
+++ b/components/Map/MapSidePanel.tsx
@@ -270,20 +270,17 @@ function CandidatesView({
           <CategoryFilterChip
             active={categoryFilter === null}
             onClick={() => setCategoryFilter(null)}
-            color={null}
           >
             모두
             <span className="tabular ml-1 opacity-70">{items.length}</span>
           </CategoryFilterChip>
           {CATEGORY_OPTIONS.filter((c) => (counts.get(c) ?? 0) > 0).map((c) => {
             const active = categoryFilter === c
-            const color = CATEGORY_META[c]?.color ?? '#cbd5e1'
             return (
               <CategoryFilterChip
                 key={c}
                 active={active}
                 onClick={() => setCategoryFilter(active ? null : c)}
-                color={color}
               >
                 {c}
                 <span className="tabular ml-1 opacity-70">{counts.get(c)}</span>
@@ -310,7 +307,6 @@ function CandidatesView({
         <ul className="min-h-0 flex-1 divide-y divide-border overflow-y-auto">
           {filtered.map((item) => {
             const active = item.id === selectedItemId
-            const color = CATEGORY_META[item.category]?.color ?? '#cbd5e1'
             const Icon = CATEGORY_META[item.category]?.Icon
             const isConfirmed = item.trip_priority === '확정'
             return (
@@ -329,11 +325,6 @@ function CandidatesView({
                     active ? 'bg-accent-subtle' : 'hover:bg-bg-subtle',
                   )}
                 >
-                  <span
-                    className="mt-1 inline-block h-2 w-2 flex-shrink-0 rounded-full"
-                    style={{ backgroundColor: color }}
-                    aria-hidden="true"
-                  />
                   <span className="min-w-0 flex-1">
                     <span className="flex items-center gap-1.5">
                       {Icon ? <Icon size={12} className="flex-shrink-0 text-fg-muted" aria-hidden="true" /> : null}
@@ -365,12 +356,10 @@ function CandidatesView({
 function CategoryFilterChip({
   active,
   onClick,
-  color,
   children,
 }: {
   active: boolean
   onClick: () => void
-  color: string | null
   children: React.ReactNode
 }) {
   return (
@@ -387,13 +376,6 @@ function CategoryFilterChip({
           : 'bg-bg-subtle text-fg-muted hover:bg-border',
       )}
     >
-      {color && (
-        <span
-          aria-hidden="true"
-          className="inline-block h-2 w-2 rounded-full"
-          style={{ backgroundColor: color }}
-        />
-      )}
       {children}
     </button>
   )

--- a/components/Schedule/CategoryStackBar.tsx
+++ b/components/Schedule/CategoryStackBar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { Category } from '@/types'
-import { CATEGORY_META } from '@/lib/itemOptions'
+import { CATEGORY_STACK_COLORS } from '@/lib/itemOptions'
 
 interface CategoryStackBarProps {
   breakdown: { category: Category; count: number }[]
@@ -19,7 +19,7 @@ export default function CategoryStackBar({ breakdown }: CategoryStackBarProps) {
     >
       {breakdown.map(({ category, count }) => {
         const pct = (count / total) * 100
-        const color = CATEGORY_META[category]?.color ?? '#cbd5e1'
+        const color = CATEGORY_STACK_COLORS[category] ?? '#cbd5e1'
         return (
           <div
             key={category}

--- a/components/Schedule/DayTimeline.tsx
+++ b/components/Schedule/DayTimeline.tsx
@@ -39,7 +39,6 @@ export default function DayTimeline({ items, selectedItemId, onSelectItem }: Day
         const prev = idx > 0 ? items[idx - 1] : null
         const km = prev ? distance(prev, item) : null
         const Icon = CATEGORY_META[item.category]?.Icon
-        const color = CATEGORY_META[item.category]?.color ?? '#cbd5e1'
         const active = item.id === selectedItemId
         return (
           <Fragment key={item.id}>
@@ -60,10 +59,7 @@ export default function DayTimeline({ items, selectedItemId, onSelectItem }: Day
                   active ? 'bg-bg-subtle' : 'hover:bg-bg-subtle'
                 }`}
               >
-                <span
-                  className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[10px] font-bold text-white"
-                  style={{ backgroundColor: color }}
-                >
+                <span className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-fg-muted text-[10px] font-bold text-bg-elevated">
                   {idx + 1}
                 </span>
                 <span className="min-w-0 flex-1">

--- a/lib/itemOptions.ts
+++ b/lib/itemOptions.ts
@@ -55,19 +55,38 @@ export const PLACEHOLDER_LABELS = {
   reservation_status: '예약 정보 없음',
 } as const
 
-// 색은 카테고리 dot 보조용. 채도 한 단계 낮춤 (Tailwind 400 톤 정렬) — 무지개 인상 완화.
-export const CATEGORY_META: Record<Category, { Icon: LucideIcon; color: string }> = {
-  교통: { Icon: Bus, color: '#94a3b8' },           // slate-400 (유지)
-  숙박: { Icon: Hotel, color: '#38bdf8' },         // sky-400
-  명소: { Icon: Landmark, color: '#fb923c' },      // orange-400
-  식당: { Icon: UtensilsCrossed, color: '#f87171' }, // red-400
-  카페: { Icon: Coffee, color: '#b45309' },        // amber-700 (밝게)
-  쇼핑: { Icon: ShoppingBag, color: '#f472b6' },   // pink-400
-  문화시설: { Icon: Palette, color: '#a78bfa' },   // violet-400
-  '공연·스포츠': { Icon: Drama, color: '#34d399' }, // emerald-400
-  액티비티: { Icon: Target, color: '#fbbf24' },    // amber-400
-  휴양: { Icon: Palmtree, color: '#4ade80' },      // green-400
-  기타: { Icon: Bookmark, color: '#cbd5e1' },      // slate-300 (유지)
+// 카테고리 식별은 아이콘 + 라벨 텍스트로만 한다 (#240). 색상은 정보 전달이 안 되고
+// 시각 잡음만 더해 제거했다. 분포 비교가 목적인 CategoryStackBar 만 예외로
+// 아래 CATEGORY_STACK_COLORS 를 쓴다.
+export const CATEGORY_META: Record<Category, { Icon: LucideIcon }> = {
+  교통: { Icon: Bus },
+  숙박: { Icon: Hotel },
+  명소: { Icon: Landmark },
+  식당: { Icon: UtensilsCrossed },
+  카페: { Icon: Coffee },
+  쇼핑: { Icon: ShoppingBag },
+  문화시설: { Icon: Palette },
+  '공연·스포츠': { Icon: Drama },
+  액티비티: { Icon: Target },
+  휴양: { Icon: Palmtree },
+  기타: { Icon: Bookmark },
+}
+
+// CategoryStackBar 전용 팔레트. 스택 바는 카테고리 분포 비교가 목적이라
+// 색상이 정보 그 자체이므로 여기서만 카테고리별 색을 유지한다 (#240 결정).
+// 다른 곳에서는 절대 import 하지 않는다.
+export const CATEGORY_STACK_COLORS: Record<Category, string> = {
+  교통: '#94a3b8',       // slate-400
+  숙박: '#38bdf8',       // sky-400
+  명소: '#fb923c',       // orange-400
+  식당: '#f87171',       // red-400
+  카페: '#b45309',       // amber-700
+  쇼핑: '#f472b6',       // pink-400
+  문화시설: '#a78bfa',   // violet-400
+  '공연·스포츠': '#34d399', // emerald-400
+  액티비티: '#fbbf24',   // amber-400
+  휴양: '#4ade80',       // green-400
+  기타: '#cbd5e1',       // slate-300
 }
 
 interface PriorityMeta {


### PR DESCRIPTION
## 관련 이슈

Closes #240

## 변경 이유

카테고리 11개(`교통`·`숙박`·`명소`·`식당`·`카페`·`쇼핑`·`문화시설`·`공연·스포츠`·`액티비티`·`휴양`·`기타`)마다 색상이 지정돼 있었으나, 색상 → 카테고리 매핑을 기억할 수 없어 정보 전달이 되지 않고 시각 잡음만 더했다. ItemCard 좌측 컬러바·하단 dot 은 notification dot 처럼 오인됐다. 카테고리 식별을 **아이콘 + 라벨 텍스트** 로만 통일한다.

## 변경 범위

- **`lib/itemOptions.ts`** — `CATEGORY_META` 의 `color` 필드 제거 (Icon 만 유지). 분포 비교가 목적이라 색상이 정보 그 자체인 `CategoryStackBar` 전용으로 `CATEGORY_STACK_COLORS` 팔레트를 분리 (해당 컴포넌트 외 import 금지).
- **`components/Items/ItemCard.tsx`** — 좌측 카테고리 컬러바 제거. 아이콘은 기존 중립색(`text-fg-muted`) 유지.
- **`components/Schedule/DayTimeline.tsx`** — 순번 원 배경을 카테고리색 → 중립(`bg-fg-muted` / `text-bg-elevated`, 지도 number marker 와 동일 톤).
- **`components/Schedule/CategoryStackBar.tsx`** — `CATEGORY_STACK_COLORS` 사용으로 분포 색 유지(이슈 결정).
- **`components/Map/MapSidePanel.tsx`** — 리스트 항목 컬러 dot · 카테고리 필터칩 컬러 dot 제거 (`CategoryFilterChip` 의 `color` prop 삭제). 아이콘만으로 식별.

지도 마커(`TripPlannerMap`·`ResearchMap`)는 이미 `currentColor` + CSS 토큰(`.tp-chip-marker`) 기반 중립이라 카테고리 색을 쓰지 않음 → 변경 불필요. 이슈의 "지도 마커 포함" 결정은 이미 충족된 상태.

### 이슈 미결정 사항 처리

- **CategoryStackBar**: `색상 유지` 선택 → 전용 팔레트로 분리.
- **지도 마커**: `이번 이슈 포함` 선택 → 확인 결과 이미 중립이라 추가 변경 없음.

## 검증

- `npm run build` 통과.
- `npm run lint` — 본 PR 변경 파일 0 에러. (`resolver.ts` 의 `no-require-imports` 2건은 본 PR 와 무관한 기존 문제.)
- 잔여 `CATEGORY_META[...].color` 참조 0건 grep 확인.

## 남은 작업 / 리스크

- 기존 `resolver.ts` lint 에러는 별도 정리 필요(본 PR 범위 외).

### Basics-First 체크

- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? — 무관 (시각만 변경)
- [x] 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — 무관
- [x] 모달·시트는 콘텐츠 양에 맞게 표시되는가? — 무관
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — 무관
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — list·map·schedule 전 표시 지점 동시 변경
