### PR TITLE
feat(copy): #258 빈 상태·랜딩 카피를 "사용자 이익 한 문장"으로 교체

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -200,8 +200,8 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
           <div className="py-12">
             <EmptyState
               icon={<Compass className="size-10" aria-hidden="true" />}
-              title="아직 여행이 없어요"
-              description="첫 여행을 만들어 일정을 정리해 보세요."
+              title="첫 여행을 시작해요"
+              description="모아둔 후보를 추려, 현장에서 안 깨지는 하루 일정으로 만들어요."
               action={
                 <Link href="/dashboard/new">
                   <Button>

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { clearAppCache } from '@/lib/clearAppCache'
 import { ErrorBanner } from '@/components/UI'
 import { useToast } from '@/components/UI/Toast'
-import { BrandMark, PRODUCT_NAME } from '@/components/Brand/Wordmark'
+import { BrandMark, PRODUCT_NAME, PRODUCT_TAGLINE } from '@/components/Brand/Wordmark'
 import type { AuthErrorCode } from '@/lib/auth-errors'
 
 export default function LoginForm() {
@@ -90,7 +90,7 @@ export default function LoginForm() {
         <div className="flex flex-col items-center text-center mb-8">
           <BrandMark size="lg" className="mb-3" />
           <h1 className="text-2xl font-semibold tracking-tight text-fg">{PRODUCT_NAME}</h1>
-          <p className="text-sm text-fg-subtle mt-1">로그인하여 여행을 계획하세요</p>
+          <p className="text-sm text-fg-subtle mt-1">{PRODUCT_TAGLINE}</p>
         </div>
 
         <form

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { useState } from 'react'
 import { clearAppCache } from '@/lib/clearAppCache'
 import { ErrorBanner } from '@/components/UI'
-import { BrandMark, PRODUCT_NAME } from '@/components/Brand/Wordmark'
+import { BrandMark, PRODUCT_TAGLINE } from '@/components/Brand/Wordmark'
 
 export default function SignupForm() {
   const [email, setEmail] = useState('')
@@ -45,7 +45,7 @@ export default function SignupForm() {
         <div className="flex flex-col items-center text-center mb-8">
           <BrandMark size="lg" className="mb-3" />
           <h1 className="text-2xl font-bold text-fg">계정 만들기</h1>
-          <p className="text-sm text-fg-subtle mt-1">{PRODUCT_NAME}</p>
+          <p className="text-sm text-fg-subtle mt-1">{PRODUCT_TAGLINE}</p>
         </div>
 
         {submitted?.needsEmailConfirmation ? (

--- a/components/Brand/Wordmark.tsx
+++ b/components/Brand/Wordmark.tsx
@@ -7,6 +7,14 @@ import { cn } from '@/lib/cn'
  */
 export const PRODUCT_NAME = 'Waypost'
 
+/**
+ * 제품 이익 한 문장 — "왜 쓰는가 = 무엇을 얻는가" (이슈 #258).
+ * 기능 나열·협업 강조 대신, 사용자가 얻는 결과만 말한다.
+ * 정본 기준 문장: "내가 모은 후보 더미를, 버리지 않고 추려서,
+ * 현장에서 안 깨지는 하루 일정으로 만든다." 를 표면용으로 압축한 것.
+ */
+export const PRODUCT_TAGLINE = '모아둔 후보를 추려, 현장에서 안 깨지는 하루 일정으로'
+
 type WordmarkSize = 'sm' | 'md' | 'lg'
 
 const SIZES: Record<WordmarkSize, { box: string; icon: string; text: string; gap: string }> = {

--- a/components/Items/ItemList.tsx
+++ b/components/Items/ItemList.tsx
@@ -307,8 +307,8 @@ export default function ItemList({
         {renderEntries.length === 0 && items.length === 0 && (
           <EmptyState
             icon={<MapPin className="size-10" aria-hidden="true" />}
-            title="아직 장소가 없어요"
-            description="가고 싶은 장소를 추가하면 여기에 모입니다."
+            title="가고 싶은 곳부터 모아요"
+            description="후보를 모아두면, 나중에 추려서 안 깨지는 하루 일정으로 만들 수 있어요."
             action={
               <Button onClick={() => router.push(tripPath('items/new'))}>
                 첫 장소 추가하기


### PR DESCRIPTION
## 관련 이슈
Closes #258

## 변경 이유
랜딩·빈 상태 카피가 "여행을 계획하세요" 같은 제네릭 안내라 "왜 이걸 쓰는가 = 무엇을 얻는가"가 드러나지 않았다. 정본 기준 문장("내가 모은 후보 더미를, 버리지 않고 추려서, 현장에서 안 깨지는 하루 일정으로 만든다")을 표면용으로 압축해 일관 적용한다.

## 변경 범위
- `components/Brand/Wordmark.tsx`: `PRODUCT_TAGLINE` 단일 소스 추가 — `모아둔 후보를 추려, 현장에서 안 깨지는 하루 일정으로`.
- `app/login/LoginForm.tsx`, `app/signup/SignupForm.tsx`: 히어로 서브카피를 이익 한 문장으로 교체.
- `app/dashboard/DashboardClient.tsx`: 첫 실행 빈 상태를 `첫 여행을 시작해요` + 이익 설명으로.
- `components/Items/ItemList.tsx`: 후보 더미 빈 상태를 `가고 싶은 곳부터 모아요` + 후보→일정 다리 한 문장으로.

## 검증
- `npm run lint` → 통과
- `npm run build` → 성공 (35/35)
- 카피 정직성(Basics-First #3): 약속한 동작(후보 추가, 추려서 일정화)은 모두 실제 가능 — 후보 추가/우선순위 전환(#256)/확정→일정 배치(#257) 동선이 닫혀 있음.

## 남은 작업 / 리스크
- 없음
