### PR TITLE
feat(schedule): #257 확정 항목이 일정(날짜)으로 떨어지는 흐름 개선

### DIFF
--- a/components/Items/ItemCard.tsx
+++ b/components/Items/ItemCard.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { useState, useRef, useEffect } from 'react'
+import Link from 'next/link'
+import { CalendarPlus } from 'lucide-react'
 import type { TripItem } from '@/types'
 import { CATEGORY_META } from '@/lib/itemOptions'
 import ItemMetadataChips from '@/components/UI/ItemMetadataChips'
 import LinkButton from './LinkButton'
 import { cn } from '@/lib/cn'
-import { useOptionalTrip } from '@/lib/hooks/useTripContext'
+import { useOptionalTrip, useTripPath } from '@/lib/hooks/useTripContext'
 import { formatBudget, normalizeCurrency } from '@/lib/currency'
 
 interface ItemCardProps {
@@ -27,8 +29,11 @@ export default function ItemCard({
   const [editingName, setEditingName] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const trip = useOptionalTrip()
+  const tripPath = useTripPath()
   const tripCurrency = normalizeCurrency(trip?.currency)
   const scheduleLabel = formatScheduleLabel(item)
+  // 확정했는데 날짜가 없으면 일정 배치로 잇는 다리 — map 패널과 동일 패턴.
+  const needsDate = item.trip_priority === '확정' && !item.date
 
   useEffect(() => {
     if (editingName !== null) inputRef.current?.select()
@@ -138,6 +143,19 @@ export default function ItemCard({
           {item.budget !== undefined && (
             <span className="font-medium">{formatBudget(item.budget, tripCurrency)}</span>
           )}
+        </div>
+      )}
+
+      {needsDate && (
+        <div className="mt-2.5 pl-[22px]">
+          <Link
+            href={`${tripPath('schedule')}?item=${item.id}`}
+            onClick={(e) => e.stopPropagation()}
+            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium text-warning-fg hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          >
+            <CalendarPlus className="size-3" aria-hidden="true" />
+            확정됨 · 날짜 배정하기
+          </Link>
         </div>
       )}
     </div>

--- a/components/Schedule/ScheduleTable.tsx
+++ b/components/Schedule/ScheduleTable.tsx
@@ -601,6 +601,10 @@ export default function ScheduleTable({
   }
 
   const undatedItems = dateGroups.get(UNDATED_KEY) ?? []
+  // 확정인데 날짜가 없는 항목 — 일정에 떨어뜨려야 할 "다음 행동" 대상.
+  const undatedNeedsDateCount = undatedItems.filter(
+    (i) => i.trip_priority === '확정',
+  ).length
   const datedEntries = Array.from(dateGroups.entries())
     .filter(([key]) => key !== UNDATED_KEY)
     .sort(([a], [b]) => a.localeCompare(b))
@@ -661,6 +665,7 @@ export default function ScheduleTable({
           <div className="overflow-hidden rounded-xl border border-border bg-bg-elevated shadow-sm">
             <UndatedGroupHeader
               count={undatedItems.length}
+              needsDateCount={undatedNeedsDateCount}
               isCollapsed={undatedCollapsed}
               dndVariant="mobile"
               onToggleCollapse={() => setUndatedCollapsed(prev => !prev)}
@@ -800,6 +805,7 @@ export default function ScheduleTable({
                 <div>
                   <UndatedGroupHeader
                     count={undatedItems.length}
+                    needsDateCount={undatedNeedsDateCount}
                     isCollapsed={undatedCollapsed}
                     dndVariant="desktop"
                     onToggleCollapse={() => setUndatedCollapsed(prev => !prev)}

--- a/components/Schedule/UndatedGroupHeader.tsx
+++ b/components/Schedule/UndatedGroupHeader.tsx
@@ -4,6 +4,8 @@ import { useDroppable } from '@dnd-kit/core'
 
 interface UndatedGroupHeaderProps {
   count: number
+  /** 이 중 확정 상태라 날짜 배정이 필요한 항목 수. */
+  needsDateCount?: number
   isCollapsed: boolean
   onToggleCollapse: () => void
   onAddItem: () => void
@@ -12,6 +14,7 @@ interface UndatedGroupHeaderProps {
 
 export default function UndatedGroupHeader({
   count,
+  needsDateCount = 0,
   isCollapsed,
   onToggleCollapse,
   onAddItem,
@@ -39,6 +42,11 @@ export default function UndatedGroupHeader({
       >
         <span className="text-sm font-semibold text-fg">날짜 미정</span>
         <span className="text-xs text-fg-muted">{count}개</span>
+        {needsDateCount > 0 && (
+          <span className="inline-flex items-center rounded-full border border-warning-border bg-warning-bg px-2 py-0.5 text-[11px] font-medium text-warning-fg">
+            확정 {needsDateCount}개 날짜 필요
+          </span>
+        )}
         <svg
           xmlns="http://www.w3.org/2000/svg"
           className={`w-3.5 h-3.5 text-fg-subtle transition-transform flex-shrink-0 ${isCollapsed ? '-rotate-90' : ''}`}


### PR DESCRIPTION
## 관련 이슈
Closes #257

## 변경 이유
확정(trip_priority='확정')은 "일정에 넣기로 결정"이지만, 날짜가 비면 일정 뷰의 '날짜 미정' 버킷에 후보들과 섞여 묻혔다. 확정→날짜 배치까지 가는 동선이 끊겨 있었다 (레버 A: 다리 연결).

## 변경 범위
- `components/Items/ItemCard.tsx`: 확정·날짜미배정 항목에 `확정됨 · 날짜 배정하기` 링크 추가 → `schedule?item=<id>` 로 패널을 열어 날짜를 지정. map 사이드패널의 기존 패턴과 대칭(Basics-First #4).
- `components/Schedule/UndatedGroupHeader.tsx`: `needsDateCount` prop 추가. '날짜 미정' 버킷 헤더에 `확정 N개 날짜 필요` 경고 배지를 노출해, 배치가 필요한 확정 항목을 일정 뷰에서 바로 식별 가능하게.
- `components/Schedule/ScheduleTable.tsx`: 미배정 항목 중 확정 개수 계산 후 데스크탑·모바일 헤더 양쪽에 전달.

## 검증
- `npm run lint` → 통과
- `npm run build` → 성공 (35/35)
- 링크 클릭이 카드 선택과 충돌하지 않도록 `stopPropagation`
- 확정인데 날짜 있으면 다리 미노출, 미배정만 노출 확인

## 남은 작업 / 리스크
- 날짜 지정 자체는 기존 ItemPanel 의 날짜 필드를 사용한다. 인라인 날짜 배정(패널 없이)은 후속 폴리시 여지.
