### PR TITLE
fix: 새 여행 생성 후 대시보드 목록 미갱신 (router.refresh 추가)

### DIFF
--- a/app/dashboard/new/NewTripWizard.tsx
+++ b/app/dashboard/new/NewTripWizard.tsx
@@ -122,7 +122,10 @@ export default function NewTripWizard() {
       }
       // 대시보드 SWR 캐시를 즉시 갱신해 두면, 사용자가 뒤로가서 목록으로 돌아왔을 때
       // 새 trip 이 0.3-0.5s 후 "팝업" 되는 대신 처음부터 보인다.
+      // SWR 메모리 캐시(globalMutate)와 Next.js Router 캐시(router.refresh)를 함께 무효화해야
+      // 대시보드 RSC(initialTrips)까지 재검증돼 새 trip 이 항상 보인다. (다른 mutation 사이트와 동일한 2줄 세트)
       await globalMutate('/api/trips')
+      router.refresh()
       router.push(`/trip/${data.tripId}/map`)
     } catch (e) {
       const msg = e instanceof Error ? e.message : '여행 생성에 실패했습니다.'


### PR DESCRIPTION
## 관련 이슈
Closes #296

## 변경 이유
새 여행을 만들고 대시보드로 돌아오면 생성한 여행이 가끔 보이지 않고 새로고침해야 나타났다. 생성 핸들러가 `globalMutate('/api/trips')`(SWR 메모리 캐시)만 호출하고 `router.refresh()`(Next.js Router 캐시)를 빠뜨려, 대시보드 RSC가 들고 있는 `initialTrips`가 재검증되지 않았기 때문이다. localStorage 영속 캐시까지 겹쳐 옛 목록이 이긴다. 다른 trip 목록 변경 사이트(`EditableTripTitle`·`TripSettingsSheet`·`ManualCenterControl`)는 모두 두 캐시를 함께 무효화한다.

## 변경 범위
- `app/dashboard/new/NewTripWizard.tsx` 생성 성공 핸들러: `globalMutate('/api/trips')` 직후 `router.refresh()` 추가 (다른 mutation 사이트와 동일한 2줄 세트). 의도 설명 주석 보강.

## 검증
- `npm run lint` — 통과 (No issues found)
- `npm run build` — 통과 (전 라우트 컴파일 성공)

## 남은 작업 / 리스크
- 리스크 낮음(가산 변경, 동작 제거 없음).
- 후속: 이런 누락이 재발하지 않도록 무효화 컨벤션 표준화 → #297.
