### PR TITLE
refactor: trip 목록 무효화 컨벤션 통일 (invalidateTrips 헬퍼)

### DIFF
--- a/app/dashboard/new/NewTripWizard.tsx
+++ b/app/dashboard/new/NewTripWizard.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
-import { mutate as globalMutate } from 'swr'
+import { invalidateTrips } from '@/lib/swr/invalidateTrips'
 import { ArrowLeft } from 'lucide-react'
 import Button from '@/components/UI/Button'
 import { Input } from '@/components/UI/Input'
@@ -227,13 +227,9 @@ export default function NewTripWizard() {
           }),
         }).catch(() => {})
       }
-      // 대시보드 SWR 캐시를 즉시 갱신해 두면, 사용자가 뒤로가서 목록으로 돌아왔을 때
-      // 새 trip 이 0.3-0.5s 후 "팝업" 되는 대신 처음부터 보인다.
-      // SWR 메모리 캐시(globalMutate)와 Next.js Router 캐시(router.refresh)를 함께 무효화해야
-      // 대시보드 RSC(initialTrips)까지 재검증돼 새 trip 이 항상 보인다. (다른 mutation 사이트와 동일한 2줄 세트)
+      // 대시보드로 돌아왔을 때 새 trip 이 바로 보이도록 SWR + Router 캐시를 함께 무효화.
       clearDraft()
-      await globalMutate('/api/trips')
-      router.refresh()
+      await invalidateTrips(router)
       router.push(`/trip/${data.tripId}/map`)
     } catch (e) {
       const msg = e instanceof Error ? e.message : '여행 생성에 실패했습니다.'

--- a/components/Map/ManualCenterControl.tsx
+++ b/components/Map/ManualCenterControl.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useMap } from 'react-leaflet'
 import { useRouter } from 'next/navigation'
-import { mutate as globalMutate } from 'swr'
+import { invalidateTrips } from '@/lib/swr/invalidateTrips'
 import type L from 'leaflet'
 import { MapPin, RotateCcw } from 'lucide-react'
 import type { TripItem } from '@/types'
@@ -75,8 +75,7 @@ export default function ManualCenterBanner({ map, items, basecampCoord, region }
         showToast({ message: data?.error ?? '저장에 실패했습니다.', type: 'error' })
         return false
       }
-      globalMutate('/api/trips')
-      router.refresh()
+      await invalidateTrips(router)
       return true
     } catch {
       showToast({ message: '네트워크 오류가 발생했습니다.', type: 'error' })

--- a/components/Trip/EditableTripTitle.tsx
+++ b/components/Trip/EditableTripTitle.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { mutate as globalMutate } from 'swr'
+import { invalidateTrips } from '@/lib/swr/invalidateTrips'
 import { MoreHorizontal } from 'lucide-react'
 import { useTrip } from '@/lib/hooks/useTripContext'
 import { useToast } from '@/components/UI/Toast'
@@ -64,8 +64,7 @@ export default function EditableTripTitle({ section }: { section: string }) {
         setDraft(trip.title)
       } else {
         showToast({ message: '제목을 저장했습니다.', type: 'success' })
-        globalMutate('/api/trips')
-        router.refresh()
+        await invalidateTrips(router)
       }
     } catch {
       showToast({ message: '네트워크 오류', type: 'error' })

--- a/components/Trip/TripSettingsSheet.tsx
+++ b/components/Trip/TripSettingsSheet.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { mutate as globalMutate } from 'swr'
+import { invalidateTrips } from '@/lib/swr/invalidateTrips'
 import Sheet, { SheetSection } from '@/components/UI/Sheet'
 import { Input } from '@/components/UI/Input'
 import Button from '@/components/UI/Button'
@@ -150,8 +150,7 @@ export default function TripSettingsSheet({ open, onClose }: Props) {
         return
       }
       showToast({ message: '여행 정보를 저장했습니다.', type: 'success' })
-      globalMutate('/api/trips')
-      router.refresh()
+      await invalidateTrips(router)
       onClose()
     } catch {
       showToast({ message: '네트워크 오류가 발생했습니다.', type: 'error' })
@@ -181,7 +180,8 @@ export default function TripSettingsSheet({ open, onClose }: Props) {
         return
       }
       showToast({ message: '여행을 삭제했어요.', type: 'success' })
-      globalMutate('/api/trips')
+      // 삭제도 Router 캐시까지 무효화해야 대시보드에서 삭제된 trip 이 사라진다(기존 누락 수정).
+      await invalidateTrips(router)
       router.push('/dashboard')
     } catch {
       showToast({ message: '네트워크 오류가 발생했습니다.', type: 'error' })

--- a/lib/swr/invalidateTrips.ts
+++ b/lib/swr/invalidateTrips.ts
@@ -1,0 +1,15 @@
+import { mutate as globalMutate } from 'swr'
+
+/** trip 목록 SWR 키 — 문자열 리터럴 산재 방지를 위한 단일 소스. */
+export const TRIPS_KEY = '/api/trips'
+
+/**
+ * trip 목록을 바꾼 뒤(생성·수정·삭제·중심 변경) 호출한다.
+ * SWR 메모리 캐시(globalMutate)와 Next.js Router 캐시(router.refresh)를 **함께**
+ * 무효화한다 — 둘 중 하나라도 빠뜨리면 대시보드 RSC(initialTrips)가 재검증되지
+ * 않아 stale 목록이 보인다(#296). 그래서 두 동작을 한 헬퍼로 묶어 빠뜨릴 수 없게 한다.
+ */
+export async function invalidateTrips(router: { refresh: () => void }) {
+  await globalMutate(TRIPS_KEY)
+  router.refresh()
+}


### PR DESCRIPTION
## 관련 이슈
Closes #297

## 변경 이유
mutation 후 캐시 무효화가 사이트마다 `globalMutate('/api/trips')` + `router.refresh()` 두 줄을 손으로 반복해, 빠뜨리기 쉬웠다(#296 이 그 첫 사례). 두 동작을 단일 헬퍼로 묶어 구조적으로 차단한다.

## 변경 범위
- `lib/swr/invalidateTrips.ts` 신설: `TRIPS_KEY` 상수 + `invalidateTrips(router)`(SWR 메모리 캐시 + Next Router 캐시 동시 무효화).
- 적용: `NewTripWizard`, `ManualCenterControl`, `EditableTripTitle`, `TripSettingsSheet`(저장). 동작 동일, 호출을 한 줄로 통일.
- **버그 보강**: `TripSettingsSheet` 삭제 핸들러가 `router.refresh()` 를 빠뜨려 삭제 후 대시보드에 stale trip 이 보일 수 있었음 — 헬퍼 적용으로 수정.
- `DashboardClient` 삭제는 대시보드 위에서 로컬 SWR(`mutateTrips`)로 직접 revalidate 하므로 별도(유지).

## 검증
- 잔여 `globalMutate('/api/trips')` 0
- `npm run lint` / `npm run build` 통과

## 남은 작업 / 리스크
- `ShareDialog`(수동 fetch+로딩) → `useShares` SWR 훅 parity 는 데이터 모델이 달라 분량·위험이 커서 후속 이슈로 분리 권장.
- 항목(items) 옵티미스틱은 이미 `useItems` 로 일관 — 본 PR 범위 밖.
