### PR TITLE
feat(brand): #228 색상 토큰 재설계 — teal→brass, 쿨그레이 바탕

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,26 +11,26 @@
  * ========================================================== */
 @layer base {
   :root {
-    /* surface */
-    --bg: 255 255 255;
-    --bg-subtle: 248 250 252;
+    /* surface — 쿨 그레이 바탕 + 흰색 카드 (브랜드: Waypost, docs/brand.md §6) */
+    --bg: 244 246 248;
+    --bg-subtle: 236 238 241;
     --bg-elevated: 255 255 255;
-    --bg-overlay: 15 23 42;
+    --bg-overlay: 22 36 63;
 
-    /* text */
-    --fg: 15 23 42;
-    --fg-muted: 71 85 105;
-    --fg-subtle: 148 163 184;
+    /* text — 잉크 네이비 */
+    --fg: 22 36 63;
+    --fg-muted: 74 88 110;
+    --fg-subtle: 137 149 166;
     --fg-on-accent: 255 255 255;
 
     /* line */
-    --border: 226 232 240;
-    --border-strong: 203 213 225;
+    --border: 228 232 236;
+    --border-strong: 213 219 225;
 
-    /* accent — Teal */
-    --accent: 13 148 136;
-    --accent-hover: 15 118 110;
-    --accent-subtle: 240 253 250;
+    /* accent — Brass (절제, CTA·활성·동선/핀 등 의미 있는 곳에만) */
+    --accent: 151 118 47;
+    --accent-hover: 126 99 38;
+    --accent-subtle: 241 234 216;
 
     /* status */
     --success-bg: 240 253 244;
@@ -99,22 +99,24 @@
 
   /* 다크 모드: html.dark 클래스로 적용 */
   :root.dark {
-    --bg: 11 16 32;
-    --bg-subtle: 19 26 46;
-    --bg-elevated: 26 34 58;
+    /* surface — 쿨 다크 (밤의 지도). Base → Elevated 갈수록 한 단계 밝게 */
+    --bg: 18 24 33;
+    --bg-subtle: 24 32 44;
+    --bg-elevated: 27 36 48;
     --bg-overlay: 0 0 0;
 
-    --fg: 241 245 249;
-    --fg-muted: 148 163 184;
-    --fg-subtle: 100 116 139;
-    --fg-on-accent: 11 16 32;
+    --fg: 230 235 241;
+    --fg-muted: 159 176 196;
+    --fg-subtle: 107 122 140;
+    --fg-on-accent: 26 20 4;
 
-    --border: 30 41 59;
-    --border-strong: 51 65 85;
+    --border: 42 51 66;
+    --border-strong: 58 68 86;
 
-    --accent: 45 212 191;
-    --accent-hover: 94 234 212;
-    --accent-subtle: 19 78 74;
+    /* accent — Brass, 다크에서 밝게 */
+    --accent: 198 160 78;
+    --accent-hover: 216 184 106;
+    --accent-subtle: 51 43 20;
 
     --success-bg: 6 78 59;
     --success-fg: 187 247 208;

--- a/components/Layout/TopProgressBar.tsx
+++ b/components/Layout/TopProgressBar.tsx
@@ -137,7 +137,7 @@ export default function TopProgressBar() {
       className="fixed top-0 inset-x-0 z-[100] h-0.5 pointer-events-none"
     >
       <div
-        className="h-full bg-accent shadow-[0_0_8px_var(--color-accent,#3b82f6)] transition-[width,opacity] duration-200 ease-out"
+        className="h-full bg-accent shadow-[0_0_8px_rgb(var(--accent)/0.6)] transition-[width,opacity] duration-200 ease-out"
         style={{
           width: `${progress}%`,
           opacity: progress >= 100 ? 0 : 1,


### PR DESCRIPTION
## 관련 이슈
Closes #228

## 변경 이유
기존 색상 시스템이 teal accent + 흰색/슬레이트 표면 조합으로 "AI 가 빠르게 생성한 대시보드" 클리셰에 가까웠다. 브랜드 디스커버리(#231)에서 확정한 **쿨 그레이 바탕 + 잉크 네이비 + 브라스 강조** 팔레트를 실제 토큰에 적용해 제품 정체성이 색에서 읽히도록 한다.

## 변경 범위
- `app/globals.css` 시맨틱 토큰 재정의 (라이트/다크 각각 별도 설계)
  - surface: 흰색 → 쿨 그레이 바탕(`#F4F6F8`) + 흰색 카드 / 다크는 쿨 다크(`#121821`)
  - text: 슬레이트 → 잉크 네이비(`#16243F`) / 다크 `#E6EBF1`
  - accent: teal(`13 148 136`) → brass(`151 118 47`) / 다크 brass(`198 160 78`)
  - border·overlay·shadow 정합 조정
  - 값은 `docs/brand.md` §6 정본과 1:1 일치
- `components/Layout/TopProgressBar.tsx`: 존재하지 않는 `--color-accent` 참조 + 파란색(`#3b82f6`) 폴백 글로우 제거 → `rgb(var(--accent))` 토큰화 (클리셰 블루 제거)

> 모든 컴포넌트가 Tailwind 토큰 클래스(`bg-bg`/`text-fg`/`bg-accent` 등)로 색을 소비하므로 토큰 값 변경이 곧 전수 적용이다.
> status(success/warning/critical/info)·카테고리·priority·reservation 토큰은 의미 전달용 기능색이라 유지(브랜드 클리셰 아님).

## 검증
- `npm run build` 성공.
- 토큰 우회 하드코딩 색 grep: 잔존 hex 는 favicon/아이콘(ImageResponse, CSS var 불가) + layout themeColor + 카테고리/priority 기능색뿐. 표면/강조에서 teal·클리셰 블루 직접 사용 0건.

## 남은 작업 / 리스크
- 라이트/다크 실기기 시각 회귀는 Vercel 프리뷰로 확인 권장.
- 카테고리 'culture'(violet)·priority 'want'(purple) 는 문서화된 기능색 매핑이라 본 PR 범위에서 유지.

---
- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름"이 보이는가? — N/A (전역 색 토큰 변경, 컨텍스트 표시 회귀 없음)
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? — N/A (색 토큰만 변경)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? — 변경 없음
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가? — 변경 없음
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? — 전역 토큰이라 양쪽 동일 적용
