### PR TITLE
feat: 비밀번호 강도 — 흔한 비번 차단 + zxcvbn-ts 강도 미터

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { signUpWithEmail } from '@/lib/auth'
 import { mapAuthError } from '@/lib/auth-errors'
+import { isCommonPassword } from '@/lib/commonPasswords'
 
 export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => null)
@@ -12,6 +13,12 @@ export async function POST(request: NextRequest) {
   }
   if (password.length < 8) {
     return NextResponse.json({ error: '비밀번호는 8자 이상이어야 합니다.' }, { status: 400 })
+  }
+  if (isCommonPassword(password)) {
+    return NextResponse.json(
+      { error: '너무 흔한 비밀번호예요. 추측하기 어려운 비밀번호로 바꿔주세요.' },
+      { status: 400 },
+    )
   }
 
   const origin = new URL(request.url).origin

--- a/app/api/auth/update-password/route.ts
+++ b/app/api/auth/update-password/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getSession, updatePassword } from '@/lib/auth'
+import { isCommonPassword } from '@/lib/commonPasswords'
 
 export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => null)
@@ -10,6 +11,12 @@ export async function POST(request: NextRequest) {
   }
   if (password.length < 8) {
     return NextResponse.json({ error: '비밀번호는 8자 이상이어야 합니다.' }, { status: 400 })
+  }
+  if (isCommonPassword(password)) {
+    return NextResponse.json(
+      { error: '너무 흔한 비밀번호예요. 추측하기 어려운 비밀번호로 바꿔주세요.' },
+      { status: 400 },
+    )
   }
 
   const session = await getSession()

--- a/app/auth/update-password/page.tsx
+++ b/app/auth/update-password/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { PasswordInput } from '@/components/UI'
+import { PasswordInput, PasswordStrengthMeter } from '@/components/UI'
 
 export default function UpdatePasswordPage() {
   const [password, setPassword] = useState('')
@@ -45,14 +45,17 @@ export default function UpdatePasswordPage() {
           onSubmit={handleSubmit}
           className="bg-bg-elevated rounded-2xl shadow-sm border border-border p-6 space-y-4"
         >
-          <PasswordInput
-            label="새 비밀번호 (8자 이상)"
-            value={password}
-            onChange={e => setPassword(e.target.value)}
-            autoComplete="new-password"
-            minLength={8}
-            required
-          />
+          <div>
+            <PasswordInput
+              label="새 비밀번호 (8자 이상)"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              autoComplete="new-password"
+              minLength={8}
+              required
+            />
+            <PasswordStrengthMeter password={password} />
+          </div>
 
           {error && (
             <div className="bg-critical-bg border border-critical-border rounded-lg px-3 py-2">

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { useState } from 'react'
 import { clearAppCache } from '@/lib/clearAppCache'
-import { ErrorBanner, PasswordInput } from '@/components/UI'
+import { ErrorBanner, PasswordInput, PasswordStrengthMeter } from '@/components/UI'
 import { BrandMark, PRODUCT_TAGLINE } from '@/components/Brand/Wordmark'
 
 export default function SignupForm() {
@@ -80,14 +80,17 @@ export default function SignupForm() {
               />
             </div>
 
-            <PasswordInput
-              label="비밀번호 (8자 이상)"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              autoComplete="new-password"
-              minLength={8}
-              required
-            />
+            <div>
+              <PasswordInput
+                label="비밀번호 (8자 이상)"
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+                autoComplete="new-password"
+                minLength={8}
+                required
+              />
+              <PasswordStrengthMeter password={password} />
+            </div>
 
             {error && (
               <ErrorBanner tone="critical" onDismiss={() => setError('')}>

--- a/components/UI/PasswordStrengthMeter.tsx
+++ b/components/UI/PasswordStrengthMeter.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { cn } from '@/lib/cn'
+import { estimateStrength, STRENGTH_LABEL, type StrengthResult } from '@/lib/passwordStrength'
+
+interface Props {
+  password: string
+}
+
+const BAR_COLOR: Record<StrengthResult['score'], string> = {
+  0: 'bg-critical-fg',
+  1: 'bg-critical-fg',
+  2: 'bg-warning-fg',
+  3: 'bg-success-fg',
+  4: 'bg-success-fg',
+}
+
+/**
+ * 비밀번호 강도 미터. zxcvbn-ts 를 동적 로드해 점수(0-4)·경고·제안을 보여준다.
+ * 가입·비밀번호 재설정에서 PasswordInput 아래에 둔다(로그인에는 쓰지 않는다).
+ */
+export default function PasswordStrengthMeter({ password }: Props) {
+  const [result, setResult] = useState<StrengthResult | null>(null)
+
+  useEffect(() => {
+    if (!password) {
+      setResult(null)
+      return
+    }
+    let cancelled = false
+    const t = setTimeout(() => {
+      estimateStrength(password)
+        .then((r) => {
+          if (!cancelled) setResult(r)
+        })
+        .catch(() => {
+          /* 동적 로드 실패 시 미터만 생략(가입 자체는 서버 검증으로 보호) */
+        })
+    }, 250)
+    return () => {
+      cancelled = true
+      clearTimeout(t)
+    }
+  }, [password])
+
+  if (!password || !result) return null
+
+  const tip = result.score < 3 ? '더 길게 쓰거나 추측하기 어려운 단어 조합을 써보세요.' : ''
+
+  return (
+    <div className="mt-1.5" aria-live="polite">
+      <div className="flex gap-1" role="presentation">
+        {[0, 1, 2, 3].map((i) => (
+          <span
+            key={i}
+            className={cn(
+              'h-1 flex-1 rounded-full transition-colors',
+              i <= result.score - 1 ? BAR_COLOR[result.score] : 'bg-border',
+            )}
+          />
+        ))}
+      </div>
+      <p className="mt-1 text-xs text-fg-subtle">
+        비밀번호 강도: <span className="font-medium text-fg-muted">{STRENGTH_LABEL[result.score]}</span>
+        {tip ? ` · ${tip}` : ''}
+      </p>
+    </div>
+  )
+}

--- a/components/UI/index.ts
+++ b/components/UI/index.ts
@@ -10,4 +10,5 @@ export { Card, CardHeader, CardBody, CardFooter, CardTitle, CardMeta } from './C
 export { Chip, ChipButton } from './Chip'
 export { Input, Textarea, Select } from './Input'
 export { PasswordInput } from './PasswordInput'
+export { default as PasswordStrengthMeter } from './PasswordStrengthMeter'
 export { Skeleton, SkeletonCard, SkeletonList } from './Skeleton'

--- a/lib/commonPasswords.ts
+++ b/lib/commonPasswords.ts
@@ -1,0 +1,54 @@
+/**
+ * 서버 측 최소 방어선(NIST 800-63B): 길이 + 흔한/유출 비밀번호 차단.
+ * 복잡도 강제(특수문자 필수 등)는 하지 않는다 — 길이 우선 + 흔한 비번 거부.
+ * 전수 유출 DB 대조는 별도(후속); 여기서는 가장 흔한 비번을 인라인으로 막는다.
+ */
+const COMMON_PASSWORDS = new Set(
+  [
+    '12345678',
+    '123456789',
+    '1234567890',
+    'password',
+    'password1',
+    'password123',
+    'qwerty123',
+    'qwertyuiop',
+    '11111111',
+    '00000000',
+    '12341234',
+    'abcd1234',
+    'a1234567',
+    '1q2w3e4r',
+    '1q2w3e4r5t',
+    'asdf1234',
+    'zxcvbnm1',
+    'iloveyou',
+    'admin123',
+    'letmein1',
+    'welcome1',
+    'monkey12',
+    'dragon123',
+    'sunshine1',
+    'football1',
+    'baseball1',
+    'trustno1',
+    'starwars1',
+    'whatever1',
+    'superman1',
+    'michael1',
+    'princess1',
+    'passw0rd',
+    'p@ssw0rd',
+    'qazwsxedc',
+    '87654321',
+    '147258369',
+    '11223344',
+    'samsung1',
+    'galaxy123',
+  ].map((p) => p.toLowerCase()),
+)
+
+/** 흔한 비밀번호이면 true. 대소문자 무시. */
+export function isCommonPassword(password: string): boolean {
+  return COMMON_PASSWORDS.has(password.toLowerCase())
+}

--- a/lib/passwordStrength.ts
+++ b/lib/passwordStrength.ts
@@ -1,0 +1,47 @@
+/**
+ * 비밀번호 강도 추정 — zxcvbn-ts 를 **동적 import** 로 지연 로드해 초기 번들에서 제외한다.
+ * 사용자가 비밀번호를 입력하기 시작할 때만 로드된다.
+ *
+ * zxcvbn-ts v4 는 ZxcvbnFactory().check() 형태이고, feedback 의 warning/suggestion 은
+ * 번역 키(언어팩 미설정 시 raw key)라 신뢰할 수 없어 점수(0-4)만 사용한다.
+ */
+
+type Score = 0 | 1 | 2 | 3 | 4
+interface Factory {
+  check(password: string): { score: number }
+}
+
+let factoryPromise: Promise<Factory> | null = null
+
+async function loadFactory(): Promise<Factory> {
+  if (!factoryPromise) {
+    factoryPromise = (async () => {
+      const { ZxcvbnFactory } = await import('@zxcvbn-ts/core')
+      const common = await import('@zxcvbn-ts/language-common')
+      return new ZxcvbnFactory({
+        dictionary: common.dictionary,
+        graphs: common.adjacencyGraphs,
+      }) as unknown as Factory
+    })()
+  }
+  return factoryPromise
+}
+
+export interface StrengthResult {
+  /** 0(매우 약함) - 4(매우 강함) */
+  score: Score
+}
+
+export async function estimateStrength(password: string): Promise<StrengthResult> {
+  const factory = await loadFactory()
+  const { score } = factory.check(password)
+  return { score: Math.max(0, Math.min(4, score)) as Score }
+}
+
+export const STRENGTH_LABEL: Record<Score, string> = {
+  0: '매우 약함',
+  1: '약함',
+  2: '보통',
+  3: '강함',
+  4: '매우 강함',
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.100.0",
+        "@zxcvbn-ts/core": "^4.1.2",
+        "@zxcvbn-ts/language-common": "^4.1.2",
         "fuse.js": "^7.3.0",
         "leaflet": "^1.9.4",
         "lucide-react": "^1.11.0",
@@ -1760,6 +1762,30 @@
         "win32"
       ]
     },
+    "node_modules/@zxcvbn-ts/core": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@zxcvbn-ts/core/-/core-4.1.2.tgz",
+      "integrity": "sha512-RQmxWB3AMI+HGQErQdUv6Aq32aQhp6xOxrfgCP0+T9MsLZoP3xtLHuT8O8VojsUxdmQVZfJlYkYb1A0wOwIS+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fastest-levenshtein": "1.0.16"
+      }
+    },
+    "node_modules/@zxcvbn-ts/dictionary-compression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@zxcvbn-ts/dictionary-compression/-/dictionary-compression-3.0.1.tgz",
+      "integrity": "sha512-p3KyPzxGc3vWSap5hHA6SllbUCmh7s+NtpGyC3qEWrxYJT9t9TUAzjPm48Okipo+UUyPQfDlIvTcs9JRShBFiQ==",
+      "license": "MIT"
+    },
+    "node_modules/@zxcvbn-ts/language-common": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@zxcvbn-ts/language-common/-/language-common-4.1.2.tgz",
+      "integrity": "sha512-uJlBzhC9/KjPImqdnc1/lPxmdn4xKbkruN5p1mASWkXA0gli+GZ5LrVL+dqscA8Pcf4OfudE56TtCWeHljJOvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zxcvbn-ts/dictionary-compression": "^3.0.1"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3375,6 +3401,15 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.100.0",
+    "@zxcvbn-ts/core": "^4.1.2",
+    "@zxcvbn-ts/language-common": "^4.1.2",
     "fuse.js": "^7.3.0",
     "leaflet": "^1.9.4",
     "lucide-react": "^1.11.0",


### PR DESCRIPTION
## 관련 이슈
Closes #287

## 변경 이유
비밀번호 검증이 "8자 이상"뿐이라 `12345678` 같은 흔한 비번이 통과했다. NIST 800-63B 방향(길이 우선 + 흔한/유출 비번 차단, 복잡도 강제 지양)으로 최소 강도를 확보한다.

## 변경 범위
- `lib/commonPasswords.ts`: 흔한 비번 차단 유틸(`isCommonPassword`).
- 서버: `signup`·`update-password` 라우트에서 흔한 비번 거부(길이 검증과 동일 위치).
- `lib/passwordStrength.ts`: zxcvbn-ts v4(`ZxcvbnFactory`)를 **동적 import** 로 지연 로드(초기 번들 제외).
- `components/UI/PasswordStrengthMeter.tsx`: 점수(0-4) 막대 + 라벨. 가입·재설정 폼에만 추가(로그인 제외). feedback 텍스트는 v4에서 번역키라 점수만 사용, 약한 경우 정적 팁.
- deps: `@zxcvbn-ts/core`, `@zxcvbn-ts/language-common`.

## 검증
- `npm run lint` / `npm run build` 통과 (zxcvbn 은 별도 동적 청크)

## 남은 작업 / 리스크
- 전수 유출 DB 대조는 미포함(인라인 흔한비번 셋으로 1차 방어). 후속 가능.
- **패스키 우선 로그인 → #305**, **가입 이메일 인증 → #306** 으로 분리 추적(이번 범위 아님).
