### PR TITLE
feat(items): #265 항목별 그룹 투표·선호 표시

### DIFF
--- a/app/api/item-votes/route.ts
+++ b/app/api/item-votes/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
+
+export interface VoteTally {
+  count: number
+  mine: boolean
+}
+
+/** GET /api/item-votes?tripId= → { [itemId]: { count, mine } } (RLS 가 멤버로 스코프). */
+export async function GET(request: NextRequest) {
+  const client = createRouteHandlerSupabase()
+  const { data: userData } = await client.auth.getUser()
+  if (!userData.user) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+  }
+  const tripId = request.nextUrl.searchParams.get('tripId')
+  if (!tripId) {
+    return NextResponse.json({ error: '대상 여행이 지정되지 않았습니다.' }, { status: 400 })
+  }
+
+  const { data, error } = await client
+    .from('item_votes')
+    .select('item_id, user_id')
+    .eq('trip_id', tripId)
+  if (error) {
+    return NextResponse.json({ error: '투표를 불러오지 못했습니다.' }, { status: 500 })
+  }
+
+  const tallies: Record<string, VoteTally> = {}
+  for (const row of (data ?? []) as Array<{ item_id: string; user_id: string }>) {
+    const t = (tallies[row.item_id] ??= { count: 0, mine: false })
+    t.count += 1
+    if (row.user_id === userData.user.id) t.mine = true
+  }
+  return NextResponse.json({ tallies })
+}
+
+/** POST /api/item-votes — 현재 사용자의 항목 투표 토글. body: { itemId, tripId }. */
+export async function POST(request: NextRequest) {
+  const client = createRouteHandlerSupabase()
+  const { data: userData } = await client.auth.getUser()
+  if (!userData.user) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+  }
+  const body = await request.json()
+  const itemId = body.itemId
+  const tripId = body.tripId
+  if (!itemId || !tripId || typeof itemId !== 'string' || typeof tripId !== 'string') {
+    return NextResponse.json({ error: 'itemId·tripId가 필요합니다.' }, { status: 400 })
+  }
+
+  const userId = userData.user.id
+  const { data: existing } = await client
+    .from('item_votes')
+    .select('item_id')
+    .eq('item_id', itemId)
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (existing) {
+    const { error } = await client
+      .from('item_votes')
+      .delete()
+      .eq('item_id', itemId)
+      .eq('user_id', userId)
+    // RLS 위반(viewer 등)은 권한 없음으로 반환.
+    if (error) return NextResponse.json({ error: '투표 권한이 없습니다.' }, { status: 403 })
+    return NextResponse.json({ voted: false })
+  }
+
+  const { error } = await client
+    .from('item_votes')
+    .insert({ item_id: itemId, trip_id: tripId, user_id: userId })
+  if (error) return NextResponse.json({ error: '투표 권한이 없습니다.' }, { status: 403 })
+  return NextResponse.json({ voted: true })
+}

--- a/app/trip/[tripId]/list/page.tsx
+++ b/app/trip/[tripId]/list/page.tsx
@@ -6,7 +6,8 @@ import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { Plus, Search, Share2 } from 'lucide-react'
 import ShareDialog from '@/components/Share/ShareDialog'
-import { useTripId } from '@/lib/hooks/useTripContext'
+import { useTripId, useOptionalTrip } from '@/lib/hooks/useTripContext'
+import { useItemVotes } from '@/lib/hooks/useItemVotes'
 import TripPageTitle from '@/components/UI/TripPageTitle'
 import Navigation from '@/components/Layout/Navigation'
 import ItemList from '@/components/Items/ItemList'
@@ -52,6 +53,9 @@ function ResearchPageContent() {
   const { items, isLoading, updateItem, createItem } = useItems()
   const { showToast } = useToast()
   const tripId = useTripId()
+  const trip = useOptionalTrip()
+  const canVote = trip?.role !== 'viewer'
+  const { tallies: voteTallies, toggle: toggleVote } = useItemVotes(tripId)
   const [shareDialogOpen, setShareDialogOpen] = useState(false)
   const [unnamedDialogOpen, setUnnamedDialogOpen] = useState(false)
 
@@ -359,6 +363,8 @@ function ResearchPageContent() {
               onSelectItem={handleSelectItem}
               onUpdateItem={updateItem}
               highlightedIds={highlightedIds}
+              votes={voteTallies}
+              onToggleVote={canVote ? toggleVote : undefined}
             />
             <StickyAddBar />
           </div>

--- a/components/Items/ItemCard.tsx
+++ b/components/Items/ItemCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 import Link from 'next/link'
-import { CalendarPlus } from 'lucide-react'
+import { CalendarPlus, ThumbsUp } from 'lucide-react'
 import type { TripItem } from '@/types'
 import { CATEGORY_META } from '@/lib/itemOptions'
 import ItemMetadataChips from '@/components/UI/ItemMetadataChips'
@@ -17,6 +17,10 @@ interface ItemCardProps {
   isActive?: boolean
   isHighlighted?: boolean
   onUpdateItem?: (id: string, changes: Record<string, unknown>) => void
+  /** 그룹 투표(#265). voteCount 는 표시용, onToggleVote 가 있으면 토글 가능(viewer 는 미전달). */
+  voteCount?: number
+  voted?: boolean
+  onToggleVote?: () => void
 }
 
 export default function ItemCard({
@@ -25,6 +29,9 @@ export default function ItemCard({
   isActive = false,
   isHighlighted = false,
   onUpdateItem,
+  voteCount = 0,
+  voted = false,
+  onToggleVote,
 }: ItemCardProps) {
   const [editingName, setEditingName] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -124,6 +131,9 @@ export default function ItemCard({
           </div>
         </div>
         <div className="flex items-center gap-1 flex-shrink-0 flex-wrap justify-end">
+          {(onToggleVote || voteCount > 0) && (
+            <VotePill voteCount={voteCount} voted={voted} onToggleVote={onToggleVote} />
+          )}
           <LinkButton links={item.links} />
         </div>
       </div>
@@ -159,6 +169,54 @@ export default function ItemCard({
         </div>
       )}
     </div>
+  )
+}
+
+function VotePill({
+  voteCount,
+  voted,
+  onToggleVote,
+}: {
+  voteCount: number
+  voted: boolean
+  onToggleVote?: () => void
+}) {
+  const label = `가고 싶어요 ${voteCount}명`
+  const content = (
+    <>
+      <ThumbsUp className={cn('size-3', voted && 'fill-current')} aria-hidden="true" />
+      <span className="tabular-nums">{voteCount}</span>
+    </>
+  )
+  const base = 'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium'
+  if (!onToggleVote) {
+    // viewer: 읽기 전용 표시.
+    return (
+      <span className={cn(base, 'border-border text-fg-muted')} title={label} aria-label={label}>
+        {content}
+      </span>
+    )
+  }
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation()
+        onToggleVote()
+      }}
+      aria-pressed={voted}
+      aria-label={label}
+      title={label}
+      className={cn(
+        base,
+        'transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+        voted
+          ? 'border-accent bg-accent-subtle text-accent'
+          : 'border-border text-fg-muted hover:border-border-strong hover:text-fg',
+      )}
+    >
+      {content}
+    </button>
   )
 }
 

--- a/components/Items/ItemList.tsx
+++ b/components/Items/ItemList.tsx
@@ -51,6 +51,9 @@ interface ItemListProps {
   onSelectItem: (id: string) => void
   onUpdateItem: (id: string, changes: Record<string, unknown>) => void
   highlightedIds?: Set<string>
+  /** 그룹 투표(#265). 집계 맵 + 토글(viewer 면 onToggleVote 미전달). */
+  votes?: Record<string, { count: number; mine: boolean }>
+  onToggleVote?: (id: string) => void
 }
 
 export default function ItemList({
@@ -59,6 +62,8 @@ export default function ItemList({
   onSelectItem,
   onUpdateItem,
   highlightedIds,
+  votes,
+  onToggleVote,
 }: ItemListProps) {
   const router = useRouter()
   const tripPath = useTripPath()
@@ -301,6 +306,9 @@ export default function ItemList({
               isActive={entry.item.id === selectedItemId}
               isHighlighted={highlightedIds?.has(entry.item.id) ?? false}
               onUpdateItem={onUpdateItem}
+              voteCount={votes?.[entry.item.id]?.count ?? 0}
+              voted={votes?.[entry.item.id]?.mine ?? false}
+              onToggleVote={onToggleVote ? () => onToggleVote(entry.item.id) : undefined}
             />
           ),
         )}

--- a/lib/hooks/useItemVotes.ts
+++ b/lib/hooks/useItemVotes.ts
@@ -1,0 +1,52 @@
+'use client'
+
+import useSWR from 'swr'
+import type { VoteTally } from '@/app/api/item-votes/route'
+
+type Tallies = Record<string, VoteTally>
+
+const fetcher = (url: string) =>
+  fetch(url).then((r) => {
+    if (!r.ok) throw new Error('투표 조회 실패')
+    return r.json() as Promise<{ tallies: Tallies }>
+  })
+
+/**
+ * 항목별 그룹 투표 집계(#265). 멤버별 1항목 1투표, 낙관적 토글.
+ * tripId 가 없으면 비활성.
+ */
+export function useItemVotes(tripId: string | null) {
+  const key = tripId ? `/api/item-votes?tripId=${tripId}` : null
+  const { data, mutate } = useSWR(key, fetcher, { revalidateOnFocus: false })
+  const tallies = data?.tallies ?? {}
+
+  async function toggle(itemId: string) {
+    if (!tripId) return
+    const current = tallies[itemId] ?? { count: 0, mine: false }
+    const optimistic: Tallies = {
+      ...tallies,
+      [itemId]: {
+        count: current.mine ? current.count - 1 : current.count + 1,
+        mine: !current.mine,
+      },
+    }
+    try {
+      await mutate(
+        async () => {
+          const res = await fetch('/api/item-votes', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ itemId, tripId }),
+          })
+          if (!res.ok) throw new Error('투표 실패')
+          return { tallies: optimistic }
+        },
+        { optimisticData: { tallies: optimistic }, rollbackOnError: true, revalidate: true },
+      )
+    } catch {
+      // 롤백은 SWR 이 처리. 권한 없음(viewer) 등은 원래 값으로 복원된다.
+    }
+  }
+
+  return { tallies, toggle }
+}

--- a/supabase/migration_265_item_votes.sql
+++ b/supabase/migration_265_item_votes.sql
@@ -1,0 +1,32 @@
+-- #265 항목별 그룹 투표·선호 표시
+-- 일행이 후보 선호를 가볍게 표시(멤버별 1항목 1투표). 집단 추리기 결정을 가시화.
+-- RLS: 멤버는 같은 trip 투표 읽기, owner/editor 만 본인 투표 insert/delete(viewer 불가).
+-- items 와 동일하게 trip_id 를 비정규화해 is_trip_member/user_role_in_trip 직접 적용.
+
+create table if not exists public.item_votes (
+  item_id    text        not null references public.items(id) on delete cascade,
+  trip_id    uuid        not null references public.trips(id) on delete cascade,
+  user_id    uuid        not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (item_id, user_id)
+);
+
+create index if not exists idx_item_votes_trip on public.item_votes(trip_id);
+
+alter table public.item_votes enable row level security;
+
+drop policy if exists item_votes_select on public.item_votes;
+create policy item_votes_select on public.item_votes
+  for select using (public.is_trip_member(trip_id));
+
+drop policy if exists item_votes_insert on public.item_votes;
+create policy item_votes_insert on public.item_votes
+  for insert with check (
+    user_id = auth.uid() and public.user_role_in_trip(trip_id) in ('owner', 'editor')
+  );
+
+drop policy if exists item_votes_delete on public.item_votes;
+create policy item_votes_delete on public.item_votes
+  for delete using (
+    user_id = auth.uid() and public.user_role_in_trip(trip_id) in ('owner', 'editor')
+  );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -80,6 +80,17 @@ create table if not exists public.place_hours_corrections (
 create index if not exists idx_phc_place
   on public.place_hours_corrections(google_place_id, created_at desc);
 
+-- 항목별 그룹 투표 (#265). 멤버별 1항목 1투표(presence = upvote).
+create table if not exists public.item_votes (
+  item_id    text        not null references public.items(id) on delete cascade,
+  trip_id    uuid        not null references public.trips(id) on delete cascade,
+  user_id    uuid        not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (item_id, user_id)
+);
+
+create index if not exists idx_item_votes_trip on public.item_votes(trip_id);
+
 -- ============================================================================
 -- RLS 재귀 회피용 헬퍼 함수 (SECURITY DEFINER)
 -- ============================================================================
@@ -130,6 +141,22 @@ create policy phc_select on public.place_hours_corrections
 drop policy if exists phc_insert on public.place_hours_corrections;
 create policy phc_insert on public.place_hours_corrections
   for insert with check (author_user_id = auth.uid());
+
+alter table public.item_votes enable row level security;
+-- item_votes: 멤버 읽기, owner/editor 본인 투표만 insert/delete (viewer 불가).
+drop policy if exists item_votes_select on public.item_votes;
+create policy item_votes_select on public.item_votes
+  for select using (public.is_trip_member(trip_id));
+drop policy if exists item_votes_insert on public.item_votes;
+create policy item_votes_insert on public.item_votes
+  for insert with check (
+    user_id = auth.uid() and public.user_role_in_trip(trip_id) in ('owner', 'editor')
+  );
+drop policy if exists item_votes_delete on public.item_votes;
+create policy item_votes_delete on public.item_votes
+  for delete using (
+    user_id = auth.uid() and public.user_role_in_trip(trip_id) in ('owner', 'editor')
+  );
 
 -- trips: 멤버만 SELECT, 본인이 owner 인 경우만 INSERT/UPDATE/DELETE
 drop policy if exists trips_select on public.trips;


### PR DESCRIPTION
## 관련 이슈
Closes #265

## 마이그레이션
`item_votes` 테이블 **운영 DB 적용 완료** (`npm run db:migrate` → `migration_265_item_votes.sql`).

## 변경 이유
일행이 후보 선호를 가볍게 표시해 "추리기" 결정을 집단으로 가시화한다 (레버 B:데이터). 멀티유저 백본(#108 trip_members + RLS) 위에서 동작.

## 변경 범위
- `migration_265` + `schema.sql`: `item_votes(item_id, trip_id, user_id, created_at)` PK(item_id,user_id) — 멤버별 1항목 1투표. items 처럼 trip_id 비정규화.
  - RLS: select `is_trip_member(trip_id)`(멤버 읽기), insert/delete `user_id=auth.uid() and user_role_in_trip in (owner,editor)` → **viewer 투표 불가**, 본인 것만.
- `app/api/item-votes/route.ts`: GET `?tripId=` → `{ [itemId]: {count, mine} }`, POST 토글(존재하면 delete, 없으면 insert; RLS 위반은 403).
- `lib/hooks/useItemVotes.ts`: SWR 집계 + 낙관적 토글(rollbackOnError).
- `components/Items/ItemCard.tsx`: VotePill(👍 N, 본인 투표 강조). `ItemList`·list 페이지에서 집계·토글 연결. viewer 는 `onToggleVote` 미전달 → 읽기 전용 표시.

## 검증
- `npm run lint` / `npm run build`(37/37, 새 API 포함) 통과
- `npm run db:migrate` 적용(is_trip_member/user_role_in_trip 헬퍼 의존 — 기존 존재)

## #265 수용 기준
- [x] 멤버별 1항목 1투표 토글 (PK(item_id,user_id) + 토글 API)
- [x] 집계 실시간 반영(낙관적 업데이트)
- [x] viewer 투표 불가 (RLS + UI 미노출)

## 남은 작업 / 리스크
- v1은 list 카드에 노출. 지도·일정 뷰 노출과 정렬(투표순)은 후속 여지.
- 그룹(중복 장소) 카드 투표는 단일 항목만 v1 대상.
