### PR TITLE
fix(ci): Node 20 → 22 (db:check WebSocket 초기화 실패 해결)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci
       - run: npm run db:check


### PR DESCRIPTION
## 변경 이유
`db-check` CI 잡이 `Node.js 20 detected without native WebSocket support` 로 실패. `@supabase/supabase-js` 2.105.4 의 realtime-js 가 `createClient` 시점에 native WebSocket 을 요구하는데 CI 의 Node 20 에는 없다. **마이그레이션·스키마 문제가 아니라** 스키마 조회를 시작하기도 전에 클라이언트 생성에서 죽은 것(로컬 Node 22 에서는 정상).

## 변경 범위
- `.github/workflows/ci.yml`: 두 잡(build, db-check) Node 20 → 22(현 LTS, 로컬 개발 환경과 동일). Node 22 는 native WebSocket 제공.

## 검증
- 로컬 Node v22.17 에서 `npm run db:check` 정상 동작 확인 → CI 도 동일 환경.

## 참고 / 후속(선택)
- `scripts/check-trips-schema.ts` 는 컬럼 존재 확인에 PostgREST select 만 쓰므로 realtime 이 불필요하다. Node 18/20 로컬 지원까지 챙기려면 supabase-js 대신 raw fetch(러너와 동일 방식)로 바꾸는 후속이 가능. 본 PR 은 CI 즉시 복구가 목적.
