### PR TITLE
fix(gmaps): import/preview·items 가 현재 trip 무시하고 첫 trip 으로 새던 버그

### DIFF
--- a/app/api/gmaps/import/route.ts
+++ b/app/api/gmaps/import/route.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { mapGoogleCategory } from '@/services/gmaps/categoryMap'
 import type { GooglePlace, TripItem } from '@/types'
 import { createRouteHandlerSupabase } from '@/lib/supabase-server'
-import { ensureActiveTrip } from '@/lib/trip'
+import { getUserRole } from '@/lib/trip'
 import { reverseGeocode } from '@/lib/geocode'
 
 // "34°39'53.7\"N 135°29'58.3\"E" 또는 "34.123, 135.456" 같이 좌표 자체가 이름인 경우를 감지.
@@ -80,9 +80,11 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
     const {
+      tripId: bodyTripId,
       places,
       categoryOverrides = {},
     } = body as {
+      tripId?: string
       places?: GooglePlace[]
       categoryOverrides?: Record<string, string>
     }
@@ -94,11 +96,34 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const supabase = createRouteHandlerSupabase()
+    // tripId 는 반드시 호출자(현재 보고 있는 trip)가 명시한다.
+    // 예전엔 누락 시 ensureActiveTrip 으로 "첫 trip" 을 골랐는데,
+    // 그게 사용자가 보고 있는 trip 과 달라 다른 trip 으로 항목이 새는 버그였다.
     const queryTripId = request.nextUrl.searchParams.get('tripId')
-    const tripId = queryTripId && queryTripId.trim()
-      ? queryTripId
-      : await ensureActiveTrip(supabase)
+    const tripId = (queryTripId && queryTripId.trim()) || (bodyTripId && bodyTripId.trim()) || ''
+    if (!tripId) {
+      return NextResponse.json(
+        { error: 'INVALID_REQUEST', message: '대상 여행이 지정되지 않았습니다.' },
+        { status: 400 }
+      )
+    }
+
+    const supabase = createRouteHandlerSupabase()
+
+    // 호출자가 이 trip 의 멤버이고 쓰기 권한(owner/editor)이 있는지 검증.
+    const role = await getUserRole(supabase, tripId)
+    if (!role) {
+      return NextResponse.json(
+        { error: 'FORBIDDEN', message: '이 여행에 접근할 수 없습니다.' },
+        { status: 403 }
+      )
+    }
+    if (role === 'viewer') {
+      return NextResponse.json(
+        { error: 'FORBIDDEN', message: '보기 전용 멤버는 장소를 추가할 수 없습니다.' },
+        { status: 403 }
+      )
+    }
 
     // trip region 을 한 번 fetch — 좌표만 있는 핀의 폴백 라벨에 사용.
     const { data: tripRow } = await supabase

--- a/app/api/gmaps/preview/route.ts
+++ b/app/api/gmaps/preview/route.ts
@@ -5,18 +5,37 @@ import { parseListPage, GmapsParserError } from '@/services/gmaps/parser'
 import { matchCandidates } from '@/services/gmaps/matcher'
 import { readItems } from '@/lib/data'
 import { createRouteHandlerSupabase } from '@/lib/supabase-server'
+import { getUserRole } from '@/lib/trip'
 import type { ImportCandidate } from '@/types'
 import { mapGoogleCategory } from '@/services/gmaps/categoryMap'
 
 export async function POST(request: Request) {
   try {
     const body = await request.json()
-    const { url } = body as { url?: string }
+    const { url, tripId: bodyTripId } = body as { url?: string; tripId?: string }
 
     if (!url || typeof url !== 'string' || url.trim() === '') {
       return NextResponse.json(
         { error: 'INVALID_URL', message: '올바른 구글맵 리스트 URL을 입력해주세요.' },
         { status: 400 }
+      )
+    }
+
+    // 중복검사는 "지금 보고 있는 trip" 의 항목과 비교해야 한다.
+    // tripId 누락 시 ensureActiveTrip("첫 trip")으로 새는 import 버그의 read 짝.
+    const tripId = bodyTripId && bodyTripId.trim()
+    if (!tripId) {
+      return NextResponse.json(
+        { error: 'INVALID_REQUEST', message: '대상 여행이 지정되지 않았습니다.' },
+        { status: 400 }
+      )
+    }
+    const supabase = createRouteHandlerSupabase()
+    const role = await getUserRole(supabase, tripId)
+    if (!role) {
+      return NextResponse.json(
+        { error: 'FORBIDDEN', message: '이 여행에 접근할 수 없습니다.' },
+        { status: 403 }
       )
     }
 
@@ -33,8 +52,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ candidates: [] })
     }
 
-    // 4. 기존 items 조회 후 중복/유사 분류
-    const existingItems = await readItems(createRouteHandlerSupabase())
+    // 4. 기존 items 조회 후 중복/유사 분류 (현재 trip 기준)
+    const existingItems = await readItems(supabase, tripId)
     const candidates: ImportCandidate[] = matchCandidates(places, existingItems).map(c => ({
       ...c,
       mappedCategory: c.mappedCategory ?? mapGoogleCategory(c.place.googleCategory),

--- a/app/api/items/[id]/route.ts
+++ b/app/api/items/[id]/route.ts
@@ -98,6 +98,9 @@ function getTripIdFromRequest(request: NextRequest): string | null {
 export async function GET(request: NextRequest, { params }: RouteContext) {
   const client = createRouteHandlerSupabase()
   const tripId = getTripIdFromRequest(request)
+  if (!tripId) {
+    return NextResponse.json({ error: '대상 여행이 지정되지 않았습니다.' }, { status: 400 })
+  }
   const items = await readItems(client, tripId)
   const item = items.find(i => i.id === params.id)
   if (!item) {
@@ -109,13 +112,16 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
 export async function PATCH(request: NextRequest, { params }: RouteContext) {
   const client = createRouteHandlerSupabase()
   const tripId = getTripIdFromRequest(request)
+  if (!tripId) {
+    return NextResponse.json({ error: '대상 여행이 지정되지 않았습니다.' }, { status: 400 })
+  }
   const items = await readItems(client, tripId)
   const idx = items.findIndex(i => i.id === params.id)
   if (idx === -1) {
     return NextResponse.json({ error: '항목을 찾을 수 없습니다.' }, { status: 404 })
   }
 
-  const bounds = tripId ? await fetchTripBounds(client, tripId) : null
+  const bounds = await fetchTripBounds(client, tripId)
   const body = await request.json()
   const error = validatePartial(body, bounds)
   if (error) return NextResponse.json({ error }, { status: 400 })
@@ -147,6 +153,9 @@ export const PUT = PATCH
 export async function DELETE(request: NextRequest, { params }: RouteContext) {
   const client = createRouteHandlerSupabase()
   const tripId = getTripIdFromRequest(request)
+  if (!tripId) {
+    return NextResponse.json({ error: '대상 여행이 지정되지 않았습니다.' }, { status: 400 })
+  }
   const items = await readItems(client, tripId)
   const idx = items.findIndex(i => i.id === params.id)
   if (idx === -1) {

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -102,6 +102,9 @@ export async function GET(request: NextRequest) {
   try {
     const client = createRouteHandlerSupabase()
     const tripId = getTripIdFromRequest(request)
+    if (!tripId) {
+      return NextResponse.json({ error: '대상 여행이 지정되지 않았습니다.' }, { status: 400 })
+    }
     const items = await readItems(client, tripId)
     return NextResponse.json({ items })
   } catch (e) {
@@ -124,7 +127,10 @@ export async function POST(request: NextRequest) {
 
   const client = createRouteHandlerSupabase()
   const tripId = getTripIdFromRequest(request)
-  const bounds = tripId ? await fetchTripBounds(client, tripId) : null
+  if (!tripId) {
+    return NextResponse.json({ error: '대상 여행이 지정되지 않았습니다.' }, { status: 400 })
+  }
+  const bounds = await fetchTripBounds(client, tripId)
 
   const error = validateItem(body, bounds)
   if (error) return NextResponse.json({ error }, { status: 400 })

--- a/app/trip/[tripId]/gmaps-import/page.tsx
+++ b/app/trip/[tripId]/gmaps-import/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import Navigation from '@/components/Layout/Navigation'
 import UrlInput from '@/components/GmapsImport/UrlInput'
 import CandidateList from '@/components/GmapsImport/CandidateList'
-import { useTripPath } from '@/lib/hooks/useTripContext'
+import { useTripId, useTripPath } from '@/lib/hooks/useTripContext'
 import TripPageHeader from '@/components/Layout/TripPageHeader'
 import type { ImportCandidate } from '@/types'
 
@@ -13,6 +13,7 @@ type PageState = 'idle' | 'loading' | 'review' | 'importing' | 'done'
 
 export default function GmapsImportPage() {
   const router = useRouter()
+  const tripId = useTripId()
   const tripPath = useTripPath()
   const [state, setState] = useState<PageState>('idle')
   const [candidates, setCandidates] = useState<ImportCandidate[]>([])
@@ -37,7 +38,7 @@ export default function GmapsImportPage() {
       const res = await fetch('/api/gmaps/preview', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url }),
+        body: JSON.stringify({ url, tripId }),
       })
 
       const data = await res.json()
@@ -72,10 +73,11 @@ export default function GmapsImportPage() {
     setError(null)
 
     try {
-      const res = await fetch('/api/gmaps/import', {
+      const res = await fetch(`/api/gmaps/import?tripId=${encodeURIComponent(tripId)}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          tripId,
           places: selected.map(c => c.place),
         }),
       })

--- a/components/Items/ItemList.tsx
+++ b/components/Items/ItemList.tsx
@@ -16,7 +16,7 @@ import { Input } from '@/components/UI/Input'
 import { TRIP_PRIORITY_META } from '@/lib/itemOptions'
 import { useTripPath } from '@/lib/hooks/useTripContext'
 
-export type SortKey = 'name' | 'date' | 'budget' | 'trip_priority'
+export type SortKey = 'name' | 'date' | 'budget' | 'trip_priority' | 'created_at'
 export type SortDir = 'asc' | 'desc'
 
 export interface FilterState {
@@ -202,6 +202,10 @@ export default function ItemList({
             (i) => TRIP_PRIORITY_META[i.trip_priority].order,
           )
           sk = orders.length ? Math.max(...orders) : 0
+        } else if (sortKey === 'created_at') {
+          // 그룹은 가장 최근에 추가된 항목 기준으로 정렬한다.
+          const times = visibleItems.map((i) => i.created_at).filter(Boolean)
+          sk = times.length ? times.reduce((a, b) => (a > b ? a : b)) : ''
         }
 
         entries.push({
@@ -217,6 +221,7 @@ export default function ItemList({
         else if (sortKey === 'budget') sk = item.budget ?? 0
         else if (sortKey === 'trip_priority')
           sk = TRIP_PRIORITY_META[item.trip_priority].order
+        else if (sortKey === 'created_at') sk = item.created_at ?? ''
 
         entries.push({ type: 'single', item, sortKey: sk })
       }

--- a/components/Research/SortButton.tsx
+++ b/components/Research/SortButton.tsx
@@ -7,10 +7,17 @@ import { cn } from '@/lib/cn'
 
 const SORT_OPTIONS: { key: SortKey; label: string }[] = [
   { key: 'name', label: '이름' },
+  { key: 'created_at', label: '추가순' },
   { key: 'date', label: '날짜' },
   { key: 'budget', label: '예산' },
   { key: 'trip_priority', label: '우선순위' },
 ]
+
+// 정렬 키를 새로 고를 때의 기본 방향. '추가순' 은 최근 추가가 위로 오는 게
+// 자연스럽다(특히 gmaps 일괄 import 직후). 나머지는 오름차순.
+const DEFAULT_DIR: Partial<Record<SortKey, SortDir>> = {
+  created_at: 'desc',
+}
 
 interface SortButtonProps {
   sortKey: SortKey
@@ -48,7 +55,7 @@ export default function SortButton({ sortKey, sortDir, onChange }: SortButtonPro
     if (key === sortKey) {
       onChange(key, sortDir === 'asc' ? 'desc' : 'asc')
     } else {
-      onChange(key, 'asc')
+      onChange(key, DEFAULT_DIR[key] ?? 'asc')
     }
     setOpen(false)
   }

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -6,17 +6,18 @@ import {
   normalizeTripItem,
   normalizeCategory,
 } from '@/lib/itemOptions'
-import { ensureActiveTrip } from '@/lib/trip'
-
 type Client = SupabaseClient
 
-async function resolveTripId(client: Client, tripId?: string | null): Promise<string> {
-  if (tripId) return tripId
-  return ensureActiveTrip(client)
+// tripId 는 반드시 호출자가 명시한다. 예전엔 누락 시 ensureActiveTrip("첫 trip")으로
+// 폴백했는데, 그게 사용자가 보고 있는 trip 과 달라 다른 trip 으로 항목이 새는 버그의
+// 근원이었다(gmaps import/preview, items CRUD). 누락은 조용히 추측하지 않고 막는다.
+function resolveTripId(tripId?: string | null): string {
+  if (tripId && tripId.trim()) return tripId
+  throw new Error('readItems/writeItems 에는 tripId 가 반드시 필요합니다.')
 }
 
 export async function readItems(client: Client, tripId?: string | null): Promise<TripItem[]> {
-  const resolvedTripId = await resolveTripId(client, tripId)
+  const resolvedTripId = resolveTripId(tripId)
   const { data, error } = await client
     .from('items')
     .select('*')
@@ -37,7 +38,7 @@ export async function writeItems(
   tripId?: string | null,
 ): Promise<void> {
   items.forEach(validateItem)
-  const resolvedTripId = await resolveTripId(client, tripId)
+  const resolvedTripId = resolveTripId(tripId)
 
   const { data: existing, error: fetchError } = await client
     .from('items')


### PR DESCRIPTION
## 문제

오사카 trip 에서 구글맵 공유로 장소를 추가했는데, **뉴욕 trip 후보 목록에 들어가는** 치명 버그가 보고됨.

### 원인

`tripId 누락 → 첫 trip` 패턴. 클라이언트가 현재 trip 을 알면서도 API 에 `tripId` 를 안 넘기고, 서버는 누락 시 `ensureActiveTrip()`(= `trip_members` 첫 행 = 가장 먼저 만든 trip)을 조용히 골랐다. CLAUDE.md 의 "단일-trip 시대 잔재" 게이트(#7) 위반.

전수 점검 결과 같은 결함이 **import(write)** 뿐 아니라 **preview(read, 중복검사)** 와 **items CRUD** 에도 잠복해 있었다.

## 수정

| 위치 | 변경 |
|---|---|
| `gmaps-import/page.tsx` | 현재 `tripId` 를 import·preview 호출에 명시 전달 |
| `/api/gmaps/import` | `tripId` 필수화(누락 시 400) + 멤버십·쓰기권한 검증(viewer 거부) |
| `/api/gmaps/preview` | 중복검사를 **현재 trip** 항목 기준으로 수행(같은 버그의 read 짝) + 멤버십 검증 |
| `lib/data.ts` `resolveTripId` | silent "첫 trip" 폴백 **제거** → `tripId` 필수(미지정 시 throw). 두 버그의 공통 뿌리 차단 |
| `/api/items`, `/api/items/[id]` | `tripId` 누락 시 400 가드 추가(라우트 계약 일관화) |

## 추가 UX

후보 목록에 **"추가순"(`created_at`) 정렬** 옵션 추가. 일괄 import 직후 방금 넣은 항목을 모아 보도록 하기 위함(`created_at` 은 이미 클라이언트에 존재 → 데이터 배선 없음). 선택 시 최신순(desc) 기본.

## 운영 데이터 정리

이미 뉴욕 trip 으로 새어버린 오사카/교토 장소 **196건**(`2026-06-22` import 배치)을 운영 DB 에서 삭제 완료. 4월의 정상 NYC gmaps import 74건은 보존.

## 체크리스트

- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? (TripPageHeader 유지)
- [x] 핵심 객체의 C/R/U/D 가 올바른 trip 으로 동작하는가?
- [x] 마법사·카피에서 약속한 동작이 실제로 가능한가? (import 가 현재 trip 으로 들어감)
- [x] 모바일·데스크탑 양쪽 동등
- [x] `tsc --noEmit` / `next lint` 통과
