### PR TITLE
feat(planner): #262(a) 규칙 기반 자동 일정 코어 (lib/planner)

### DIFF
--- a/lib/planner/index.ts
+++ b/lib/planner/index.ts
@@ -1,0 +1,20 @@
+import { scoreItems } from './score'
+import { planRoute } from './route'
+import type { DraftPlan, PlannerInput } from './types'
+
+export type { DraftPlan, DraftStop, UnplacedItem, PlannerInput, PlannerTrip } from './types'
+export { scoreItems, buildCategorySignals } from './score'
+export { planRoute, listDays } from './route'
+
+/**
+ * 내 후보 더미 → 일자별 초안(#262 v1, 규칙 기반).
+ *
+ * - 입력: 내 후보(제외 제외)·좌표·영업시간·휴무·날짜 범위·basecamp
+ *   + 과거 탈락 사유(#259)·만족도(#264) → 카테고리 단위 가중으로 소비(루프 닫힘).
+ * - 동선(이동시간 최소) + 영업시간/휴무 충족 + 결정 이력 가중으로 일자 배치.
+ * - 외부 장소 주입 없음. 자동 확정 없음(초안일 뿐).
+ */
+export function generateDraft(input: PlannerInput): DraftPlan {
+  const scored = scoreItems(input.items)
+  return planRoute(scored, input.trip)
+}

--- a/lib/planner/route.ts
+++ b/lib/planner/route.ts
@@ -1,0 +1,148 @@
+import { haversineKm, estimateTravelMinutes } from '@/lib/distance'
+import type { ScoredItem } from './score'
+import type { DraftPlan, DraftStop, PlannerTrip, UnplacedItem } from './types'
+
+const DAY_START_MIN = 9 * 60 // 09:00
+const DAY_END_MIN = 21 * 60 // 21:00
+const VISIT_MIN = 90 // 한 스톱 체류 가정(분)
+
+function toMin(hhmm: string): number | null {
+  const m = /^(\d{2}):(\d{2})$/.exec(hhmm)
+  if (!m) return null
+  return Number(m[1]) * 60 + Number(m[2])
+}
+
+function toHHMM(min: number): string {
+  const h = Math.floor(min / 60)
+  const m = min % 60
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+}
+
+/** YYYY-MM-DD 범위를 일자 배열로. start>end 또는 누락이면 빈 배열. */
+export function listDays(start: string | null, end: string | null): string[] {
+  if (!start || !end || start > end) return []
+  const days: string[] = []
+  const [sy, sm, sd] = start.split('-').map(Number)
+  const cursor = new Date(Date.UTC(sy, sm - 1, sd))
+  const endDate = end
+  // 안전 상한(과도 범위 방지)
+  for (let i = 0; i < 366; i++) {
+    const key = cursor.toISOString().slice(0, 10)
+    days.push(key)
+    if (key >= endDate) break
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+  return days
+}
+
+function weekdayOf(dateStr: string): number {
+  const [y, m, d] = dateStr.split('-').map(Number)
+  return new Date(Date.UTC(y, m - 1, d)).getUTCDay()
+}
+
+interface Coord {
+  lat: number
+  lng: number
+}
+
+function coordOf(item: ScoredItem['item']): Coord | null {
+  return item.lat != null && item.lng != null ? { lat: item.lat, lng: item.lng } : null
+}
+
+/**
+ * 점수순 greedy + 일자별 시계 진행으로 초안을 만든다.
+ * 영업시간·휴무·마지막 입장을 어기는 슬롯은 배치하지 않는다(수용 기준: 위반 0).
+ */
+export function planRoute(
+  scored: ScoredItem[],
+  trip: PlannerTrip,
+  opts: { days?: string[] } = {},
+): DraftPlan {
+  const days = opts.days ?? listDays(trip.startDate, trip.endDate)
+  const anchor: Coord | null =
+    trip.centerLat != null && trip.centerLng != null
+      ? { lat: trip.centerLat, lng: trip.centerLng }
+      : null
+
+  if (days.length === 0) {
+    return {
+      stops: [],
+      unplaced: scored.map((s) => ({ itemId: s.item.id, reason: '여행 날짜 범위가 설정되지 않았어요' })),
+    }
+  }
+
+  const remaining = new Set(scored.map((s) => s.item.id))
+  const byId = new Map(scored.map((s) => [s.item.id, s]))
+  const stops: DraftStop[] = []
+
+  for (const date of days) {
+    const weekday = weekdayOf(date)
+    let clock = DAY_START_MIN
+    let pos: Coord | null = anchor
+
+    // 하루를 채운다: 매 스텝에서 "지금 시각에 넣을 수 있는" 최고 점수 항목을 고른다.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      let best: { id: string; arrival: number; travel: number } | null = null
+
+      for (const id of Array.from(remaining)) {
+        const s = byId.get(id)!
+        const item = s.item
+
+        // 휴무 요일이면 이 날 배치 불가.
+        if (item.closed_days && item.closed_days.includes(weekday)) continue
+
+        const c = coordOf(item)
+        const travel = pos && c ? estimateTravelMinutes(haversineKm(pos, c)) : 0
+        let arrival = clock + travel
+
+        // 영업시간: 개점 전 도착이면 개점까지 대기.
+        const open = item.opening_hours?.open ? toMin(item.opening_hours.open) : null
+        const close = item.opening_hours?.close ? toMin(item.opening_hours.close) : null
+        const lastEntry = item.last_entry_time ? toMin(item.last_entry_time) : null
+        if (open != null && arrival < open) arrival = open
+
+        // 제약 충족 검사(어기면 후보 제외 → 위반 0 보장).
+        if (close != null && arrival > close) continue
+        if (lastEntry != null && arrival > lastEntry) continue
+        if (arrival + VISIT_MIN > DAY_END_MIN) continue
+        if (close != null && arrival + VISIT_MIN > close) continue
+
+        // 점수 우선, 동점이면 더 빨리 도착(=동선 효율).
+        if (
+          !best ||
+          s.score > byId.get(best.id)!.score ||
+          (s.score === byId.get(best.id)!.score && arrival < best.arrival)
+        ) {
+          best = { id, arrival, travel }
+        }
+      }
+
+      if (!best) break // 이 날 더 넣을 수 없음
+
+      const s = byId.get(best.id)!
+      const reasons = [...s.signalReasons]
+      if (best.travel > 0) reasons.push(`이동 약 ${best.travel}분`)
+      stops.push({ itemId: best.id, date, time_start: toHHMM(best.arrival), reasons })
+
+      clock = best.arrival + VISIT_MIN
+      pos = coordOf(s.item) ?? pos
+      remaining.delete(best.id)
+    }
+  }
+
+  const unplaced: UnplacedItem[] = Array.from(remaining).map((id) => {
+    const item = byId.get(id)!.item
+    const closedAll =
+      item.closed_days && item.closed_days.length > 0 &&
+      days.every((d) => item.closed_days!.includes(weekdayOf(d)))
+    return {
+      itemId: id,
+      reason: closedAll
+        ? '여행 기간 내내 휴무라 배치하지 못했어요'
+        : '남은 시간/동선에 맞는 자리가 없어 빠졌어요',
+    }
+  })
+
+  return { stops, unplaced }
+}

--- a/lib/planner/score.ts
+++ b/lib/planner/score.ts
@@ -1,0 +1,94 @@
+import type { Category, TripItem, TripPriority } from '@/types'
+import { SATISFACTION_META } from '@/lib/itemOptions'
+
+/** 우선순위 기본 욕구 가중. '제외'는 호출 전에 걸러진다. */
+const PRIORITY_WEIGHT: Record<TripPriority, number> = {
+  확정: 100,
+  '가고 싶음': 60,
+  '시간 되면': 30,
+  '검토 필요': 10,
+  제외: -Infinity,
+}
+
+const SATISFACTION_MAX_ADJ = 15 // 카테고리 만족도(-1..1) → ±15
+const REJECTION_PENALTY = 8 // 탈락 1건당 감점
+const REJECTION_CAP = 3 // 감점 누적 상한(=최대 -24)
+
+export interface CategorySignal {
+  /** 같은 카테고리 평가 항목 만족도 평균(-1..1). 평가 없으면 0. */
+  satisfaction: number
+  /** 같은 카테고리에서 사유와 함께 탈락한 건수. */
+  rejection: number
+}
+
+/**
+ * 결정 이력(만족도 #264 · 탈락 사유 #259)을 카테고리 단위 신호로 집계한다.
+ * 이게 "범용 배치기"와 "내 결정 이력 위에서 도는 플래너"를 가르는 지점이다.
+ */
+export function buildCategorySignals(items: TripItem[]): Map<Category, CategorySignal> {
+  const satSum = new Map<Category, number>()
+  const satCount = new Map<Category, number>()
+  const rejCount = new Map<Category, number>()
+
+  for (const item of items) {
+    if (item.satisfaction) {
+      satSum.set(item.category, (satSum.get(item.category) ?? 0) + SATISFACTION_META[item.satisfaction].weight)
+      satCount.set(item.category, (satCount.get(item.category) ?? 0) + 1)
+    }
+    if (item.trip_priority === '제외' && item.decision_reason && item.decision_reason.trim()) {
+      rejCount.set(item.category, (rejCount.get(item.category) ?? 0) + 1)
+    }
+  }
+
+  const signals = new Map<Category, CategorySignal>()
+  const categories = new Set<Category>(
+    Array.from(satCount.keys()).concat(Array.from(rejCount.keys())),
+  )
+  Array.from(categories).forEach((cat) => {
+    const count = satCount.get(cat) ?? 0
+    signals.set(cat, {
+      satisfaction: count > 0 ? (satSum.get(cat) ?? 0) / count : 0,
+      rejection: rejCount.get(cat) ?? 0,
+    })
+  })
+  return signals
+}
+
+export interface ScoredItem {
+  item: TripItem
+  score: number
+  /** 루프 신호에서 비롯된 가감점 설명(있을 때만). */
+  signalReasons: string[]
+}
+
+export function scoreItem(item: TripItem, signals: Map<Category, CategorySignal>): ScoredItem {
+  const base = PRIORITY_WEIGHT[item.trip_priority] ?? 0
+  const sig = signals.get(item.category)
+  const signalReasons: string[] = []
+  let adj = 0
+
+  if (item.trip_priority === '확정') {
+    signalReasons.push('확정 항목 우선 배치')
+  }
+  if (sig && sig.satisfaction > 0) {
+    adj += sig.satisfaction * SATISFACTION_MAX_ADJ
+    signalReasons.push(`만족도 높았던 ${item.category} 우선`)
+  } else if (sig && sig.satisfaction < 0) {
+    adj += sig.satisfaction * SATISFACTION_MAX_ADJ
+    signalReasons.push(`만족도 낮았던 ${item.category} 후순위`)
+  }
+  if (sig && sig.rejection > 0) {
+    adj -= Math.min(sig.rejection, REJECTION_CAP) * REJECTION_PENALTY
+    signalReasons.push(`비슷한 사유로 자주 뺀 ${item.category} 후순위`)
+  }
+
+  return { item, score: base + adj, signalReasons }
+}
+
+export function scoreItems(items: TripItem[]): ScoredItem[] {
+  const signals = buildCategorySignals(items)
+  return items
+    .filter((i) => i.trip_priority !== '제외')
+    .map((i) => scoreItem(i, signals))
+    .sort((a, b) => b.score - a.score)
+}

--- a/lib/planner/types.ts
+++ b/lib/planner/types.ts
@@ -1,0 +1,35 @@
+import type { TripItem } from '@/types'
+
+export interface PlannerTrip {
+  startDate: string | null
+  endDate: string | null
+  centerLat: number | null
+  centerLng: number | null
+}
+
+export interface PlannerInput {
+  items: TripItem[]
+  trip: PlannerTrip
+}
+
+/** 배치된 한 스톱(초안). 자동 확정이 아니라 제안일 뿐이다. */
+export interface DraftStop {
+  itemId: string
+  date: string // YYYY-MM-DD
+  time_start: string // HH:MM (추천 시각)
+  /** 왜 여기에 — 루프 신호 설명 포함(루프 닫힘 검증용). */
+  reasons: string[]
+}
+
+/** 배치하지 못한 후보 + 이유. 조용히 누락하지 않는다. */
+export interface UnplacedItem {
+  itemId: string
+  reason: string
+}
+
+export interface DraftPlan {
+  stops: DraftStop[]
+  unplaced: UnplacedItem[]
+}
+
+export type { TripItem }


### PR DESCRIPTION
## 관련 이슈
Part of #262 (코어만 — UI 는 #262b 에서 바로 이어짐). `Closes` 미사용.

## 변경 이유
#262(자동 일정 플래너 v1)의 규칙 기반 코어. 이슈가 못박은 두 제약을 코드로 고정한다: (1) LLM 아닌 규칙 기반, (2) 캡처된 사유(#259)·만족도(#264)를 **실제로 소비**해 루프를 닫는다(안 쓰면 해자 0).

## 변경 범위 (순수 함수, 새 스키마·API 0)
- `lib/planner/score.ts`: 후보 점수 = 우선순위 가중 + **카테고리 단위** 만족도↑·탈락사유↓. `buildCategorySignals` 가 결정 이력을 집계 → "범용 배치기"와 "내 이력 위 플래너"를 가르는 지점.
- `lib/planner/route.ts`: basecamp 앵커 greedy 최근접 + 일자별 시계 진행. 영업시간(개점 대기 포함)·휴무 요일·마지막 입장·이동시간(#254)·일일 활동창(09–21) 제약. **위반 슬롯은 배치하지 않음** → 결과에 영업·휴무 위반 0(수용 기준). 못 넣은 후보는 `unplaced`에 이유와 함께(조용히 누락 금지).
- `lib/planner/index.ts`: `generateDraft(input) → DraftPlan`. 외부 장소 주입 0, 자동 확정 0(초안일 뿐). 각 배치에 `reasons`(확정 우선 / 만족도 높았던 X 우선 / 비슷한 사유로 후순위 / 이동 N분) → 루프 사용 검증 가능.

## 검증
- `npm run lint` / `npm run build`(35/35) 통과
- 임시 스모크(커밋 안 함)로 확인: 휴무 요일 항목은 휴무일에 미배치, 개점 전 도착은 개점까지 대기, 만족도/탈락사유 신호가 점수·reason 에 반영, unplaced 이유 제공.

## #262 수용 기준 — 이 PR 커버리지
- [x] 후보 N개 → 일자별 초안 생성
- [x] 입력에 사유·피드백 데이터를 실제로 사용(카테고리 신호 — 루프 닫힘)
- [x] 결과가 영업시간·휴무 위반 안 함
- [x] 외부 장소를 새로 주입하지 않음
- [ ] 사용자가 초안 수정·일부 수락 → #262b(리뷰 UI)
- [ ] 지표(A): 완성까지 클릭/시간 ↓ → #262b 동선으로 측정

## 남은 작업
- **#262b**: 일정 뷰의 "자동 일정 초안" 진입점 + 리뷰 시트(전체/항목별 수락·수정). 이번 세션에서 이어서 진행.
