### PR TITLE
feat(planner): #263 개인 제약(반드시 갈 곳·예산) 반영 일정 생성

### DIFF
--- a/app/trip/[tripId]/schedule/page.tsx
+++ b/app/trip/[tripId]/schedule/page.tsx
@@ -147,6 +147,7 @@ function SchedulePageContent() {
           centerLat: trip.centerLat,
           centerLng: trip.centerLng,
         }}
+        currency={trip.currency}
         onApply={async (stops) => {
           await Promise.all(
             stops.map((s) => updateItem(s.itemId, { date: s.date, time_start: s.time_start })),

--- a/components/Schedule/DraftPlanSheet.tsx
+++ b/components/Schedule/DraftPlanSheet.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { CalendarRange, Sparkles } from 'lucide-react'
+import { CalendarRange, CheckCircle2, Sparkles, TriangleAlert } from 'lucide-react'
 import type { TripItem } from '@/types'
-import { generateDraft, type DraftStop, type PlannerTrip } from '@/lib/planner'
+import { generateDraft, type DraftStop, type PlannerTrip, type UnplacedItem } from '@/lib/planner'
 import { CATEGORY_META } from '@/lib/itemOptions'
+import { formatBudget, normalizeCurrency } from '@/lib/currency'
 import Sheet from '@/components/UI/Sheet'
 import Button from '@/components/UI/Button'
 
@@ -15,23 +16,36 @@ function formatDate(dateStr: string): string {
   return `${m}월 ${d}일 (${days[dt.getUTCDay()]})`
 }
 
+const UNPLACED_GROUPS: { kind: UnplacedItem['kind']; label: string; tone: 'warn' | 'muted' }[] = [
+  { kind: 'must-include', label: '반드시(확정)인데 못 넣음 — 확인 필요', tone: 'warn' },
+  { kind: 'budget', label: '예산 한도로 제외', tone: 'muted' },
+  { kind: 'closed', label: '기간 내내 휴무', tone: 'muted' },
+  { kind: 'fit', label: '자리가 없어 빠짐', tone: 'muted' },
+]
+
 interface DraftPlanSheetProps {
   open: boolean
   onClose: () => void
   items: TripItem[]
   trip: PlannerTrip
+  currency: string
   onApply: (stops: DraftStop[]) => Promise<void>
 }
 
-export default function DraftPlanSheet({ open, onClose, items, trip, onApply }: DraftPlanSheetProps) {
-  // 시트가 열릴 때의 항목 스냅샷으로 초안을 만든다.
-  const plan = useMemo(() => generateDraft({ items, trip }), [items, trip])
+export default function DraftPlanSheet({ open, onClose, items, trip, currency, onApply }: DraftPlanSheetProps) {
+  const cur = normalizeCurrency(currency)
+  const [budgetInput, setBudgetInput] = useState('')
+  const budgetCap = budgetInput.trim() ? Number(budgetInput.replace(/[^0-9]/g, '')) : null
+
+  const plan = useMemo(
+    () => generateDraft({ items, trip }, { budgetCap }),
+    [items, trip, budgetCap],
+  )
   const byId = useMemo(() => new Map(items.map((i) => [i.id, i])), [items])
 
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [applying, setApplying] = useState(false)
 
-  // 열릴 때마다 전체 선택으로 초기화.
   useEffect(() => {
     if (open) setSelected(new Set(plan.stops.map((s) => s.itemId)))
   }, [open, plan])
@@ -66,6 +80,9 @@ export default function DraftPlanSheet({ open, onClose, items, trip, onApply }: 
     }
   }
 
+  const mustOk = plan.mustInclude.total > 0 && plan.mustInclude.placed === plan.mustInclude.total
+  const mustFailed = plan.mustInclude.total - plan.mustInclude.placed
+
   const footer = (
     <div className="flex items-center justify-between gap-3">
       <span className="text-xs text-fg-subtle">초안일 뿐 — 수락해도 확정 상태는 그대로예요</span>
@@ -89,6 +106,55 @@ export default function DraftPlanSheet({ open, onClose, items, trip, onApply }: 
       footer={footer}
     >
       <div className="space-y-5 px-1 py-1">
+        {/* 예산 제약 입력 + 합계 (#263) */}
+        <div className="rounded-lg border border-border bg-bg-subtle p-3 space-y-2">
+          <label className="flex items-center justify-between gap-3 text-xs font-medium text-fg">
+            예산 한도 <span className="font-normal text-fg-subtle">(선택)</span>
+            <input
+              type="number"
+              min="0"
+              inputMode="numeric"
+              value={budgetInput}
+              onChange={(e) => setBudgetInput(e.target.value)}
+              placeholder="예: 300000"
+              className="w-32 rounded border border-border-strong bg-bg-elevated px-2 py-1 text-right text-sm text-fg outline-none focus:ring-2 focus:ring-border-strong"
+            />
+          </label>
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-fg-muted">초안 예산 합계</span>
+            <span className={`tabular-nums font-medium ${plan.budget.over > 0 ? 'text-warning-fg' : 'text-fg'}`}>
+              {formatBudget(plan.budget.total, cur)}
+              {plan.budget.cap != null && ` / ${formatBudget(plan.budget.cap, cur)}`}
+            </span>
+          </div>
+          {plan.budget.over > 0 && (
+            <p className="flex items-center gap-1 text-[11px] text-warning-fg">
+              <TriangleAlert className="size-3 flex-shrink-0" aria-hidden="true" />
+              확정(반드시) 항목만으로 한도를 {formatBudget(plan.budget.over, cur)} 초과해요.
+            </p>
+          )}
+        </div>
+
+        {/* 반드시(확정) 충족 상태 */}
+        {plan.mustInclude.total > 0 && (
+          <div
+            className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium ${
+              mustOk
+                ? 'border-success-border bg-success-bg text-success-fg'
+                : 'border-warning-border bg-warning-bg text-warning-fg'
+            }`}
+          >
+            {mustOk ? (
+              <CheckCircle2 className="size-4 flex-shrink-0" aria-hidden="true" />
+            ) : (
+              <TriangleAlert className="size-4 flex-shrink-0" aria-hidden="true" />
+            )}
+            {mustOk
+              ? `반드시 갈 곳 ${plan.mustInclude.total}곳 모두 넣었어요`
+              : `반드시 갈 곳 ${mustFailed}곳을 못 넣었어요 — 아래 사유 확인`}
+          </div>
+        )}
+
         {plan.stops.length === 0 ? (
           <div className="flex flex-col items-center gap-2 py-8 text-center text-sm text-fg-muted">
             <CalendarRange className="size-8 text-fg-subtle" aria-hidden="true" />
@@ -147,25 +213,37 @@ export default function DraftPlanSheet({ open, onClose, items, trip, onApply }: 
           ))
         )}
 
-        {plan.unplaced.length > 0 && (
-          <section>
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-fg-subtle">
-              넣지 못한 후보 ({plan.unplaced.length})
-            </h3>
-            <ul className="space-y-1">
-              {plan.unplaced.map((u) => {
-                const item = byId.get(u.itemId)
-                if (!item) return null
-                return (
-                  <li key={u.itemId} className="flex items-center justify-between gap-2 px-1 text-xs text-fg-muted">
-                    <span className="truncate">{item.name}</span>
-                    <span className="flex-shrink-0 text-fg-subtle">{u.reason}</span>
-                  </li>
-                )
-              })}
-            </ul>
-          </section>
-        )}
+        {/* 못 넣은 후보 — kind 별 그룹, 조용히 누락하지 않고 설명 (#263) */}
+        {plan.unplaced.length > 0 &&
+          UNPLACED_GROUPS.map(({ kind, label, tone }) => {
+            const group = plan.unplaced.filter((u) => u.kind === kind)
+            if (group.length === 0) return null
+            return (
+              <section key={kind}>
+                <h3
+                  className={`mb-2 text-xs font-semibold uppercase tracking-wider ${
+                    tone === 'warn' ? 'text-warning-fg' : 'text-fg-subtle'
+                  }`}
+                >
+                  {label} ({group.length})
+                </h3>
+                <ul className="space-y-1">
+                  {group.map((u) => {
+                    const item = byId.get(u.itemId)
+                    if (!item) return null
+                    return (
+                      <li key={u.itemId} className="flex items-center justify-between gap-2 px-1 text-xs">
+                        <span className={`truncate ${tone === 'warn' ? 'text-fg' : 'text-fg-muted'}`}>
+                          {item.name}
+                        </span>
+                        <span className="flex-shrink-0 text-fg-subtle">{u.reason}</span>
+                      </li>
+                    )
+                  })}
+                </ul>
+              </section>
+            )
+          })}
       </div>
     </Sheet>
   )

--- a/lib/planner/index.ts
+++ b/lib/planner/index.ts
@@ -1,20 +1,82 @@
-import { scoreItems } from './score'
+import { scoreItems, type ScoredItem } from './score'
 import { planRoute } from './route'
-import type { DraftPlan, PlannerInput } from './types'
+import type { DraftPlan, PlannerConstraints, PlannerInput, UnplacedItem } from './types'
 
-export type { DraftPlan, DraftStop, UnplacedItem, PlannerInput, PlannerTrip } from './types'
+export type {
+  DraftPlan,
+  DraftStop,
+  UnplacedItem,
+  PlannerInput,
+  PlannerTrip,
+  PlannerConstraints,
+  BudgetSummary,
+} from './types'
 export { scoreItems, buildCategorySignals } from './score'
 export { planRoute, listDays } from './route'
 
+function isMustInclude(s: ScoredItem): boolean {
+  return s.item.trip_priority === '확정'
+}
+
 /**
- * 내 후보 더미 → 일자별 초안(#262 v1, 규칙 기반).
- *
- * - 입력: 내 후보(제외 제외)·좌표·영업시간·휴무·날짜 범위·basecamp
- *   + 과거 탈락 사유(#259)·만족도(#264) → 카테고리 단위 가중으로 소비(루프 닫힘).
- * - 동선(이동시간 최소) + 영업시간/휴무 충족 + 결정 이력 가중으로 일자 배치.
- * - 외부 장소 주입 없음. 자동 확정 없음(초안일 뿐).
+ * 예산 상한으로 라우팅 대상(eligible)을 추린다.
+ * "반드시"(확정)는 예산과 무관하게 항상 포함 — must-include 우선. 선택 항목은
+ * 점수순으로 누적 예산이 상한을 넘지 않는 선까지만 포함하고, 넘친 항목은 사유와 함께 제외한다.
  */
-export function generateDraft(input: PlannerInput): DraftPlan {
+function selectByBudget(
+  scored: ScoredItem[],
+  budgetCap: number | null | undefined,
+): { eligible: ScoredItem[]; excluded: UnplacedItem[] } {
+  if (budgetCap == null) return { eligible: scored, excluded: [] }
+
+  const must = scored.filter(isMustInclude)
+  const optional = scored.filter((s) => !isMustInclude(s)) // scoreItems 가 이미 점수순 정렬
+
+  let running = must.reduce((sum, s) => sum + (s.item.budget ?? 0), 0)
+  const eligible = [...must]
+  const excluded: UnplacedItem[] = []
+
+  for (const s of optional) {
+    const cost = s.item.budget ?? 0
+    if (running + cost <= budgetCap) {
+      eligible.push(s)
+      running += cost
+    } else {
+      excluded.push({
+        itemId: s.item.id,
+        kind: 'budget',
+        reason: cost > 0 ? `예산 한도로 제외 (이 항목 ${cost.toLocaleString()})` : '예산 한도로 제외',
+      })
+    }
+  }
+  return { eligible, excluded }
+}
+
+/**
+ * 내 후보 더미 → 일자별 초안(#262 v1) + 개인 제약(#263).
+ *
+ * - 결정 이력(사유 #259·만족도 #264)을 카테고리 가중으로 소비(루프 닫힘).
+ * - 동선·영업시간·휴무 제약 충족, 위반 슬롯은 배치 안 함.
+ * - 제약(#263): "반드시"(확정) 100% 시도, 예산 상한 초과 선택 항목은 사유와 함께 제외.
+ * - 못 넣은 항목은 kind 와 이유로 설명(조용히 누락 금지). 외부 장소·자동 확정 없음.
+ */
+export function generateDraft(input: PlannerInput, constraints: PlannerConstraints = {}): DraftPlan {
   const scored = scoreItems(input.items)
-  return planRoute(scored, input.trip)
+  const mustTotal = scored.filter(isMustInclude).length
+
+  const { eligible, excluded } = selectByBudget(scored, constraints.budgetCap)
+  const routed = planRoute(eligible, input.trip)
+
+  const byId = new Map(input.items.map((i) => [i.id, i]))
+  const total = routed.stops.reduce((sum, s) => sum + (byId.get(s.itemId)?.budget ?? 0), 0)
+  const cap = constraints.budgetCap ?? null
+
+  const placedMust = routed.stops.filter((s) => byId.get(s.itemId)?.trip_priority === '확정').length
+
+  return {
+    stops: routed.stops,
+    unplaced: [...routed.unplaced, ...excluded],
+    budget: { cap, total, over: cap != null ? Math.max(0, total - cap) : 0 },
+    mustInclude: { total: mustTotal, placed: placedMust },
+  }
 }

--- a/lib/planner/route.ts
+++ b/lib/planner/route.ts
@@ -1,6 +1,12 @@
 import { haversineKm, estimateTravelMinutes } from '@/lib/distance'
 import type { ScoredItem } from './score'
-import type { DraftPlan, DraftStop, PlannerTrip, UnplacedItem } from './types'
+import type { DraftStop, PlannerTrip, UnplacedItem } from './types'
+
+/** planRoute 산출(예산·must-include 요약은 generateDraft 가 덧붙인다). */
+export interface RouteResult {
+  stops: DraftStop[]
+  unplaced: UnplacedItem[]
+}
 
 const DAY_START_MIN = 9 * 60 // 09:00
 const DAY_END_MIN = 21 * 60 // 21:00
@@ -57,7 +63,7 @@ export function planRoute(
   scored: ScoredItem[],
   trip: PlannerTrip,
   opts: { days?: string[] } = {},
-): DraftPlan {
+): RouteResult {
   const days = opts.days ?? listDays(trip.startDate, trip.endDate)
   const anchor: Coord | null =
     trip.centerLat != null && trip.centerLng != null
@@ -67,7 +73,11 @@ export function planRoute(
   if (days.length === 0) {
     return {
       stops: [],
-      unplaced: scored.map((s) => ({ itemId: s.item.id, reason: '여행 날짜 범위가 설정되지 않았어요' })),
+      unplaced: scored.map((s) => ({
+        itemId: s.item.id,
+        reason: '여행 날짜 범위가 설정되지 않았어요',
+        kind: 'fit' as const,
+      })),
     }
   }
 
@@ -133,15 +143,19 @@ export function planRoute(
 
   const unplaced: UnplacedItem[] = Array.from(remaining).map((id) => {
     const item = byId.get(id)!.item
-    const closedAll =
+    const closedAll = !!(
       item.closed_days && item.closed_days.length > 0 &&
       days.every((d) => item.closed_days!.includes(weekdayOf(d)))
-    return {
-      itemId: id,
-      reason: closedAll
-        ? '여행 기간 내내 휴무라 배치하지 못했어요'
-        : '남은 시간/동선에 맞는 자리가 없어 빠졌어요',
-    }
+    )
+    const mustInclude = item.trip_priority === '확정'
+    const reason = closedAll
+      ? '여행 기간 내내 휴무라 배치하지 못했어요'
+      : mustInclude
+        ? '확정인데 자리를 못 잡았어요 — 동선·시간을 확인해 주세요'
+        : '남은 시간/동선에 맞는 자리가 없어 빠졌어요'
+    // 확정("반드시")은 못 넣은 이유가 무엇이든 제약 불충족으로 가장 눈에 띄게 표시한다.
+    const kind: UnplacedItem['kind'] = mustInclude ? 'must-include' : closedAll ? 'closed' : 'fit'
+    return { itemId: id, reason, kind }
   })
 
   return { stops, unplaced }

--- a/lib/planner/types.ts
+++ b/lib/planner/types.ts
@@ -21,15 +21,39 @@ export interface DraftStop {
   reasons: string[]
 }
 
-/** 배치하지 못한 후보 + 이유. 조용히 누락하지 않는다. */
+/** 배치하지 못한 후보 + 이유. 조용히 누락하지 않는다(#263). */
 export interface UnplacedItem {
   itemId: string
   reason: string
+  /**
+   * must-include: 확정("반드시")인데 자리를 못 잡음 — 제약 불충족(가장 눈에 띄게).
+   * budget: 예산 한도로 제외.
+   * closed: 여행 기간 내내 휴무.
+   * fit: 남은 시간/동선에 자리 없음.
+   */
+  kind: 'must-include' | 'budget' | 'closed' | 'fit'
+}
+
+/** 개인 제약(#263). */
+export interface PlannerConstraints {
+  /** 예산 상한(trip 통화). null/undefined 면 제약 없음. */
+  budgetCap?: number | null
+}
+
+export interface BudgetSummary {
+  cap: number | null
+  /** 배치된 스톱들의 예산 합. */
+  total: number
+  /** cap 초과분(없으면 0). */
+  over: number
 }
 
 export interface DraftPlan {
   stops: DraftStop[]
   unplaced: UnplacedItem[]
+  budget: BudgetSummary
+  /** 확정("반드시") 항목 중 배치에 성공/실패한 수 — 제약 충족 검증용. */
+  mustInclude: { total: number; placed: number }
 }
 
 export type { TripItem }


### PR DESCRIPTION
## 관련 이슈
Closes #263

## 변경 이유
#262 자동 일정 플래너에 개인 제약을 반영한다. 핵심 원칙: **제약 불충족을 조용히 누락하지 않고 설명**.

## 변경 범위
- `lib/planner` (`PlannerConstraints`, `generateDraft(input, constraints)`):
  - **반드시(확정) 100% 시도**: 확정 항목은 예산과 무관하게 항상 라우팅 대상. 배치 실패 시 `kind: 'must-include'` 로 가장 눈에 띄게 surface.
  - **예산 상한**: 선택 항목은 점수순으로 누적 예산이 한도 내인 동안만 포함, 초과분은 `kind: 'budget'` + "이 항목 ₩X" 사유와 함께 제외. 확정만으로 한도 초과 시 그 사실을 명시.
  - `DraftPlan.budget`(합계/한도/초과) · `mustInclude`(총/배치 수) 요약 추가. `unplaced` 에 `kind`(must-include/budget/closed/fit).
  - `planRoute` 산출은 `RouteResult` 로 좁히고 generateDraft 가 요약을 덧붙임.
- `components/Schedule/DraftPlanSheet`: 예산 한도 입력 + 합계/초과 표시, "반드시 갈 곳 N곳 모두 넣음/못 넣음" 상태 배너, 못 넣은 후보를 kind별 그룹(반드시/예산/휴무/자리없음)으로 사유와 함께 노출.

## 검증
- `npm run lint` / `npm run build`(35/35) 통과
- 임시 스모크(커밋 안 함)로 확인: 확정은 예산 무관 포함, 휴무로 못 넣은 확정은 must-include 로 표시, 예산 초과 선택항목은 budget 으로 사유와 함께 제외, 합계/초과 정확.

## #263 수용 기준
- [x] "반드시"(확정) 항목 100% 포함 시도 — 실패 시 누락 아니라 명시 설명
- [x] 예산 초과 시 사유와 함께 표시
- [x] 제약 불충족을 조용히 누락하지 않고 설명 (kind별 그룹)

## 남은 작업 / 리스크
- 예산 한도는 시트 내 입력(비영속). trip 단위 예산 필드화는 필요 시 후속.
- 라이브 UI 검증 권장(초안→예산 입력→제약 표시→수락).
