### PR TITLE
feat: 온보딩·가치제안·메타 카피 보이스 패스

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -201,7 +201,7 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
             <EmptyState
               icon={<BrandMark size="lg" />}
               title="첫 여행을 시작해요"
-              description="모아둔 후보를 추려, 현장에서 안 깨지는 하루 일정으로 만들어요."
+              description="가 보고 싶은 곳을 모으면, 여기서 하루 단위 일정으로 정리할 수 있어요."
               action={
                 <Link href="/dashboard/new">
                   <Button>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 
 export const metadata: Metadata = {
   title: 'Waypost',
-  description: '지도 위에서 후보를 모아 동선을 직접 깎는 여행 설계 도구',
+  description: '가 보고 싶은 곳을 지도에 모아 하루 일정으로 정리하는 여행 계획 도구',
   applicationName: 'Waypost',
   appleWebApp: {
     capable: true,
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: 'Waypost',
-    description: '지도 위에서 후보를 모아 동선을 직접 깎는 여행 설계 도구',
+    description: '가 보고 싶은 곳을 지도에 모아 하루 일정으로 정리하는 여행 계획 도구',
     type: 'website',
   },
 }

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -4,7 +4,7 @@ export default function manifest(): MetadataRoute.Manifest {
   return {
     name: 'Waypost',
     short_name: 'Waypost',
-    description: '지도 위에서 후보를 모아 동선을 직접 깎는 여행 설계 도구',
+    description: '가 보고 싶은 곳을 지도에 모아 하루 일정으로 정리하는 여행 계획 도구',
     lang: 'ko',
     start_url: '/',
     scope: '/',

--- a/components/Brand/Wordmark.tsx
+++ b/components/Brand/Wordmark.tsx
@@ -7,12 +7,12 @@ import { cn } from '@/lib/cn'
 export const PRODUCT_NAME = 'Waypost'
 
 /**
- * 제품 이익 한 문장 — "왜 쓰는가 = 무엇을 얻는가" (이슈 #258).
+ * 제품 이익 한 문장 — "왜 쓰는가 = 무엇을 얻는가" (이슈 #258·#289).
  * 기능 나열·협업 강조 대신, 사용자가 얻는 결과만 말한다.
- * 정본 기준 문장: "내가 모은 후보 더미를, 버리지 않고 추려서,
- * 현장에서 안 깨지는 하루 일정으로 만든다." 를 표면용으로 압축한 것.
+ * 보이스 규칙(design-guidelines §11): 사람처럼·짧게, 부정추상('안 깨지는')·
+ * PM 관점 동사('동선을 깎다') 대신 사용자 체감 결과로 적는다.
  */
-export const PRODUCT_TAGLINE = '모아둔 후보를 추려, 현장에서 안 깨지는 하루 일정으로'
+export const PRODUCT_TAGLINE = '가 보고 싶은 곳을 모아, 하루 일정으로 정리해요'
 
 type WordmarkSize = 'sm' | 'md' | 'lg'
 

--- a/components/Items/ItemList.tsx
+++ b/components/Items/ItemList.tsx
@@ -316,7 +316,7 @@ export default function ItemList({
           <EmptyState
             icon={<MapPin className="size-10" aria-hidden="true" />}
             title="가고 싶은 곳부터 모아요"
-            description="후보를 모아두면, 나중에 추려서 안 깨지는 하루 일정으로 만들 수 있어요."
+            description="마음에 둔 장소를 먼저 담아 두세요. 일정은 나중에 정리하면 돼요."
             action={
               <Button onClick={() => router.push(tripPath('items/new'))}>
                 첫 장소 추가하기


### PR DESCRIPTION
## 관련 이슈
Closes #289

## 변경 이유
온보딩·가치제안 카피가 "AI가 쓴 티"가 나 제품 퀄리티를 낮췄다. #258이 "이익 한 문장"을 글자대로 따르다 부정추상('안 깨지는')·과압축·verbatim 중복을 양산했고, 메타엔 PM 관점 동사('동선을 직접 깎다')가 남아 있었다. 이미 존재하는 §11 보이스 가이드에 맞춰 사용자 체감 언어로 다시 쓴다.

## 변경 범위 (승인된 리라이트)
- 대시보드 빈 상태: "모아둔 후보를 추려, 현장에서 안 깨지는…" → "가 보고 싶은 곳을 모으면, 여기서 하루 단위 일정으로 정리할 수 있어요."
- 항목 목록 빈 상태: "후보를 모아두면, 나중에 추려서 안 깨지는…" → "마음에 둔 장소를 먼저 담아 두세요. 일정은 나중에 정리하면 돼요."
- 메타/OG/manifest: "지도 위에서 후보를 모아 동선을 직접 깎는 여행 설계 도구" → "가 보고 싶은 곳을 지도에 모아 하루 일정으로 정리하는 여행 계획 도구"
- `PRODUCT_TAGLINE`(가입·로그인 표면): "모아둔 후보를 추려, 현장에서 안 깨지는…" → "가 보고 싶은 곳을 모아, 하루 일정으로 정리해요"
- verbatim 중복("안 깨지는 하루 일정으로 만들어요") 제거.

## 검증
- 잔여 안티패턴 grep — 사용자향 문자열 0 (주석의 예시 인용만 남김)
- `npm run lint` / `npm run build` 통과

## 남은 작업 / 리스크
- 재발 방지(PR 템플릿 + §11 안티패턴 박제)는 #290 에서.
