### PR TITLE
feat(schedule): #255 비효율 동선 구간 시각적 경고

### DIFF
--- a/components/Schedule/DayTimeline.tsx
+++ b/components/Schedule/DayTimeline.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { Fragment } from 'react'
+import { TriangleAlert } from 'lucide-react'
 import type { TripItem } from '@/types'
 import { CATEGORY_META } from '@/lib/itemOptions'
-import { formatDistance, haversineKm, estimateTravelMinutes, formatDuration } from '@/lib/distance'
+import { formatDistance, haversineKm, estimateTravelMinutes, formatDuration, isFarLeg } from '@/lib/distance'
 
 interface DayTimelineProps {
   items: TripItem[]
@@ -42,15 +43,24 @@ export default function DayTimeline({ items, selectedItemId, onSelectItem }: Day
         const active = item.id === selectedItemId
         return (
           <Fragment key={item.id}>
-            {km != null && (
-              <li
-                aria-hidden="true"
-                className="flex items-center gap-2 pl-7 pr-4 py-1 text-[10px] tabular-nums text-fg-subtle"
-              >
-                <span className="inline-block h-3 w-px bg-border" />
-                <span>약 {formatDuration(estimateTravelMinutes(km))} · 직선 {formatDistance(km)}</span>
-              </li>
-            )}
+            {km != null && (() => {
+              const far = isFarLeg(km)
+              return (
+                <li
+                  aria-hidden="true"
+                  className={`flex items-center gap-2 pl-7 pr-4 py-1 text-[10px] tabular-nums ${
+                    far ? 'text-warning-fg' : 'text-fg-subtle'
+                  }`}
+                >
+                  <span className={`inline-block h-3 w-px ${far ? 'bg-warning-fg/40' : 'bg-border'}`} />
+                  {far && <TriangleAlert className="size-3 flex-shrink-0" />}
+                  <span>
+                    약 {formatDuration(estimateTravelMinutes(km))} · 직선 {formatDistance(km)}
+                    {far ? ' · 동선이 멀어요' : ''}
+                  </span>
+                </li>
+              )
+            })()}
             <li>
               <button
                 type="button"

--- a/components/Schedule/DistanceSeparator.tsx
+++ b/components/Schedule/DistanceSeparator.tsx
@@ -1,26 +1,24 @@
 'use client'
 
 import { TriangleAlert } from 'lucide-react'
-import { formatDistance, estimateTravelMinutes, formatDuration } from '@/lib/distance'
+import { formatDistance, estimateTravelMinutes, formatDuration, isFarLeg } from '@/lib/distance'
 import { cn } from '@/lib/cn'
-
-/**
- * 이 값을 넘는 직선거리 구간은 "동선이 멀다"는 정보성 경고로 위계를 올린다.
- * 직선거리 기준이라 실제 경로는 더 길다 — 보수적으로 잡는다.
- */
-const FAR_LEG_KM = 2
 
 interface DistanceSeparatorProps {
   km: number
   variant: 'desktop' | 'mobile'
 }
 
+// 먼 구간임을 색·아이콘만이 아니라 텍스트로도 명시한다 (정보성).
+const FAR_NOTE = '동선이 멀어요'
+
 export default function DistanceSeparator({ km, variant }: DistanceSeparatorProps) {
-  const far = km >= FAR_LEG_KM
+  const far = isFarLeg(km)
   const minutes = estimateTravelMinutes(km)
   // 이동시간은 추정이라 "약", 거리는 직선임을 정직하게 라벨링한다.
-  const text = `약 ${formatDuration(minutes)} · 직선 ${formatDistance(km)}`
-  const label = `다음 장소까지 ${text}${far ? ', 동선이 멀어요' : ''}`
+  const base = `약 ${formatDuration(minutes)} · 직선 ${formatDistance(km)}`
+  const text = far ? `${base} · ${FAR_NOTE}` : base
+  const label = `다음 장소까지 ${text}`
 
   // 평상시 구간은 장식적 반복이라 스크린리더에서 숨기되, 먼 구간은 새 정보(경고)라 읽힌다.
   const a11y = far

--- a/lib/distance.ts
+++ b/lib/distance.ts
@@ -49,3 +49,12 @@ export function formatDuration(minutes: number): string {
   const m = minutes % 60
   return m === 0 ? `${h}시간` : `${h}시간 ${m}분`
 }
+
+// 추정 이동시간이 이 분(min)을 넘는 구간은 "동선이 비효율적"이라는 정보성 경고로
+// 위계를 올린다. 차단이 아니라 인지를 돕는 신호다.
+export const FAR_LEG_MINUTES = 25
+
+/** 두 항목 사이가 과도하게 먼(비효율) 구간인지 — 추정 이동시간 기준. */
+export function isFarLeg(straightKm: number): boolean {
+  return estimateTravelMinutes(straightKm) >= FAR_LEG_MINUTES
+}


### PR DESCRIPTION
## 관련 이슈
Closes #255

## 변경 이유
왕복·역행 등 비효율 동선 구간을 사용자가 인지하게 한다 (레버 A + B:신뢰). #254 로 좌표 기반 이동시간 추정이 생겼으니, 먼 구간 판정을 단순 직선거리가 아닌 추정 이동시간 임계값으로 끌어올린다. 차단이 아니라 정보성 신호다.

## 변경 범위
- `lib/distance.ts`: `FAR_LEG_MINUTES`(25분) + `isFarLeg(km)` 추가로 임계 판정 중앙화. 기존 `DistanceSeparator` 로컬 상수 `FAR_LEG_KM` 제거.
- `components/Schedule/DistanceSeparator.tsx`: 임계 초과 구간에 색·아이콘에 더해 `· 동선이 멀어요` 텍스트를 명시 노출. a11y `role="note"` 라벨 유지.
- `components/Schedule/DayTimeline.tsx`: 지도 사이드패널 타임라인에도 동일한 경고 위계(warning 토큰 + 아이콘 + 텍스트) 적용.

## 검증
- `npm run lint` → 통과
- `npm run build` → 성공 (35/35)
- 디자인 가이드 `warning-fg` / `warning-fg/40` 토큰 사용, hex 직접 사용 없음
- 정보성(차단 아님): 표시만 바뀌고 동작 차단 없음

## 남은 작업 / 리스크
- 임계값(25분)은 직선 기반 추정치다. 실측 라우팅·사용자 검증으로 정확도를 올리는 작업은 #260.
