### PR TITLE
feat: 헤더 컨텍스트 표시 + 트립페이지 크롬 정리 (#291 1차)

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,6 +3,8 @@ import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 import { listUserTrips } from '@/lib/trips'
 import DashboardClient from './DashboardClient'
 
+export const metadata = { title: '내 여행' }
+
 export const dynamic = 'force-dynamic'
 
 export default async function DashboardPage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,10 @@ import Providers from './providers'
 import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 
 export const metadata: Metadata = {
-  title: 'Waypost',
+  title: {
+    default: 'Waypost',
+    template: '%s · Waypost',
+  },
   description: '가 보고 싶은 곳을 지도에 모아 하루 일정으로 정리하는 여행 계획 도구',
   applicationName: 'Waypost',
   appleWebApp: {

--- a/app/trip/[tripId]/layout.tsx
+++ b/app/trip/[tripId]/layout.tsx
@@ -5,6 +5,24 @@ import TripAccessDenied from '@/components/UI/TripAccessDenied'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
+// 브라우저 탭·공유 미리보기에 "지금 보고 있는 여행" 을 표시(Basics-First #1 컨텍스트).
+// 루트 template("%s · Waypost") 가 적용돼 "도쿄 여행 · Waypost" 가 된다.
+export async function generateMetadata({ params }: { params: { tripId: string } }) {
+  if (!UUID_RE.test(params.tripId)) return {}
+  try {
+    const client = createRouteHandlerSupabase()
+    const { data } = await client
+      .from('trips')
+      .select('title')
+      .eq('id', params.tripId)
+      .maybeSingle<{ title: string }>()
+    if (data?.title) return { title: data.title }
+  } catch {
+    /* 메타데이터는 보조 정보 — 실패해도 페이지 렌더에 영향 없음 */
+  }
+  return {}
+}
+
 // PostgreSQL "undefined_column" — 운영 DB 에 마이그레이션이 적용되지 않은 경우 등.
 // 권한 문제가 아니므로 forbidden 으로 처리하지 않는다.
 const PG_UNDEFINED_COLUMN = '42703'

--- a/app/trip/[tripId]/list/page.tsx
+++ b/app/trip/[tripId]/list/page.tsx
@@ -19,7 +19,6 @@ import FilterButton from '@/components/Research/FilterButton'
 import FilterPanel from '@/components/Research/FilterPanel'
 import ActiveFilterChips from '@/components/Research/ActiveFilterChips'
 import { Input } from '@/components/UI/Input'
-import ThemeToggle from '@/components/Theme/ThemeToggle'
 import { useItems } from '@/lib/hooks/useItems'
 import { useToast } from '@/components/UI/Toast'
 import type { FilterState } from '@/components/Items/ItemList'
@@ -279,9 +278,6 @@ function ResearchPageContent() {
               <Share2 className="size-4" aria-hidden />
               공유
             </button>
-            <div className="md:hidden">
-              <ThemeToggle />
-            </div>
           </div>
         </div>
 

--- a/components/Layout/TripPageHeader.tsx
+++ b/components/Layout/TripPageHeader.tsx
@@ -2,7 +2,6 @@
 
 import type { ReactNode } from 'react'
 import EditableTripTitle from '@/components/Trip/EditableTripTitle'
-import ThemeToggle from '@/components/Theme/ThemeToggle'
 
 interface Props {
   section: string
@@ -16,7 +15,7 @@ interface Props {
 /**
  * 모든 /trip/[tripId]/** 페이지 공통 헤더.
  * - 좌: TripPageTitle (trip 제목 인라인 편집 · ⋯ 설정 · 섹션명)
- * - 우: 페이지 고유 액션 + 모바일 ThemeToggle
+ * - 우: 페이지 고유 액션 (테마 토글은 모바일 '더보기' 시트로 이동 — #291)
  * - 하단: 페이지 고유 body 슬롯 (검색·필터 등)
  *
  * G-1/G-2 의 인라인 편집·여행 설정 시트가 자동 포함.
@@ -28,9 +27,6 @@ export default function TripPageHeader({ section, actions, body, className = '' 
         <EditableTripTitle section={section} />
         <div className="flex items-center gap-2">
           {actions}
-          <div className="md:hidden">
-            <ThemeToggle />
-          </div>
         </div>
       </div>
       {body}

--- a/components/Plan/PlanScreen.tsx
+++ b/components/Plan/PlanScreen.tsx
@@ -5,7 +5,6 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import dynamic from 'next/dynamic'
 import Navigation from '@/components/Layout/Navigation'
 import MapSidePanel, { type DaySummary } from '@/components/Map/MapSidePanel'
-import ThemeToggle from '@/components/Theme/ThemeToggle'
 import FAB from '@/components/UI/FAB'
 import { useTripPath } from '@/lib/hooks/useTripContext'
 import Link from 'next/link'
@@ -206,10 +205,7 @@ export default function PlanScreen({ basePath }: PlanScreenProps) {
           <div className="pointer-events-none absolute top-3 left-3 z-[600] max-w-[60%] rounded-md bg-bg-elevated/90 px-2.5 py-1.5 shadow-sm backdrop-blur">
             <TripContextLabel />
           </div>
-          {/* 모바일 우측 상단 떠있는 테마 토글 + FAB */}
-          <div className="absolute top-3 right-3 z-[600]">
-            <ThemeToggle />
-          </div>
+          {/* 테마 토글은 모바일 '더보기' 시트로 통합(#291) — 지도 우상단은 비워 둠 */}
           <FAB className="bottom-[calc(var(--mobile-panel-height,40vh)+1rem)] right-4" />
         </div>
         <div

--- a/components/Trip/EditableTripTitle.tsx
+++ b/components/Trip/EditableTripTitle.tsx
@@ -101,18 +101,25 @@ export default function EditableTripTitle({ section }: { section: string }) {
             aria-label="여행 제목"
           />
         ) : (
-          <button
-            type="button"
-            onClick={() => editable && setEditing(true)}
-            className={`truncate text-xs font-medium text-fg-subtle ${
-              editable ? 'cursor-text hover:text-fg' : 'cursor-default'
-            }`}
-            title={editable ? '클릭하여 제목 편집' : trip.title}
-            disabled={!editable}
-          >
-            <span className="truncate">{trip.title}</span>
-            {range ? <span className="text-fg-subtle/70"> · {range}</span> : null}
-          </button>
+          <>
+            {/* 제목만 truncate, 기간(종료일)은 항상 보이도록 분리 (Basics-First #1 컨텍스트) */}
+            <button
+              type="button"
+              onClick={() => editable && setEditing(true)}
+              className={`min-w-0 truncate text-xs font-medium text-fg-subtle ${
+                editable ? 'cursor-text hover:text-fg' : 'cursor-default'
+              }`}
+              title={editable ? '클릭하여 제목 편집' : trip.title}
+              disabled={!editable}
+            >
+              {trip.title}
+            </button>
+            {range ? (
+              <span className="shrink-0 whitespace-nowrap text-xs font-medium text-fg-subtle/70">
+                · {range}
+              </span>
+            ) : null}
+          </>
         )}
         {editable && !editing && (
           <IconButton


### PR DESCRIPTION
## 관련 이슈
Closes #291

## 변경 이유
헤더 컨텍스트 부재(모든 탭이 "Waypost"), 트립 헤더 종료일 잘림, 모바일 크롬에 중복 상주하던 테마 토글을 정리한다.

## 변경 범위
**컨텍스트(Basics-First #1)**
- `app/layout.tsx`: title `template: '%s · Waypost'`
- `app/dashboard/page.tsx`: `metadata.title = '내 여행'`
- `app/trip/[tripId]/layout.tsx`: `generateMetadata` 로 trip 제목 주입(탭=`{trip} · Waypost`)
- `components/Trip/EditableTripTitle.tsx`: 제목/기간 분리 — 제목만 truncate, 기간(종료일)은 `shrink-0 whitespace-nowrap` 으로 항상 표시

**크롬 정리(트립 페이지)**
- 모바일 테마 토글 제거: `TripPageHeader`, `PlanScreen`(지도 떠있는 토글), `list/page.tsx`(중복). 모바일은 '더보기' 시트의 토글로 접근(진입점 유지 — Navigation.tsx 그대로).

## 검증
- `npm run lint` / `npm run build` 통과
- 트립 페이지 모바일에서 테마 토글은 '더보기' 시트에 남아있음(진입점 회귀 없음)

## 남은 작업 / 리스크
- **대시보드 헤더 통합 + 모바일 유저메뉴 신설은 분리 → #310.** 대시보드는 bottom-nav·AvatarDropdown(데스크탑 전용)이 없어, 낱개 버튼 제거 전 모바일 유저메뉴를 먼저 지어야 로그아웃/프로필 진입점 회귀가 없음(시각 QA 필요해 오토 머지 부적합).
