### PR TITLE
feat(schedule): #254 일정 뷰 확정 항목 간 이동시간·거리 표시

### DIFF
--- a/components/Schedule/DayTimeline.tsx
+++ b/components/Schedule/DayTimeline.tsx
@@ -3,7 +3,7 @@
 import { Fragment } from 'react'
 import type { TripItem } from '@/types'
 import { CATEGORY_META } from '@/lib/itemOptions'
-import { formatDistance, haversineKm } from '@/lib/distance'
+import { formatDistance, haversineKm, estimateTravelMinutes, formatDuration } from '@/lib/distance'
 
 interface DayTimelineProps {
   items: TripItem[]
@@ -48,7 +48,7 @@ export default function DayTimeline({ items, selectedItemId, onSelectItem }: Day
                 className="flex items-center gap-2 pl-7 pr-4 py-1 text-[10px] tabular-nums text-fg-subtle"
               >
                 <span className="inline-block h-3 w-px bg-border" />
-                <span>{formatDistance(km)}</span>
+                <span>약 {formatDuration(estimateTravelMinutes(km))} · 직선 {formatDistance(km)}</span>
               </li>
             )}
             <li>

--- a/components/Schedule/DistanceSeparator.tsx
+++ b/components/Schedule/DistanceSeparator.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { TriangleAlert } from 'lucide-react'
-import { formatDistance } from '@/lib/distance'
+import { formatDistance, estimateTravelMinutes, formatDuration } from '@/lib/distance'
 import { cn } from '@/lib/cn'
 
 /**
@@ -17,13 +17,15 @@ interface DistanceSeparatorProps {
 
 export default function DistanceSeparator({ km, variant }: DistanceSeparatorProps) {
   const far = km >= FAR_LEG_KM
-  // 직선거리임을 정직하게 라벨링한다 — "이동 거리"라 부르지 않는다.
-  const label = `다음 장소까지 직선거리 약 ${formatDistance(km)}${far ? ', 동선이 멀어요' : ''}`
+  const minutes = estimateTravelMinutes(km)
+  // 이동시간은 추정이라 "약", 거리는 직선임을 정직하게 라벨링한다.
+  const text = `약 ${formatDuration(minutes)} · 직선 ${formatDistance(km)}`
+  const label = `다음 장소까지 ${text}${far ? ', 동선이 멀어요' : ''}`
 
   // 평상시 구간은 장식적 반복이라 스크린리더에서 숨기되, 먼 구간은 새 정보(경고)라 읽힌다.
   const a11y = far
     ? ({ role: 'note' as const, 'aria-label': label })
-    : ({ 'aria-hidden': true as const, title: `직선거리 약 ${formatDistance(km)}` })
+    : ({ 'aria-hidden': true as const, title: text })
 
   const toneText = far ? 'text-warning-fg' : 'text-fg-subtle'
   const toneLine = far ? 'bg-warning-fg/40' : 'bg-border'
@@ -40,7 +42,7 @@ export default function DistanceSeparator({ km, variant }: DistanceSeparatorProp
         <div className="flex min-w-[220px] flex-1 items-center gap-2">
           <span className={cn('h-px w-3', toneLine)} />
           {far && <TriangleAlert className="size-3 flex-shrink-0" aria-hidden="true" />}
-          <span className="tabular-nums">{formatDistance(km)}</span>
+          <span className="tabular-nums">{text}</span>
         </div>
       </div>
     )
@@ -50,7 +52,7 @@ export default function DistanceSeparator({ km, variant }: DistanceSeparatorProp
     <div {...a11y} className={cn('flex items-center gap-2 pl-12 pr-2', toneText)}>
       <span className={cn('h-3 w-px', toneLine)} />
       {far && <TriangleAlert className="size-3 flex-shrink-0" aria-hidden="true" />}
-      <span className="text-[11px] tabular-nums">{formatDistance(km)}</span>
+      <span className="text-[11px] tabular-nums">{text}</span>
     </div>
   )
 }

--- a/lib/distance.ts
+++ b/lib/distance.ts
@@ -24,3 +24,28 @@ export function formatDistance(km: number): string {
   if (km < 10) return `${km.toFixed(1)} km`
   return `${Math.round(km)} km`
 }
+
+// 직선거리 → 실제 경로 보정. 직선은 항상 실제보다 짧아 보수적으로 늘린다.
+const DETOUR_FACTOR = 1.3
+// 이 직선거리(km) 이하는 도보, 초과는 대중교통/차량 평균속도로 가정한다.
+const WALK_MAX_KM = 1.2
+const WALK_KMH = 4.5
+const TRANSIT_KMH = 18
+
+/**
+ * 직선거리(km)에서 대략적인 이동 시간(분)을 추정한다.
+ * 외부 라우팅 API 없이 시작하는 편의 추정이라 "약" 으로만 표기해야 한다 —
+ * 실측 라우팅·신뢰 해자는 #260 에서 다룬다.
+ */
+export function estimateTravelMinutes(straightKm: number): number {
+  const realKm = straightKm * DETOUR_FACTOR
+  const kmh = straightKm <= WALK_MAX_KM ? WALK_KMH : TRANSIT_KMH
+  return Math.max(1, Math.round((realKm / kmh) * 60))
+}
+
+export function formatDuration(minutes: number): string {
+  if (minutes < 60) return `${minutes}분`
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  return m === 0 ? `${h}시간` : `${h}시간 ${m}분`
+}


### PR DESCRIPTION
## 관련 이슈
Closes #254

## 변경 이유
일정 뷰에서 확정 항목 사이 동선은 직선거리만 보였다. "안 깨지는 일정"을 한눈에 보려면 거리뿐 아니라 대략적 이동 시간이 필요하다 (레버 A). 외부 라우팅 API 없이 좌표만으로 시작한다 — 실측 라우팅 기반 신뢰 해자는 #260 에서 다룬다.

## 변경 범위
- `lib/distance.ts`: `estimateTravelMinutes(km)` 추가. 직선거리에 detour 보정(1.3x) 후 도보(≤1.2km, 4.5km/h)/대중교통(18km/h) 분기로 분 추정. `formatDuration(min)` 추가.
- `components/Schedule/DistanceSeparator.tsx`: 일정표(데스크탑·모바일) 구간 라벨을 `약 N분 · 직선 ~km` 로 변경. 먼 구간(≥2km) 경고·a11y 유지.
- `components/Schedule/DayTimeline.tsx`: 지도 사이드패널 타임라인도 동일 포맷으로 일관화.

## 검증
- `npm run lint` → No issues found
- `npm run build` → 성공
- 좌표 누락 항목은 기존 `distance()`/`distanceBetween()` 가 `null` 반환 → 구간 미표시로 graceful 유지
- 표기는 항상 "약"(시간 추정)·"직선"(거리) 으로 정직하게 라벨링

## 남은 작업 / 리스크
- 이동시간은 직선 기반 편의 추정이다. 실측 라우팅·사용자 검증 누적은 #260, 임계 초과 동선 경고 강화는 #255 에서 이어진다.
