### PR TITLE
feat(list): #256 후보→보류→확정→탈락 상태 전환 1-2클릭으로 단축

### DIFF
--- a/components/Items/GroupCard.tsx
+++ b/components/Items/GroupCard.tsx
@@ -134,6 +134,7 @@ export default function GroupCard({
               item={item}
               isActive={item.id === selectedItemId}
               onSelect={onSelectItem}
+              onUpdateItem={onUpdateItem}
             />
           ))}
         </div>
@@ -146,10 +147,12 @@ function BranchRow({
   item,
   isActive,
   onSelect,
+  onUpdateItem,
 }: {
   item: TripItem
   isActive: boolean
   onSelect: (id: string) => void
+  onUpdateItem: (id: string, changes: Record<string, unknown>) => void
 }) {
   return (
     <div
@@ -184,7 +187,12 @@ function BranchRow({
             <span className="text-xs text-fg-subtle italic block">(주소 없음)</span>
           )}
           <div className="mt-1.5">
-            <ItemMetadataChips item={item} />
+            <ItemMetadataChips
+              item={item}
+              onChangePriority={(priority) =>
+                onUpdateItem(item.id, { trip_priority: priority })
+              }
+            />
           </div>
         </div>
       </div>

--- a/components/Items/ItemCard.tsx
+++ b/components/Items/ItemCard.tsx
@@ -124,7 +124,12 @@ export default function ItemCard({
       </div>
 
       <div className="mt-3 pl-[22px]">
-        <ItemMetadataChips item={item} />
+        <ItemMetadataChips
+          item={item}
+          onChangePriority={
+            onUpdateItem ? (priority) => onUpdateItem(item.id, { trip_priority: priority }) : undefined
+          }
+        />
       </div>
 
       {(scheduleLabel || item.budget !== undefined) && (

--- a/components/UI/ItemMetadataChips.tsx
+++ b/components/UI/ItemMetadataChips.tsx
@@ -1,7 +1,8 @@
-import type { TripItem } from '@/types'
+import type { TripItem, TripPriority } from '@/types'
 import { ITEM_FIELD_LABELS, PLACEHOLDER_LABELS } from '@/lib/itemOptions'
 import TripPriorityBadge from '@/components/UI/TripPriorityBadge'
 import ReservationStatusBadge from '@/components/UI/ReservationStatusBadge'
+import PriorityQuickPicker from '@/components/UI/PriorityQuickPicker'
 import { Chip } from '@/components/UI/Chip'
 
 function PlaceholderChip({ label }: { label: string }) {
@@ -24,9 +25,12 @@ function CategoryChip({ category }: { category: TripItem['category'] | undefined
 export default function ItemMetadataChips({
   item,
   showLabels = false,
+  onChangePriority,
 }: {
   item: TripItem
   showLabels?: boolean
+  /** 전달 시 우선순위 칩을 1-2클릭 인라인 전환 컨트롤로 렌더한다. */
+  onChangePriority?: (priority: TripPriority) => void
 }) {
   const chips = [
     {
@@ -38,7 +42,11 @@ export default function ItemMetadataChips({
       key: 'trip_priority',
       label: ITEM_FIELD_LABELS.trip_priority,
       node: item.trip_priority ? (
-        <TripPriorityBadge tripPriority={item.trip_priority} />
+        onChangePriority ? (
+          <PriorityQuickPicker value={item.trip_priority} onChange={onChangePriority} />
+        ) : (
+          <TripPriorityBadge tripPriority={item.trip_priority} />
+        )
       ) : (
         <PlaceholderChip label={PLACEHOLDER_LABELS.trip_priority} />
       ),

--- a/components/UI/PriorityQuickPicker.tsx
+++ b/components/UI/PriorityQuickPicker.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useState } from 'react'
+import type { TripPriority } from '@/types'
+import PriorityCell from '@/components/Schedule/cells/PriorityCell'
+
+interface PriorityQuickPickerProps {
+  value: TripPriority
+  onChange: (priority: TripPriority) => void
+}
+
+/**
+ * 자체 open 상태를 갖는 우선순위 1-2클릭 전환 컨트롤.
+ * schedule 테이블·map 패널이 쓰는 PriorityCell 을 감싸, 카드처럼 편집 상태를
+ * 위에서 관리하지 않는 곳(list 카드)에도 그대로 떨어뜨릴 수 있게 한다.
+ * 카드 클릭(선택)과 충돌하지 않도록 클릭 이벤트 전파를 막는다.
+ */
+export default function PriorityQuickPicker({ value, onChange }: PriorityQuickPickerProps) {
+  const [editing, setEditing] = useState(false)
+  return (
+    <span
+      className="inline-flex"
+      onClick={(e) => e.stopPropagation()}
+      onDoubleClick={(e) => e.stopPropagation()}
+    >
+      <PriorityCell
+        value={value}
+        isEditing={editing}
+        onClick={() => setEditing((v) => !v)}
+        onSelect={(priority) => {
+          onChange(priority)
+          setEditing(false)
+        }}
+        onClose={() => setEditing(false)}
+      />
+    </span>
+  )
+}


### PR DESCRIPTION
## 관련 이슈
Closes #256

## 변경 이유
triage(후보→보류→확정→탈락)는 매일 동작인데 list 카드에서는 우선순위가 읽기전용 배지라 바꾸려면 패널을 열어야 했다. map·schedule 은 이미 `PriorityCell` 로 1-2클릭이 가능했으므로, list 만 비대칭이었다 (Basics-First #4: 6조합 동등 도달).

## 변경 범위
- `components/UI/PriorityQuickPicker.tsx` (신규): 자체 open 상태를 가진 재사용 컨트롤. schedule·map 이 쓰는 `PriorityCell` 을 감싸 카드처럼 편집 상태를 위에서 관리하지 않는 곳에도 떨어뜨릴 수 있게 함. 카드 선택 클릭과 충돌하지 않도록 이벤트 전파 차단.
- `components/UI/ItemMetadataChips.tsx`: `onChangePriority` 전달 시 우선순위 칩을 인라인 전환 컨트롤로 렌더(미전달 시 기존 읽기전용 배지 유지 — 상세 페이지는 자체 편집 폼이 있어 그대로).
- `components/Items/ItemCard.tsx`, `components/Items/GroupCard.tsx`: list 카드/그룹 행에 `updateItem` 연결.

## 검증
- `npm run lint` → 통과
- `npm run build` → 성공 (35/35)
- 낙관적 업데이트: `useItems.updateItem` 이 SWR 캐시를 즉시 mutate 후 실패 시 롤백(기존 동작) — 별도 추가 없이 충족
- 상세 페이지의 `ItemMetadataChips`(onChangePriority 미전달)는 읽기전용 유지 확인

## 남은 작업 / 리스크
- 없음
