### PR TITLE
feat(brand): #229 제품명 노출 — Waypost 워드마크 + 표면·메타·아이콘

### DIFF
--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -10,16 +10,21 @@ export default function AppleIcon() {
         style={{
           width: '100%',
           height: '100%',
-          background: '#0D9488',
+          background: '#16243F',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
         }}
       >
         <svg width="62%" height="62%" viewBox="0 0 32 32" fill="none">
+          <circle cx="9.5" cy="22.5" r="2.6" fill="#C6A04E" />
+          <circle cx="22.5" cy="9.5" r="2.6" fill="#C6A04E" />
           <path
-            d="M16 6C12.134 6 9 9.134 9 13C9 18.25 16 26 16 26C16 26 23 18.25 23 13C23 9.134 19.866 6 16 6ZM16 16C14.343 16 13 14.657 13 13C13 11.343 14.343 10 16 10C17.657 10 19 11.343 19 13C19 14.657 17.657 16 16 16Z"
-            fill="white"
+            d="M9.5 22.5 C 9.5 14 22.5 18 22.5 9.5"
+            stroke="#C6A04E"
+            strokeWidth="2.4"
+            fill="none"
+            strokeLinecap="round"
           />
         </svg>
       </div>

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Compass, LogOut, MapPin, MoreVertical, Plus, Search, SearchX, Trash2, User } from 'lucide-react'
 import ThemeToggle from '@/components/Theme/ThemeToggle'
+import Wordmark from '@/components/Brand/Wordmark'
 import { Input } from '@/components/UI/Input'
 import Button from '@/components/UI/Button'
 import EmptyState from '@/components/UI/EmptyState'
@@ -129,6 +130,7 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
       <header className="border-b border-border bg-bg-elevated">
         <div className="max-w-5xl mx-auto px-4 md:px-8 py-4 flex items-center justify-between gap-4">
           <div className="min-w-0">
+            <Wordmark size="sm" className="mb-1.5" />
             <h1 className="text-lg md:text-xl font-bold text-fg">내 여행</h1>
             {userEmail && (
               <p className="text-xs text-fg-subtle mt-0.5 truncate">{userEmail}</p>

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,4 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <rect width="32" height="32" rx="8" fill="#0D9488"/>
-  <path d="M16 6C12.134 6 9 9.134 9 13C9 18.25 16 26 16 26C16 26 23 18.25 23 13C23 9.134 19.866 6 16 6ZM16 16C14.343 16 13 14.657 13 13C13 11.343 14.343 10 16 10C17.657 10 19 11.343 19 13C19 14.657 17.657 16 16 16Z" fill="white"/>
+  <rect width="32" height="32" rx="8" fill="#16243F"/>
+  <circle cx="9.5" cy="22.5" r="2.6" fill="#C6A04E"/>
+  <circle cx="22.5" cy="9.5" r="2.6" fill="#C6A04E"/>
+  <path d="M9.5 22.5 C 9.5 14 22.5 18 22.5 9.5" stroke="#C6A04E" stroke-width="2.4" fill="none" stroke-linecap="round"/>
 </svg>

--- a/app/icon0.tsx
+++ b/app/icon0.tsx
@@ -10,7 +10,7 @@ export default function Icon() {
         style={{
           width: '100%',
           height: '100%',
-          background: '#0D9488',
+          background: '#16243F',
           borderRadius: '22%',
           display: 'flex',
           alignItems: 'center',
@@ -18,9 +18,14 @@ export default function Icon() {
         }}
       >
         <svg width="62%" height="62%" viewBox="0 0 32 32" fill="none">
+          <circle cx="9.5" cy="22.5" r="2.6" fill="#C6A04E" />
+          <circle cx="22.5" cy="9.5" r="2.6" fill="#C6A04E" />
           <path
-            d="M16 6C12.134 6 9 9.134 9 13C9 18.25 16 26 16 26C16 26 23 18.25 23 13C23 9.134 19.866 6 16 6ZM16 16C14.343 16 13 14.657 13 13C13 11.343 14.343 10 16 10C17.657 10 19 11.343 19 13C19 14.657 17.657 16 16 16Z"
-            fill="white"
+            d="M9.5 22.5 C 9.5 14 22.5 18 22.5 9.5"
+            stroke="#C6A04E"
+            strokeWidth="2.4"
+            fill="none"
+            strokeLinecap="round"
           />
         </svg>
       </div>

--- a/app/icon1.tsx
+++ b/app/icon1.tsx
@@ -10,7 +10,7 @@ export default function Icon() {
         style={{
           width: '100%',
           height: '100%',
-          background: '#0D9488',
+          background: '#16243F',
           borderRadius: '22%',
           display: 'flex',
           alignItems: 'center',
@@ -18,9 +18,14 @@ export default function Icon() {
         }}
       >
         <svg width="62%" height="62%" viewBox="0 0 32 32" fill="none">
+          <circle cx="9.5" cy="22.5" r="2.6" fill="#C6A04E" />
+          <circle cx="22.5" cy="9.5" r="2.6" fill="#C6A04E" />
           <path
-            d="M16 6C12.134 6 9 9.134 9 13C9 18.25 16 26 16 26C16 26 23 18.25 23 13C23 9.134 19.866 6 16 6ZM16 16C14.343 16 13 14.657 13 13C13 11.343 14.343 10 16 10C17.657 10 19 11.343 19 13C19 14.657 17.657 16 16 16Z"
-            fill="white"
+            d="M9.5 22.5 C 9.5 14 22.5 18 22.5 9.5"
+            stroke="#C6A04E"
+            strokeWidth="2.4"
+            fill="none"
+            strokeLinecap="round"
           />
         </svg>
       </div>

--- a/app/icon2.tsx
+++ b/app/icon2.tsx
@@ -10,16 +10,21 @@ export default function Icon() {
         style={{
           width: '100%',
           height: '100%',
-          background: '#0D9488',
+          background: '#16243F',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
         }}
       >
         <svg width="50%" height="50%" viewBox="0 0 32 32" fill="none">
+          <circle cx="9.5" cy="22.5" r="2.6" fill="#C6A04E" />
+          <circle cx="22.5" cy="9.5" r="2.6" fill="#C6A04E" />
           <path
-            d="M16 6C12.134 6 9 9.134 9 13C9 18.25 16 26 16 26C16 26 23 18.25 23 13C23 9.134 19.866 6 16 6ZM16 16C14.343 16 13 14.657 13 13C13 11.343 14.343 10 16 10C17.657 10 19 11.343 19 13C19 14.657 17.657 16 16 16Z"
-            fill="white"
+            d="M9.5 22.5 C 9.5 14 22.5 18 22.5 9.5"
+            stroke="#C6A04E"
+            strokeWidth="2.4"
+            fill="none"
+            strokeLinecap="round"
           />
         </svg>
       </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,28 +5,28 @@ import Providers from './providers'
 import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 
 export const metadata: Metadata = {
-  title: 'Trip Planner',
-  description: '지도와 함께 만드는 여행 계획',
-  applicationName: 'Trip Planner',
+  title: 'Waypost',
+  description: '지도 위에서 후보를 모아 동선을 직접 깎는 여행 설계 도구',
+  applicationName: 'Waypost',
   appleWebApp: {
     capable: true,
     statusBarStyle: 'default',
-    title: 'Trip Planner',
+    title: 'Waypost',
   },
   formatDetection: {
     telephone: false,
   },
   openGraph: {
-    title: 'Trip Planner',
-    description: '지도와 함께 만드는 여행 계획',
+    title: 'Waypost',
+    description: '지도 위에서 후보를 모아 동선을 직접 깎는 여행 설계 도구',
     type: 'website',
   },
 }
 
 export const viewport = {
   themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
-    { media: '(prefers-color-scheme: dark)', color: '#0b1020' },
+    { media: '(prefers-color-scheme: light)', color: '#f4f6f8' },
+    { media: '(prefers-color-scheme: dark)', color: '#121821' },
   ],
   width: 'device-width',
   initialScale: 1,

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { clearAppCache } from '@/lib/clearAppCache'
 import { ErrorBanner } from '@/components/UI'
 import { useToast } from '@/components/UI/Toast'
+import { BrandMark, PRODUCT_NAME } from '@/components/Brand/Wordmark'
 import type { AuthErrorCode } from '@/lib/auth-errors'
 
 export default function LoginForm() {
@@ -86,22 +87,9 @@ export default function LoginForm() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-bg via-bg-subtle to-bg flex items-center justify-center p-4">
       <div className="w-full max-w-sm">
-        <div className="text-center mb-8">
-          <div className="w-12 h-12 bg-accent rounded-2xl flex items-center justify-center mx-auto mb-4">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="w-6 h-6 text-accent-fg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fillRule="evenodd"
-                d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </div>
-          <h1 className="text-2xl font-bold text-fg">trip-planner</h1>
+        <div className="flex flex-col items-center text-center mb-8">
+          <BrandMark size="lg" className="mb-3" />
+          <h1 className="text-2xl font-semibold tracking-tight text-fg">{PRODUCT_NAME}</h1>
           <p className="text-sm text-fg-subtle mt-1">로그인하여 여행을 계획하세요</p>
         </div>
 

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -2,16 +2,16 @@ import type { MetadataRoute } from 'next'
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: 'Trip Planner',
-    short_name: 'Trip Planner',
-    description: '지도와 함께 만드는 여행 계획',
+    name: 'Waypost',
+    short_name: 'Waypost',
+    description: '지도 위에서 후보를 모아 동선을 직접 깎는 여행 설계 도구',
     lang: 'ko',
     start_url: '/',
     scope: '/',
     display: 'standalone',
     orientation: 'portrait',
-    background_color: '#ffffff',
-    theme_color: '#0D9488',
+    background_color: '#f4f6f8',
+    theme_color: '#97762f',
     icons: [
       { src: '/icon.svg', sizes: 'any', type: 'image/svg+xml' },
       { src: '/icon0', sizes: '192x192', type: 'image/png', purpose: 'any' },

--- a/app/share/[token]/page.tsx
+++ b/app/share/[token]/page.tsx
@@ -33,12 +33,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const payload = await fetchSharedTrip(params.token)
   if (!payload) {
     return {
-      title: '공유 링크가 유효하지 않습니다 · Trip Planner',
+      title: '공유 링크가 유효하지 않습니다 · Waypost',
       description: '이 링크는 만료되었거나 회수되었습니다.',
       robots: { index: false, follow: false },
     }
   }
-  const title = `${payload.trip.title} · Trip Planner`
+  const title = `${payload.trip.title} · Waypost`
   const description = ogDescription(payload)
   return {
     title,
@@ -95,7 +95,7 @@ export default async function SharePage({ params }: Props) {
             href="/"
             className="mt-5 inline-flex items-center gap-1 text-sm font-medium text-accent hover:underline"
           >
-            Trip Planner 둘러보기
+            Waypost 둘러보기
             <ExternalLink className="size-3.5" aria-hidden />
           </Link>
         </div>
@@ -168,7 +168,7 @@ export default async function SharePage({ params }: Props) {
           href="/signup"
           className="mt-3 inline-flex items-center justify-center rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-fg hover:bg-accent-hover"
         >
-          Trip Planner 시작하기
+          Waypost 시작하기
         </Link>
       </footer>
     </main>

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useState } from 'react'
 import { clearAppCache } from '@/lib/clearAppCache'
 import { ErrorBanner } from '@/components/UI'
+import { BrandMark, PRODUCT_NAME } from '@/components/Brand/Wordmark'
 
 export default function SignupForm() {
   const [email, setEmail] = useState('')
@@ -41,23 +42,10 @@ export default function SignupForm() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-bg via-bg-subtle to-bg flex items-center justify-center p-4">
       <div className="w-full max-w-sm">
-        <div className="text-center mb-8">
-          <div className="w-12 h-12 bg-accent rounded-2xl flex items-center justify-center mx-auto mb-4">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="w-6 h-6 text-accent-fg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fillRule="evenodd"
-                d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </div>
+        <div className="flex flex-col items-center text-center mb-8">
+          <BrandMark size="lg" className="mb-3" />
           <h1 className="text-2xl font-bold text-fg">계정 만들기</h1>
-          <p className="text-sm text-fg-subtle mt-1">trip-planner</p>
+          <p className="text-sm text-fg-subtle mt-1">{PRODUCT_NAME}</p>
         </div>
 
         {submitted?.needsEmailConfirmation ? (

--- a/components/Brand/Wordmark.tsx
+++ b/components/Brand/Wordmark.tsx
@@ -1,0 +1,60 @@
+import { Route } from 'lucide-react'
+import { cn } from '@/lib/cn'
+
+/**
+ * 제품명 단일 소스. 이름 변경 시 이 상수 한 곳만 바꾸면 모든 표면에 반영된다.
+ * (브랜드 정본: docs/brand.md — 이슈 #231)
+ */
+export const PRODUCT_NAME = 'Waypost'
+
+type WordmarkSize = 'sm' | 'md' | 'lg'
+
+const SIZES: Record<WordmarkSize, { box: string; icon: string; text: string; gap: string }> = {
+  sm: { box: 'size-6', icon: 'size-3.5', text: 'text-base', gap: 'gap-1.5' },
+  md: { box: 'size-8', icon: 'size-[18px]', text: 'text-xl', gap: 'gap-2' },
+  lg: { box: 'size-11', icon: 'size-6', text: 'text-2xl', gap: 'gap-2.5' },
+}
+
+/**
+ * 동선·이정표 모티프(lucide `route`)를 브라스 원형 테두리 안에 둔 브랜드 마크.
+ * 아이콘 단독으로 쓸 때는 `aria-label` 을 부모가 제공한다.
+ */
+export function BrandMark({ size = 'md', className }: { size?: WordmarkSize; className?: string }) {
+  const s = SIZES[size]
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center justify-center rounded-full border-2 border-accent text-accent shrink-0',
+        s.box,
+        className,
+      )}
+    >
+      <Route className={s.icon} aria-hidden="true" />
+    </span>
+  )
+}
+
+interface WordmarkProps {
+  size?: WordmarkSize
+  /** 마크만 표시하고 텍스트는 숨김 (아이콘 단독). */
+  iconOnly?: boolean
+  className?: string
+}
+
+/**
+ * Waypost 워드마크: 마크 + 제품명. 헤더·로그인·빈 상태 등 브랜드 노출 표면에 사용.
+ */
+export default function Wordmark({ size = 'md', iconOnly = false, className }: WordmarkProps) {
+  const s = SIZES[size]
+  return (
+    <span
+      className={cn('inline-flex items-center', s.gap, className)}
+      aria-label={iconOnly ? PRODUCT_NAME : undefined}
+    >
+      <BrandMark size={size} />
+      {!iconOnly && (
+        <span className={cn('font-semibold tracking-tight text-fg', s.text)}>{PRODUCT_NAME}</span>
+      )}
+    </span>
+  )
+}

--- a/components/Layout/Navigation.tsx
+++ b/components/Layout/Navigation.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { ArrowLeft, List, Map, CalendarDays, Download, LogOut, MoreHorizontal, User, Loader2 } from 'lucide-react'
 import ThemeToggle from '@/components/Theme/ThemeToggle'
+import Wordmark from '@/components/Brand/Wordmark'
 import Sheet, { SheetSection } from '@/components/UI/Sheet'
 import { cn } from '@/lib/cn'
 import { logout } from '@/lib/auth-client'
@@ -193,10 +194,17 @@ export default function Navigation() {
         className="hidden md:flex md:flex-col md:fixed md:left-0 md:top-0 md:h-full md:w-44 z-50 bg-bg-elevated border-r border-border p-4"
         aria-label="기본 네비게이션"
       >
-        <div className="mb-6 px-3">
+        <div className="mb-6 px-3 space-y-3">
           <Link
             href="/dashboard"
-            className="inline-flex items-center gap-1.5 text-xs text-fg-subtle hover:text-fg transition-colors"
+            aria-label="Waypost 홈"
+            className="inline-flex rounded focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          >
+            <Wordmark size="sm" />
+          </Link>
+          <Link
+            href="/dashboard"
+            className="flex items-center gap-1.5 text-xs text-fg-subtle hover:text-fg transition-colors"
           >
             <ArrowLeft className="size-3.5" aria-hidden="true" />
             내 여행 목록


### PR DESCRIPTION
## 관련 이슈
Closes #229

## 변경 이유
제품명이 "Trip Planner"로 일반적이고 앱 표면(헤더/로그인/빈 상태/메타)에 노출되지 않아 "개인 프로토타입" 같은 인상을 줬다. 브랜드 디스커버리(#231)에서 확정한 이름 **Waypost** 와 동선·이정표 모티프를 표면 전체에 일관 노출한다.

## 변경 범위
- `components/Brand/Wordmark.tsx` 신규 — 워드마크/마크 단일 소스
  - `PRODUCT_NAME` 상수 한 곳만 바꾸면 모든 표면에 반영 (이름은 잠정·변경 가능 전제)
  - `Wordmark`(마크+이름) / `BrandMark`(마크 단독), size sm/md/lg
  - 마크는 lucide `route`(동선·이정표 모티프)를 브라스 원형 테두리 안에 배치
- 표면 배치
  - 글로벌 데스크탑 사이드바 상단 (`Navigation.tsx`)
  - 로그인 / 가입 화면 (`LoginForm` / `SignupForm`) — 기존 teal 핀 SVG 제거, 마크+제품명 h1
  - 대시보드 헤더 (`DashboardClient`)
  - 공유 페이지 텍스트/메타 "Trip Planner" → "Waypost"
- 메타/PWA: `layout.tsx`(title/OG/appleWebApp/themeColor) · `manifest.ts`(name/short_name/theme_color) → Waypost + 브랜드 팔레트
- favicon/아이콘: `icon.svg` + `icon0/1/2` + `apple-icon` 을 teal 핀 → 잉크 네이비 바탕 + 브라스 동선 마크로 교체

## 검증
- `npm run build` 성공.
- 사용자 노출 "Trip Planner"/"trip-planner" 문자열 grep 0건 (내부 storage key 제외).
- 이름 변경 시 `PRODUCT_NAME` 단일 수정으로 전 표면 반영됨을 컴포넌트 구조로 보장.

## 남은 작업 / 리스크
- 색상 토큰의 실제 globals.css/Tailwind 전수 적용은 #228 에서 진행(본 PR은 브랜드 노출 + 아이콘 색만 직접 지정).
- 이름 Waypost 는 working name (정식 출시 전 변경 가능).

---
- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름"이 보이는가? — 대시보드/헤더에 trip 컨텍스트 유지, 브랜드 워드마크 추가(기존 trip 이름 표시 회귀 없음)
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — N/A (브랜딩 노출 변경, 동작 변경 없음)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? — 변경 없음
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — 변경 없음
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — 데스크탑 사이드바·모바일 로그인/가입/대시보드 모두 워드마크 노출 확인
