### PR TITLE
feat(trust): #278 영업시간·휴무 crowd-correction 축적 (해자 본체)

### DIFF
--- a/app/api/place-corrections/route.ts
+++ b/app/api/place-corrections/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
+import { readLatestCorrections, insertCorrection } from '@/lib/placeCorrections'
+import { isValidOpeningHours, isValidClosedDays } from '@/lib/itemValidation'
+
+/** GET /api/place-corrections?placeIds=a,b,c → place 별 최신 공유 보정. */
+export async function GET(request: NextRequest) {
+  const client = createRouteHandlerSupabase()
+  const { data: userData } = await client.auth.getUser()
+  if (!userData.user) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+  }
+
+  const raw = request.nextUrl.searchParams.get('placeIds') ?? ''
+  const placeIds = raw.split(',').map((s) => s.trim()).filter(Boolean)
+  if (placeIds.length === 0) return NextResponse.json({ corrections: {} })
+
+  try {
+    const map = await readLatestCorrections(client, placeIds)
+    const corrections = Object.fromEntries(map.entries())
+    return NextResponse.json({ corrections })
+  } catch {
+    return NextResponse.json({ error: '공유 보정을 불러오지 못했습니다.' }, { status: 500 })
+  }
+}
+
+/** POST /api/place-corrections — 현재 사용자가 한 장소의 영업시간/휴무 보정을 공유. */
+export async function POST(request: NextRequest) {
+  const client = createRouteHandlerSupabase()
+  const { data: userData } = await client.auth.getUser()
+  if (!userData.user) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const googlePlaceId = body.googlePlaceId
+  if (!googlePlaceId || typeof googlePlaceId !== 'string') {
+    return NextResponse.json({ error: 'googlePlaceId가 필요합니다.' }, { status: 400 })
+  }
+  if (body.openingHours != null && !isValidOpeningHours(body.openingHours)) {
+    return NextResponse.json({ error: 'opening_hours 형식이 올바르지 않습니다.' }, { status: 400 })
+  }
+  if (body.closedDays != null && !isValidClosedDays(body.closedDays)) {
+    return NextResponse.json({ error: 'closed_days 형식이 올바르지 않습니다.' }, { status: 400 })
+  }
+  if (body.openingHours == null && body.closedDays == null) {
+    return NextResponse.json({ error: '공유할 영업시간 또는 휴무 정보가 필요합니다.' }, { status: 400 })
+  }
+
+  try {
+    await insertCorrection(client, userData.user.id, {
+      googlePlaceId,
+      openingHours: body.openingHours ?? null,
+      closedDays: body.closedDays ?? null,
+    })
+    return NextResponse.json({ ok: true }, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: '공유에 실패했습니다.' }, { status: 500 })
+  }
+}

--- a/components/Panel/PanelItemForm.tsx
+++ b/components/Panel/PanelItemForm.tsx
@@ -5,11 +5,13 @@ import type { Category, ReservationStatus, Satisfaction, TripItem, TripPriority,
 import { useItems } from '@/lib/hooks/useItems'
 import { useTrip } from '@/lib/hooks/useTripContext'
 import { currencyFieldLabel, normalizeCurrency } from '@/lib/currency'
-import { TriangleAlert } from 'lucide-react'
+import { TriangleAlert, Users } from 'lucide-react'
 import CollapsibleSection from '@/components/UI/CollapsibleSection'
 import MemoField from '@/components/UI/MemoField'
+import { useToast } from '@/components/UI/Toast'
 import { cn } from '@/lib/cn'
 import { getScheduleWarnings } from '@/lib/scheduleWarnings'
+import type { PlaceCorrection } from '@/lib/placeCorrections'
 import {
   CATEGORY_OPTIONS,
   ITEM_FIELD_LABELS,
@@ -82,9 +84,13 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
     closed_days: item.closed_days ?? [],
     links: item.links ?? [],
   })
+  const { showToast } = useToast()
   const [nameError, setNameError] = useState('')
   const [geocoding, setGeocoding] = useState(false)
   const [geocodeError, setGeocodeError] = useState('')
+  // #278 공유 영업시간 보정(crowd-correction).
+  const [shared, setShared] = useState<PlaceCorrection | null>(null)
+  const [sharing, setSharing] = useState(false)
   const memoRef = useRef<HTMLTextAreaElement>(null)
   const nameRef = useRef<HTMLInputElement>(null)
 
@@ -125,6 +131,66 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
   function setField<K extends keyof FormData>(key: K, value: FormData[K]) {
     if (key === 'name') setNameError('')
     setForm(prev => ({ ...prev, [key]: value }))
+  }
+
+  // 공유 보정(#278): 같은 google_place_id 의 최신 보정을 불러온다.
+  useEffect(() => {
+    const placeId = item.google_place_id
+    if (!placeId) {
+      setShared(null)
+      return
+    }
+    let alive = true
+    fetch(`/api/place-corrections?placeIds=${encodeURIComponent(placeId)}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (alive) setShared(data?.corrections?.[placeId] ?? null)
+      })
+      .catch(() => {})
+    return () => {
+      alive = false
+    }
+  }, [item.google_place_id, item.id])
+
+  function applyShared() {
+    if (!shared) return
+    if (shared.openingHours) {
+      setField('open_time', shared.openingHours.open)
+      setField('close_time', shared.openingHours.close)
+    }
+    if (shared.closedDays) setField('closed_days', shared.closedDays)
+  }
+
+  async function shareHours() {
+    const placeId = item.google_place_id
+    if (!placeId) return
+    const openingHours = form.open_time && form.close_time ? { open: form.open_time, close: form.close_time } : null
+    const closedDays = form.closed_days.length ? [...form.closed_days].sort((a, b) => a - b) : null
+    if (!openingHours && !closedDays) {
+      showToast({ type: 'error', message: '공유할 영업시간이나 휴무를 먼저 입력하세요' })
+      return
+    }
+    setSharing(true)
+    try {
+      const res = await fetch('/api/place-corrections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ googlePlaceId: placeId, openingHours, closedDays }),
+      })
+      if (!res.ok) throw new Error()
+      showToast({ type: 'success', message: '영업정보를 공유했어요 — 다른 사용자에게도 반영돼요' })
+      setShared(prev => ({
+        googlePlaceId: placeId,
+        openingHours,
+        closedDays,
+        count: (prev?.count ?? 0) + 1,
+        updatedAt: new Date().toISOString(),
+      }))
+    } catch {
+      showToast({ type: 'error', message: '공유에 실패했어요' })
+    } finally {
+      setSharing(false)
+    }
   }
 
   async function handleAddressBlur() {
@@ -387,6 +453,28 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
           <p className="text-xs text-fg-subtle">
             입력하면 휴무일·영업시간 밖 방문에 경고가 떠요. 비워두면 “정보 없음”으로 두고 경고하지 않아요.
           </p>
+
+          {item.google_place_id && shared && (
+            <div className="rounded-lg border border-info-border bg-info-bg/50 p-2.5 text-xs">
+              <div className="flex items-center gap-1.5 font-medium text-info-fg">
+                <Users className="size-3.5 flex-shrink-0" aria-hidden="true" />
+                다른 사용자가 보정한 영업정보가 있어요 ({shared.count}건)
+              </div>
+              <div className="mt-1 text-fg-muted">
+                {shared.openingHours ? `영업 ${shared.openingHours.open}-${shared.openingHours.close}` : '영업시간 정보 없음'}
+                {shared.closedDays && shared.closedDays.length > 0
+                  ? ` · 휴무 ${shared.closedDays.map(d => WEEKDAY_LABELS[d]).join('·')}`
+                  : ''}
+              </div>
+              <button
+                type="button"
+                onClick={applyShared}
+                className="mt-1.5 rounded border border-info-border px-2 py-1 text-[11px] font-medium text-info-fg hover:bg-info-bg"
+              >
+                이 값 적용
+              </button>
+            </div>
+          )}
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <Field label="영업 시작">
               <input
@@ -436,6 +524,17 @@ export default function PanelItemForm({ item, onSave, onCancel, onDirtyChange }:
               })}
             </div>
           </Field>
+          {item.google_place_id && (
+            <button
+              type="button"
+              onClick={shareHours}
+              disabled={sharing}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-fg-muted transition-colors hover:border-border-strong hover:text-fg disabled:opacity-50"
+            >
+              <Users className="size-3.5" aria-hidden="true" />
+              {sharing ? '공유 중…' : '이 영업정보 공유 (다른 사용자에게 반영)'}
+            </button>
+          )}
         </CollapsibleSection>
 
         <CollapsibleSection title="위치" defaultOpen={locationHasValue}>

--- a/lib/placeCorrections.ts
+++ b/lib/placeCorrections.ts
@@ -1,0 +1,75 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { OpeningHours } from '@/types'
+
+export interface PlaceCorrection {
+  googlePlaceId: string
+  openingHours: OpeningHours | null
+  closedDays: number[] | null
+  /** 이 장소의 누적 보정 수(신뢰도 신호). */
+  count: number
+  /** 최신 보정 시각(ISO). */
+  updatedAt: string
+}
+
+export interface CorrectionInput {
+  googlePlaceId: string
+  openingHours: OpeningHours | null
+  closedDays: number[] | null
+}
+
+type Client = SupabaseClient
+
+/**
+ * 여러 place 의 "현재값"(=최신 보정) + 누적 수를 한 번에 읽는다.
+ * created_at desc 정렬이라 place 별 첫 행이 최신값, 같은 place 의 후속 행은 count 만 올린다.
+ */
+export async function readLatestCorrections(
+  client: Client,
+  placeIds: string[],
+): Promise<Map<string, PlaceCorrection>> {
+  const ids = Array.from(new Set(placeIds.filter(Boolean)))
+  if (ids.length === 0) return new Map()
+
+  const { data, error } = await client
+    .from('place_hours_corrections')
+    .select('google_place_id, opening_hours, closed_days, created_at')
+    .in('google_place_id', ids)
+    .order('created_at', { ascending: false })
+  if (error) throw error
+
+  const map = new Map<string, PlaceCorrection>()
+  for (const row of (data ?? []) as Array<{
+    google_place_id: string
+    opening_hours: OpeningHours | null
+    closed_days: number[] | null
+    created_at: string
+  }>) {
+    const existing = map.get(row.google_place_id)
+    if (!existing) {
+      map.set(row.google_place_id, {
+        googlePlaceId: row.google_place_id,
+        openingHours: row.opening_hours ?? null,
+        closedDays: row.closed_days ?? null,
+        count: 1,
+        updatedAt: row.created_at,
+      })
+    } else {
+      existing.count += 1
+    }
+  }
+  return map
+}
+
+export async function insertCorrection(
+  client: Client,
+  authorUserId: string,
+  input: CorrectionInput,
+): Promise<void> {
+  const { error } = await client.from('place_hours_corrections').insert({
+    google_place_id: input.googlePlaceId,
+    opening_hours: input.openingHours ?? null,
+    closed_days: input.closedDays ?? null,
+    author_user_id: authorUserId,
+  })
+  if (error) throw error
+}

--- a/supabase/migration_278_place_hours_corrections.sql
+++ b/supabase/migration_278_place_hours_corrections.sql
@@ -1,0 +1,28 @@
+-- #278 영업시간·휴무 crowd-correction 축적 (해자 본체)
+-- 한 사용자의 "정보 틀려요" 수정을 google_place_id 기준 전역 공유 테이블에 append.
+-- 영업시간은 개인정보 아닌 공개 사실 → 로그인 사용자 전역 읽기, 본인 작성만 쓰기.
+-- append-only(감사·신뢰도): 같은 장소의 최신 레코드가 현재값, 누적 수가 신뢰 신호.
+
+create table if not exists public.place_hours_corrections (
+  id              uuid        primary key default gen_random_uuid(),
+  google_place_id text        not null,
+  opening_hours   jsonb,
+  closed_days     jsonb,
+  author_user_id  uuid        not null references auth.users(id) on delete cascade,
+  created_at      timestamptz not null default now()
+);
+
+create index if not exists idx_phc_place
+  on public.place_hours_corrections(google_place_id, created_at desc);
+
+alter table public.place_hours_corrections enable row level security;
+
+-- 로그인 사용자는 모두 읽기(공유 사실).
+drop policy if exists phc_select on public.place_hours_corrections;
+create policy phc_select on public.place_hours_corrections
+  for select using (auth.uid() is not null);
+
+-- 본인이 작성한 행만 insert(작성자 위조 방지). update/delete 없음(append-only).
+drop policy if exists phc_insert on public.place_hours_corrections;
+create policy phc_insert on public.place_hours_corrections
+  for insert with check (author_user_id = auth.uid());

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -67,6 +67,19 @@ create table if not exists public.items (
 
 create index if not exists idx_items_trip on public.items(trip_id);
 
+-- 영업시간·휴무 crowd-correction 공유 테이블 (#278). google_place_id 기준 전역 공유.
+create table if not exists public.place_hours_corrections (
+  id              uuid        primary key default gen_random_uuid(),
+  google_place_id text        not null,
+  opening_hours   jsonb,
+  closed_days     jsonb,
+  author_user_id  uuid        not null references auth.users(id) on delete cascade,
+  created_at      timestamptz not null default now()
+);
+
+create index if not exists idx_phc_place
+  on public.place_hours_corrections(google_place_id, created_at desc);
+
 -- ============================================================================
 -- RLS 재귀 회피용 헬퍼 함수 (SECURITY DEFINER)
 -- ============================================================================
@@ -108,6 +121,15 @@ grant execute on function public.user_role_in_trip(uuid) to authenticated;
 alter table public.trips         enable row level security;
 alter table public.trip_members  enable row level security;
 alter table public.items         enable row level security;
+alter table public.place_hours_corrections enable row level security;
+
+-- place_hours_corrections: 로그인 사용자 전역 읽기, 본인 작성만 insert (append-only).
+drop policy if exists phc_select on public.place_hours_corrections;
+create policy phc_select on public.place_hours_corrections
+  for select using (auth.uid() is not null);
+drop policy if exists phc_insert on public.place_hours_corrections;
+create policy phc_insert on public.place_hours_corrections
+  for insert with check (author_user_id = auth.uid());
 
 -- trips: 멤버만 SELECT, 본인이 owner 인 경우만 INSERT/UPDATE/DELETE
 drop policy if exists trips_select on public.trips;


### PR DESCRIPTION
## 관련 이슈
Closes #278

## 마이그레이션
`place_hours_corrections` 테이블 **운영 DB 적용 완료** (`npm run db:migrate` → `migration_278_place_hours_corrections.sql`).

## 변경 이유
#260(a)에서 영업시간·휴무를 개별 입력했지만, 이슈가 못박았듯 개별/공용소스만으론 패리티(해자 0). 한 사용자의 "정보 틀려요" 수정을 `google_place_id` 기준 **전역 공유로 축적**해 쓸수록 정확해지는 독점 데이터를 만든다 — 해자의 본체.

## 권한 모델 (결정: 전역 공유)
영업시간은 개인정보 아닌 공개 사실 → **로그인 사용자 전역 읽기, 본인 작성만 insert**. append-only(감사·신뢰도 — 누적 수가 신뢰 신호). 작성자 위조는 RLS `with check (author_user_id = auth.uid())` 로 차단.

## 변경 범위
- `migration_278` + `schema.sql`: `place_hours_corrections(google_place_id, opening_hours, closed_days, author_user_id, created_at)` + 인덱스 + RLS(phc_select: `auth.uid() is not null`, phc_insert: 본인만).
- `lib/placeCorrections.ts`: `readLatestCorrections`(place별 최신값+누적수), `insertCorrection`.
- `app/api/place-corrections/route.ts`: GET `?placeIds=` (place별 최신 보정), POST(보정 공유 — 인증 + 형식 검증, author=세션 사용자).
- `components/Panel/PanelItemForm.tsx` '영업 정보': google_place_id 있는 항목에 (1) 공유 보정 표시("N건")+"이 값 적용", (2) "이 영업정보 공유" 버튼 → 현재 입력을 전역 공유.

## 검증
- `npm run lint` / `npm run build`(36/36, 새 API 라우트 포함) 통과
- `npm run db:migrate` 적용(Management API 성공 = 테이블+RLS 생성)

## #278 수용 기준
- [x] 사용자가 잘못된 시간 데이터를 수정·저장 가능, 다음에 반영(공유 보정 적용)
- [x] 같은 장소의 보정이 trip 간 공유되어 축적(google_place_id 전역)
- [x] 공유 데이터에 RLS·권한 모델 적용
- [~] 지표(B): 축적 시작(POST 1건마다 누적, count 노출)

## 남은 작업 / 리스크
- v1은 **항목 단위 수동 적용**(패널에서 "이 값 적용"). 일정 뷰·플래너에 공유 보정을 자동 오버레이(individual > shared > none)하는 건 후속.
- google_place_id 는 gmaps 스크레이프에서만 기회적으로 채워짐 — 좌표-only 핀 매칭은 별도.
- 스팸/오입력 완화(신뢰도 가중·다수결)는 누적 후 후속.
