### PR TITLE
perf(trip): #234 trip 진입 layout 두 Supabase 쿼리 병렬화 — TTFB 단축

### DIFF
--- a/app/trip/[tripId]/layout.tsx
+++ b/app/trip/[tripId]/layout.tsx
@@ -51,14 +51,27 @@ export default async function TripLayout({
     redirect(`/login?next=${encodeURIComponent(`/trip/${tripId}`)}`)
   }
 
-  // Stage A — 접근 체크. 스키마 진화에 영향받지 않는 안정 컬럼만 사용한다.
-  // 스키마 드리프트(예: 신규 컬럼 마이그레이션 누락) 가 권한 거부로 오인되는 것을 막는다.
-  const access = await client
-    .from('trips')
-    .select('id, title, trip_members!inner(role)')
-    .eq('id', tripId)
-    .eq('trip_members.user_id', userData.user.id)
-    .maybeSingle<AccessRow>()
+  // #234 — trip 진입 TTFB 최적화. 두 쿼리는 같은 trips 행을 읽을 뿐 데이터 의존성이 없으므로
+  // 순차 await 대신 병렬로 실행해 DB 왕복 1회를 제거한다. 스키마 드리프트 격리를 위해
+  // 쿼리 자체는 안정 컬럼(access) / 확장 컬럼(meta) 으로 분리한 상태를 유지한다.
+  //  - Stage A: 접근 체크. 스키마 진화에 영향받지 않는 안정 컬럼만 사용한다.
+  //    스키마 드리프트(예: 신규 컬럼 마이그레이션 누락) 가 권한 거부로 오인되는 것을 막는다.
+  //  - Stage B: 메타데이터. 컬럼 누락(42703) 은 권한 문제가 아니므로 기본값으로 폴백한다.
+  //    그래야 deploy-vs-DB 마이그레이션 시차에서도 사용자가 여행에 진입은 할 수 있다.
+  //    비멤버의 경우 RLS 로 빈 결과가 돌아오고, access 게이트 통과 전에는 사용하지 않으므로 안전.
+  const [access, meta] = await Promise.all([
+    client
+      .from('trips')
+      .select('id, title, trip_members!inner(role)')
+      .eq('id', tripId)
+      .eq('trip_members.user_id', userData.user.id)
+      .maybeSingle<AccessRow>(),
+    client
+      .from('trips')
+      .select(EXTENDED_COLUMNS)
+      .eq('id', tripId)
+      .maybeSingle<ExtendedRow>(),
+  ])
 
   if (access.error) {
     console.error('[TripLayout] access check failed', {
@@ -79,14 +92,7 @@ export default async function TripLayout({
     return <TripAccessDenied reason="forbidden" />
   }
 
-  // Stage B — 메타데이터. 컬럼 누락(42703) 은 권한 문제가 아니므로 기본값으로 폴백한다.
-  // 그래야 deploy-vs-DB 마이그레이션 시차에서도 사용자가 여행에 진입은 할 수 있다.
-  const meta = await client
-    .from('trips')
-    .select(EXTENDED_COLUMNS)
-    .eq('id', tripId)
-    .maybeSingle<ExtendedRow>()
-
+  // 메타데이터 결과 적용 — 위 Promise.all 에서 함께 fetch 됨.
   let extended: ExtendedRow = {
     start_date: null,
     end_date: null,


### PR DESCRIPTION
## 관련 이슈

Closes #234

## 변경 이유

이슈 #234 의 수용 기준은 **측정 기반으로 핵심 전환의 병목 1-2개를 식별하고 최적화**하는 것이다.
측정 인프라(`WebVitalsReporter`, PR #245)는 pathname 별 LCP/INP/CLS/FCP/**TTFB** 를 버퍼링한다.

수용 기준이 지목한 핵심 전환 **"목록 → trip 진입"** 의 서버 응답(TTFB) 지배 요인을 코드로 추적한 결과,
`app/trip/[tripId]/layout.tsx` 가 매 trip 진입마다 **두 개의 Supabase 쿼리를 순차 await** 하고 있었다.

- Stage A — 접근 체크 (`id, title, trip_members!inner(role)`)
- Stage B — 메타데이터 (`start_date … home_currency_rate` 확장 컬럼)

두 쿼리는 **같은 `trips` 행을 읽을 뿐 데이터 의존성이 없는데도 직렬**이라, trip 진입 SSR 경로에 DB 왕복 1회가 불필요하게 추가되고 있었다.

### 대조 검증으로 제외한 후보

- **Dashboard (`/dashboard`)** — SSR fetch → `fallbackData` → SWR 패턴으로 이미 최적. 이중 블로킹 fetch 아님.
- **list ↔ map ↔ schedule 뷰 전환** — 공유 SWR 캐시(`/api/items?tripId`)를 읽어 서버 왕복 없음. 라우트 응답 병목이 아니며, 지각 속도 영역은 자매 이슈 #233 소관.

## 변경 범위

- `app/trip/[tripId]/layout.tsx` — Stage A/B 두 쿼리를 `Promise.all` 로 병렬 실행하도록 변경.
  - DB 왕복을 2회 직렬 → 1회(병렬)로 단축.
  - **스키마 드리프트 격리는 유지**: 안정 컬럼(access) / 확장 컬럼(meta) 의 2-쿼리 분리 구조를 그대로 두고 실행만 동시화. 확장 컬럼 누락(42703) 시 기본값 폴백, 권한 거부 오인 방지 로직 변경 없음.
  - 비멤버의 경우 RLS 로 meta 가 빈 결과를 돌려주고, `access` 게이트 통과 전에는 meta 를 사용하지 않으므로 안전.

변경 1파일, +22/-16.

## 검증

- `npm run lint` — 통과 (No issues found)
- `npm run build` — 통과 (`/trip/[tripId]` 세그먼트 정상 빌드)
- 로직 동등성: access 에러/비멤버/스키마 드리프트 분기와 `TripProvider` 전달 값 모두 변경 전과 동일. fetch 순서만 직렬→병렬.

## 남은 작업 / 리스크

- 본 PR 은 수용 기준의 "병목 1-2개 중 1개"(서버 응답 TTFB) 를 측정 경로 기준으로 닫는다. 지각 속도(스피너/스켈레톤 등) 는 자매 이슈 #233 에서 별도로 다룬다.
- 리스크 낮음: 쿼리 의미 변화 없이 실행 동시성만 변경. RLS·드리프트 폴백 경로 영향 없음.
