### PR TITLE
fix: '이름 미정' 일괄편집 저장 시 항목이 하나씩 사라지는 문제

### DIFF
--- a/app/trip/[tripId]/list/page.tsx
+++ b/app/trip/[tripId]/list/page.tsx
@@ -49,7 +49,7 @@ function ResearchPageContent() {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
-  const { items, isLoading, updateItem, createItem } = useItems()
+  const { items, isLoading, updateItem, updateItemsBulk, createItem } = useItems()
   const { showToast } = useToast()
   const tripId = useTripId()
   const trip = useOptionalTrip()
@@ -400,6 +400,7 @@ function ResearchPageContent() {
         onClose={() => setUnnamedDialogOpen(false)}
         items={filterUnnamed(items)}
         onUpdateItem={updateItem}
+        onUpdateItems={updateItemsBulk}
       />
 
       <ShareDialog

--- a/components/Items/UnnamedBulkEditDialog.tsx
+++ b/components/Items/UnnamedBulkEditDialog.tsx
@@ -12,6 +12,10 @@ interface Props {
   onClose: () => void
   items: TripItem[]
   onUpdateItem: (id: string, changes: Record<string, unknown>) => Promise<unknown> | unknown
+  /** 일괄 저장 — 옵티미스틱 1회 + 병렬 PATCH + revalidate 1회로 stagger 없이 수렴(#298). */
+  onUpdateItems: (
+    updates: { id: string; changes: Record<string, unknown> }[],
+  ) => Promise<{ okIds: string[]; failedIds: string[] }>
 }
 
 interface RowState {
@@ -28,7 +32,7 @@ const UNNAMED_PREFIX = '📍'
  * Gmaps import 이후 `📍` prefix 가 붙은 좌표만 가진 항목을 모아 한 시트에서 명명.
  * 각 행: reverse geocode 후보 (선택 시 입력에 적용) + 직접 입력 + 개별 저장.
  */
-export default function UnnamedBulkEditDialog({ open, onClose, items, onUpdateItem }: Props) {
+export default function UnnamedBulkEditDialog({ open, onClose, items, onUpdateItem, onUpdateItems }: Props) {
   const { showToast } = useToast()
   const [rows, setRows] = useState<Record<string, RowState>>({})
   const [savingAll, setSavingAll] = useState(false)
@@ -102,32 +106,26 @@ export default function UnnamedBulkEditDialog({ open, onClose, items, onUpdateIt
 
   async function handleSaveAll() {
     setSavingAll(true)
-    const toSave = items.filter((it) => {
-      const row = rows[it.id]
-      if (!row) return false
-      if (row.saved) return false
-      return row.draft.trim().length > 0
+    const updates = items
+      .filter((it) => {
+        const row = rows[it.id]
+        return row && !row.saved && row.draft.trim().length > 0
+      })
+      .map((it) => ({ id: it.id, changes: { name: rows[it.id].draft.trim() } }))
+
+    // 개별 N회 저장 대신 일괄 처리 — 옵티미스틱 1회 + revalidate 1회로 항목이
+    // "하나씩" 사라지는 stagger 없이 한 번에 정리된다(#298).
+    const { okIds, failedIds } = await onUpdateItems(updates)
+
+    setRows((prev) => {
+      const next = { ...prev }
+      for (const id of okIds) next[id] = { ...next[id], saved: true, error: null }
+      for (const id of failedIds) next[id] = { ...next[id], error: '저장 실패' }
+      return next
     })
-    let ok = 0
-    for (const it of toSave) {
-      const name = rows[it.id]?.draft.trim()
-      if (!name) continue
-      try {
-        await onUpdateItem(it.id, { name })
-        setRows((prev) => ({
-          ...prev,
-          [it.id]: { ...prev[it.id], saved: true },
-        }))
-        ok++
-      } catch {
-        setRows((prev) => ({
-          ...prev,
-          [it.id]: { ...prev[it.id], error: '저장 실패' },
-        }))
-      }
-    }
     setSavingAll(false)
-    if (ok > 0) showToast({ type: 'success', message: `${ok}개 저장했어요` })
+    if (okIds.length > 0) showToast({ type: 'success', message: `${okIds.length}개 저장했어요` })
+    else if (failedIds.length > 0) showToast({ type: 'error', message: '저장에 실패했어요' })
   }
 
   const pending = items.filter((it) => !rows[it.id]?.saved)

--- a/lib/hooks/useItems.ts
+++ b/lib/hooks/useItems.ts
@@ -149,7 +149,62 @@ export function useItems() {
     syncStatus,
     error: error ?? null,
     updateItem,
+    updateItemsBulk,
     deleteItem,
     createItem,
+  }
+
+  /**
+   * 여러 항목을 한 번에 수정한다(일괄 명명 등).
+   * 개별 updateItem 을 N번 부르면 매 건마다 전체 revalidate 가 일어나 항목이
+   * "하나씩" 갱신/사라지는 stagger 가 생긴다(#298). 대신:
+   *  1) 옵티미스틱 업데이트 1회로 전체 변경을 한 번에 반영
+   *  2) PATCH 를 병렬 실행
+   *  3) 끝나고 revalidate 1회로 수렴(실패분은 서버 진실로 자동 복원)
+   */
+  async function updateItemsBulk(
+    updates: { id: string; changes: Record<string, unknown> }[],
+  ): Promise<{ okIds: string[]; failedIds: string[] }> {
+    if (typeof navigator !== 'undefined' && !navigator.onLine) {
+      showToast({ type: 'info', message: '오프라인 상태입니다. 인터넷 연결 후 다시 시도해주세요.' })
+      return { okIds: [], failedIds: updates.map(u => u.id) }
+    }
+    if (updates.length === 0) return { okIds: [], failedIds: [] }
+
+    const changeMap = new Map(updates.map(u => [u.id, u.changes]))
+    mutate(
+      prev =>
+        prev
+          ? {
+              items: prev.items.map(i =>
+                changeMap.has(i.id) ? applyItemChanges(i, changeMap.get(i.id)!) : i,
+              ),
+            }
+          : prev,
+      { revalidate: false },
+    )
+
+    const results = await Promise.all(
+      updates.map(async u => {
+        try {
+          const res = await fetch(withTripId(`/api/items/${u.id}`, tripId), {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(u.changes),
+          })
+          return { id: u.id, ok: res.ok }
+        } catch {
+          return { id: u.id, ok: false }
+        }
+      }),
+    )
+
+    // revalidate 1회로 수렴 — 성공분은 서버 새 값, 실패분은 옛 값으로 자동 복원.
+    mutate()
+
+    return {
+      okIds: results.filter(r => r.ok).map(r => r.id),
+      failedIds: results.filter(r => !r.ok).map(r => r.id),
+    }
   }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #298

## 변경 이유
"이름 미정" 일괄편집 저장 후 일부 항목이 편집 대상처럼 남아 있다가 하나씩 사라졌다. `handleSaveAll` 이 `updateItem` 을 순차 N회 호출해 매 건마다 전체 목록 revalidate 가 일어나고, 다이얼로그가 로컬 `saved` 를 서버 확인 전에 켜 stagger/ghost 가 생겼다. (데이터는 정상 저장됨 — UI 일관성 문제.)

## 변경 범위
- `lib/hooks/useItems.ts`: `updateItemsBulk` 신설 — 옵티미스틱 업데이트 1회로 전체 반영 → PATCH 병렬 실행 → revalidate 1회 수렴(실패분은 서버 진실로 자동 복원). `okIds/failedIds` 반환.
- `components/Items/UnnamedBulkEditDialog.tsx`: `handleSaveAll` 이 순차 루프 대신 `onUpdateItems`(벌크) 1회 호출. 결과로 saved/error 일괄 반영.
- `app/trip/[tripId]/list/page.tsx`: `updateItemsBulk` 배선.

## 검증
- `npm run lint` / `npm run build` 통과
- 동작(수동 확인 권장): 여러 항목 명명 후 "모두 저장" → 항목이 한 번에 목록에서 정리됨(하나씩 사라지지 않음).

## 남은 작업 / 리스크
- `📍` 접두사를 "편집 대상" 판정 기준으로 쓰는 취약성(사용자가 📍로 시작하는 이름 입력 가능) → `needsName`/좌표-only 플래그 전환은 별도 P3.
