### PR TITLE
fix: 스켈레톤을 실물 레이아웃에 정렬 (가짜 배지 제거·layout shift 해소)

### DIFF
--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -16,19 +16,21 @@ export default function DashboardLoading() {
         </div>
       </header>
       <main className="max-w-5xl mx-auto px-4 md:px-8 py-6">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {/* 실물 trip 카드(DashboardClient)와 동일 레이아웃: 제목 + 텍스트 3줄 + 우상단 메뉴.
+            실물에 없는 배지 placeholder 를 두지 않아 로드 후 layout shift 가 없다. */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className="rounded-xl border border-border bg-bg-elevated p-5 space-y-3"
+              className="relative rounded-xl border border-border bg-bg-elevated p-4"
             >
-              <Skeleton className="h-5 w-3/4 rounded" />
-              <Skeleton className="h-3 w-1/2 rounded" />
-              <Skeleton className="h-3 w-2/3 rounded" />
-              <div className="flex gap-2 pt-2">
-                <Skeleton className="h-6 w-16 rounded-full" />
-                <Skeleton className="h-6 w-12 rounded-full" />
+              <Skeleton className="h-4 w-3/4 rounded mb-2" />
+              <div className="space-y-1">
+                <Skeleton className="h-3 w-1/2 rounded" />
+                <Skeleton className="h-3 w-2/3 rounded" />
+                <Skeleton className="h-3 w-2/5 rounded" />
               </div>
+              <Skeleton className="absolute top-3 right-3 size-8 rounded-md" />
             </div>
           ))}
         </div>

--- a/components/UI/ItemCardSkeleton.tsx
+++ b/components/UI/ItemCardSkeleton.tsx
@@ -1,22 +1,28 @@
 import { Skeleton } from './Skeleton'
 
+/**
+ * 실물 ItemCard 와 동일 레이아웃: 16px 아이콘 + 이름/주소 2줄, 우측 액션,
+ * 하단 메타데이터 칩 행(mt-3 pl-[22px]). 실물에 실재하는 요소만 placeholder 로 둔다.
+ */
 export default function ItemCardSkeleton() {
   return (
     <div
       className="bg-bg-elevated border border-border rounded-lg p-4"
       aria-hidden="true"
     >
-      <div className="flex items-start justify-between gap-2">
+      <div className="flex items-start justify-between gap-2 pl-2">
         <div className="flex items-center gap-2.5 min-w-0 flex-1">
-          <Skeleton className="size-3 rounded-full shrink-0" />
-          <div className="min-w-0 flex-1 space-y-1.5">
+          <Skeleton className="size-4 rounded shrink-0" />
+          <div className="min-w-0 flex-1 space-y-1">
             <Skeleton className="h-3.5 w-2/5" />
             <Skeleton className="h-3 w-3/5" />
           </div>
         </div>
-        <div className="flex items-center gap-1 shrink-0">
-          <Skeleton className="h-5 w-12 rounded-full" />
-        </div>
+        <Skeleton className="h-5 w-10 rounded shrink-0" />
+      </div>
+      <div className="mt-3 pl-[22px] flex gap-1.5">
+        <Skeleton className="h-5 w-14 rounded-full" />
+        <Skeleton className="h-5 w-12 rounded-full" />
       </div>
     </div>
   )

--- a/components/UI/ResearchTableSkeleton.tsx
+++ b/components/UI/ResearchTableSkeleton.tsx
@@ -1,39 +1,54 @@
 import { Skeleton } from './Skeleton'
 
+/**
+ * 실물 ResearchTable 과 동일한 고정폭 컬럼(이름 flex-1 · 분류 w-10 · 우선순위 w-28 ·
+ * 예약상태 w-28 · 예산 w-24 · 액션 w-8)과 rounded-xl · bg-bg-elevated 헤더에 정렬.
+ * 컬럼 정렬이 실물과 일치해 로드 후 가로 흔들림이 없다.
+ */
 export default function ResearchTableSkeleton() {
   return (
-    <div className="border border-border rounded-lg overflow-hidden bg-bg-elevated" aria-hidden="true">
-      {/* 헤더 */}
-      <div className="flex items-center border-b border-border bg-bg-subtle px-3 py-2.5 gap-4">
-        <Skeleton className="h-3 w-8" />
-        <Skeleton className="h-3 w-6 ml-auto" />
-        <Skeleton className="h-3 w-14" />
-        <Skeleton className="h-3 w-14" />
-        <Skeleton className="h-3 w-10" />
+    <div className="border border-border rounded-xl overflow-hidden" aria-hidden="true">
+      {/* 헤더 — 실물 컬럼 폭/패딩에 정렬 */}
+      <div className="flex items-center border-b border-border bg-bg-elevated">
+        <div className="flex-1 min-w-0 px-3 py-2.5">
+          <Skeleton className="h-3 w-10" />
+        </div>
+        <div className="w-10 flex-shrink-0 px-2 py-2.5 flex justify-center">
+          <Skeleton className="h-3 w-6" />
+        </div>
+        <div className="w-28 flex-shrink-0 px-2 py-2.5">
+          <Skeleton className="h-3 w-12" />
+        </div>
+        <div className="w-28 flex-shrink-0 px-2 py-2.5">
+          <Skeleton className="h-3 w-12" />
+        </div>
+        <div className="w-24 flex-shrink-0 px-3 py-2.5 flex justify-end">
+          <Skeleton className="h-3 w-8" />
+        </div>
+        <div className="w-8 flex-shrink-0" />
       </div>
       {/* 행 */}
       {Array.from({ length: 8 }).map((_, i) => (
         <div
           key={i}
-          className="flex items-center border-b border-border last:border-b-0 px-3 py-3 gap-4"
+          className="flex items-center border-b border-border last:border-b-0"
         >
-          <Skeleton
-            className="flex-1 h-3.5"
-            // eslint-disable-next-line react/forbid-dom-props
-          />
-          <div className="w-10 flex justify-center">
-            <Skeleton className="size-5 rounded" />
+          <div className="flex-1 min-w-0 px-3 py-2.5">
+            <Skeleton className="h-3.5 w-3/4" />
           </div>
-          <div className="w-28">
-            <Skeleton className="h-5 w-20 rounded-full" />
+          <div className="w-10 flex-shrink-0 px-2 py-2.5 flex justify-center">
+            <Skeleton className="size-4 rounded" />
           </div>
-          <div className="w-28">
+          <div className="w-28 flex-shrink-0 px-2 py-2.5">
             <Skeleton className="h-5 w-16 rounded-full" />
           </div>
-          <div className="w-24 flex justify-end">
+          <div className="w-28 flex-shrink-0 px-2 py-2.5">
+            <Skeleton className="h-5 w-16 rounded-full" />
+          </div>
+          <div className="w-24 flex-shrink-0 px-3 py-2.5 flex justify-end">
             <Skeleton className="h-3 w-10" />
           </div>
-          <div className="w-8" />
+          <div className="w-8 flex-shrink-0" />
         </div>
       ))}
     </div>


### PR DESCRIPTION
## 관련 이슈
Closes #292

## 변경 이유
스켈레톤이 실물과 형태가 달라 로딩 후 layout shift 가 났고, 대시보드 스켈레톤은 실물에 없는 배지 2개를 약속했다(레이아웃판 정직성 위반). 3개 스켈레톤을 현재 실물 구조에 정확히 정렬한다.

## 변경 범위
- `app/dashboard/loading.tsx`: 가짜 배지 제거, p-5→p-4·gap-4→gap-3·간격, 우상단 메뉴 placeholder — 실물 카드(제목+텍스트 3줄+메뉴)와 일치.
- `components/UI/ItemCardSkeleton.tsx`: 아이콘 12→16px, 이름/주소 2줄, 하단 메타칩 행(mt-3 pl-[22px]) — 실재 요소만 placeholder.
- `components/UI/ResearchTableSkeleton.tsx`: 고정폭 컬럼·rounded-xl·bg-bg-elevated 헤더로 실물 컬럼 정렬, 불필요한 eslint-disable 제거.

## 검증
- `npm run lint` / `npm run build` 통과

## 남은 작업 / 리스크
- 본 PR은 "정밀 정렬"로 현재 드리프트를 해소한다. 실물 변경 시 자동 추종하는 **레이아웃 셸 공유**(real+skeleton 동일 래퍼)는 DashboardClient/ItemCard 렌더 경로를 건드리는 더 큰 리팩터라, 드리프트 재발 시 후속으로 권장.
