### PR TITLE
feat(planner): #262(b) 자동 일정 초안 리뷰 UI + 수락 동선

### DIFF
--- a/app/trip/[tripId]/schedule/page.tsx
+++ b/app/trip/[tripId]/schedule/page.tsx
@@ -12,8 +12,10 @@ import { useToast } from '@/components/UI/Toast'
 import TripPageHeader from '@/components/Layout/TripPageHeader'
 import StickyAddBar from '@/components/UI/StickyAddBar'
 import IconButton from '@/components/UI/IconButton'
-import { Share } from 'lucide-react'
+import { Share, Sparkles } from 'lucide-react'
 import ExportScheduleDialog from '@/components/Schedule/ExportScheduleDialog'
+import DraftPlanSheet from '@/components/Schedule/DraftPlanSheet'
+import { useTrip } from '@/lib/hooks/useTripContext'
 
 const ItemPanel = dynamic(() => import('@/components/Panel/ItemPanel'), { ssr: false })
 
@@ -31,11 +33,13 @@ function SchedulePageContent() {
   const searchParams = useSearchParams()
   const { items, isLoading, updateItem, createItem, deleteItem } = useItems()
   const { showToast } = useToast()
+  const trip = useTrip()
 
   const [selectedItemId, setSelectedItemId] = useState<string | null>(() =>
     searchParams.get('item'),
   )
   const [exportOpen, setExportOpen] = useState(false)
+  const [draftOpen, setDraftOpen] = useState(false)
 
   const selectedItem = items.find((i) => i.id === selectedItemId) ?? null
 
@@ -74,13 +78,22 @@ function SchedulePageContent() {
         <TripPageHeader
           section="일정"
           actions={
-            <IconButton
-              aria-label="일정 내보내기"
-              onClick={() => setExportOpen(true)}
-              title="일정 내보내기"
-            >
-              <Share className="size-5" />
-            </IconButton>
+            <div className="flex items-center gap-1">
+              <IconButton
+                aria-label="자동 일정 초안 만들기"
+                onClick={() => setDraftOpen(true)}
+                title="자동 일정 초안 만들기"
+              >
+                <Sparkles className="size-5" />
+              </IconButton>
+              <IconButton
+                aria-label="일정 내보내기"
+                onClick={() => setExportOpen(true)}
+                title="일정 내보내기"
+              >
+                <Share className="size-5" />
+              </IconButton>
+            </div>
           }
         />
       </div>
@@ -122,6 +135,24 @@ function SchedulePageContent() {
         open={exportOpen}
         onClose={() => setExportOpen(false)}
         items={items}
+      />
+
+      <DraftPlanSheet
+        open={draftOpen}
+        onClose={() => setDraftOpen(false)}
+        items={items}
+        trip={{
+          startDate: trip.startDate,
+          endDate: trip.endDate,
+          centerLat: trip.centerLat,
+          centerLng: trip.centerLng,
+        }}
+        onApply={async (stops) => {
+          await Promise.all(
+            stops.map((s) => updateItem(s.itemId, { date: s.date, time_start: s.time_start })),
+          )
+          showToast({ type: 'success', message: `${stops.length}개 일정에 넣었어요` })
+        }}
       />
     </div>
   )

--- a/components/Schedule/DraftPlanSheet.tsx
+++ b/components/Schedule/DraftPlanSheet.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { CalendarRange, Sparkles } from 'lucide-react'
+import type { TripItem } from '@/types'
+import { generateDraft, type DraftStop, type PlannerTrip } from '@/lib/planner'
+import { CATEGORY_META } from '@/lib/itemOptions'
+import Sheet from '@/components/UI/Sheet'
+import Button from '@/components/UI/Button'
+
+function formatDate(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number)
+  const dt = new Date(Date.UTC(y, m - 1, d))
+  const days = ['일', '월', '화', '수', '목', '금', '토']
+  return `${m}월 ${d}일 (${days[dt.getUTCDay()]})`
+}
+
+interface DraftPlanSheetProps {
+  open: boolean
+  onClose: () => void
+  items: TripItem[]
+  trip: PlannerTrip
+  onApply: (stops: DraftStop[]) => Promise<void>
+}
+
+export default function DraftPlanSheet({ open, onClose, items, trip, onApply }: DraftPlanSheetProps) {
+  // 시트가 열릴 때의 항목 스냅샷으로 초안을 만든다.
+  const plan = useMemo(() => generateDraft({ items, trip }), [items, trip])
+  const byId = useMemo(() => new Map(items.map((i) => [i.id, i])), [items])
+
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [applying, setApplying] = useState(false)
+
+  // 열릴 때마다 전체 선택으로 초기화.
+  useEffect(() => {
+    if (open) setSelected(new Set(plan.stops.map((s) => s.itemId)))
+  }, [open, plan])
+
+  const byDate = useMemo(() => {
+    const map = new Map<string, DraftStop[]>()
+    for (const s of plan.stops) {
+      if (!map.has(s.date)) map.set(s.date, [])
+      map.get(s.date)!.push(s)
+    }
+    return Array.from(map.entries())
+  }, [plan])
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  async function handleApply() {
+    const stops = plan.stops.filter((s) => selected.has(s.itemId))
+    if (stops.length === 0) return
+    setApplying(true)
+    try {
+      await onApply(stops)
+      onClose()
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  const footer = (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-xs text-fg-subtle">초안일 뿐 — 수락해도 확정 상태는 그대로예요</span>
+      <div className="flex gap-2">
+        <Button variant="secondary" onClick={onClose} disabled={applying}>
+          닫기
+        </Button>
+        <Button onClick={handleApply} disabled={applying || selected.size === 0}>
+          {applying ? '적용 중…' : `선택 ${selected.size}개 일정에 넣기`}
+        </Button>
+      </div>
+    </div>
+  )
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title="자동 일정 초안"
+      description="내 후보·결정 이력으로 만든 제안이에요. 받을 것만 골라 넣으세요."
+      footer={footer}
+    >
+      <div className="space-y-5 px-1 py-1">
+        {plan.stops.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-8 text-center text-sm text-fg-muted">
+            <CalendarRange className="size-8 text-fg-subtle" aria-hidden="true" />
+            배치할 수 있는 후보가 없어요. 여행 날짜·후보를 먼저 확인해 주세요.
+          </div>
+        ) : (
+          byDate.map(([date, stops]) => (
+            <section key={date}>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-fg-subtle">
+                {formatDate(date)}
+              </h3>
+              <ul className="space-y-1.5">
+                {stops.map((stop) => {
+                  const item = byId.get(stop.itemId)
+                  if (!item) return null
+                  const Icon = CATEGORY_META[item.category]?.Icon
+                  const checked = selected.has(stop.itemId)
+                  return (
+                    <li key={stop.itemId}>
+                      <label className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-border bg-bg-elevated p-2.5 hover:border-border-strong">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => toggle(stop.itemId)}
+                          className="mt-0.5 size-4 accent-accent"
+                          aria-label={`${item.name} 초안 선택`}
+                        />
+                        <span className="min-w-0 flex-1">
+                          <span className="flex items-center gap-1.5">
+                            <span className="text-xs font-semibold tabular-nums text-accent">
+                              {stop.time_start}
+                            </span>
+                            {Icon ? <Icon size={12} className="flex-shrink-0 text-fg-muted" aria-hidden="true" /> : null}
+                            <span className="truncate text-sm font-medium text-fg">{item.name}</span>
+                          </span>
+                          {stop.reasons.length > 0 && (
+                            <span className="mt-1 flex flex-wrap gap-1">
+                              {stop.reasons.map((r, i) => (
+                                <span
+                                  key={i}
+                                  className="inline-flex items-center gap-0.5 rounded-full bg-bg-subtle px-1.5 py-0.5 text-[10px] text-fg-muted"
+                                >
+                                  <Sparkles className="size-2.5" aria-hidden="true" />
+                                  {r}
+                                </span>
+                              ))}
+                            </span>
+                          )}
+                        </span>
+                      </label>
+                    </li>
+                  )
+                })}
+              </ul>
+            </section>
+          ))
+        )}
+
+        {plan.unplaced.length > 0 && (
+          <section>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-fg-subtle">
+              넣지 못한 후보 ({plan.unplaced.length})
+            </h3>
+            <ul className="space-y-1">
+              {plan.unplaced.map((u) => {
+                const item = byId.get(u.itemId)
+                if (!item) return null
+                return (
+                  <li key={u.itemId} className="flex items-center justify-between gap-2 px-1 text-xs text-fg-muted">
+                    <span className="truncate">{item.name}</span>
+                    <span className="flex-shrink-0 text-fg-subtle">{u.reason}</span>
+                  </li>
+                )
+              })}
+            </ul>
+          </section>
+        )}
+      </div>
+    </Sheet>
+  )
+}


### PR DESCRIPTION
## 관련 이슈
Closes #262 (코어 #262a #279 + 본 PR UI 로 수용 기준 충족)

## 변경 이유
#262a 의 순수 플래너 코어(`lib/planner`)를 일정 뷰에 연결해 실제 사용 가능하게 한다. 1클릭으로 초안을 받아 골라 넣는 동선 → "일정 1개 완성까지 클릭/시간 ↓"(지표 A).

## 변경 범위
- `components/Schedule/DraftPlanSheet.tsx` (신규): 열릴 때 `generateDraft({items, trip})` 계산 → 일자별 초안 표시. 각 배치의 `reasons`(확정 우선 / 만족도 높았던 X 우선 / 비슷한 사유로 후순위 / 이동 N분)를 칩으로 노출해 **사유·피드백 소비를 가시화**. 항목별 체크박스로 일부 수락, "선택 N개 일정에 넣기" → `date`·`time_start` 만 기록(확정 상태는 안 올림 — 자동 확정 금지). 넣지 못한 후보는 이유와 함께 표시(조용히 누락 안 함).
- `app/trip/[tripId]/schedule/page.tsx`: 헤더에 Sparkles 진입점 + 시트 렌더. 수락 시 `updateItem`(낙관적)로 일괄 적용.

## 검증
- `npm run lint` / `npm run build`(35/35) 통과
- 262a 코어는 스모크로 제약(영업·휴무) 위반 0·루프 신호 반영 확인됨. 본 PR 은 그 위의 선언적 UI.
- 권장: 후보·날짜·basecamp 가 있는 trip 에서 라이브 1회 확인(초안 생성→일부 수락→일정 반영).

## #262 수용 기준 (전체)
- [x] 후보 N개 → 일자별 초안
- [x] 입력에 사유·피드백 데이터 실제 사용(루프 닫힘 — reasons 로 검증 가능)
- [x] 영업시간·휴무 위반 안 함
- [x] 사용자가 초안 일부 수락(항목별 체크) + 수락 후 일반 일정 편집으로 수정
- [x] 외부 장소 주입 없음
- [x] 지표(A): 1클릭 진입 → 수락

## 남은 작업 / 리스크
- "시트 내 인라인 시간 수정"은 미지원(받은 뒤 일정 뷰에서 편집). 필요 시 후속.
- 제약 반영(반드시 갈 곳·예산)은 #263 에서. 루프 신호 텍스트 클러스터링·LLM 은 후속.
