### PR TITLE
feat: 구글맵 연동 모바일 — 텍스트 줄바꿈 + 다른 URL sticky 푸터

### DIFF
--- a/app/trip/[tripId]/gmaps-import/page.tsx
+++ b/app/trip/[tripId]/gmaps-import/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import Navigation from '@/components/Layout/Navigation'
 import UrlInput from '@/components/GmapsImport/UrlInput'
 import CandidateList from '@/components/GmapsImport/CandidateList'
+import StickyActionBar from '@/components/UI/StickyActionBar'
 import { useTripId, useTripPath } from '@/lib/hooks/useTripContext'
 import TripPageHeader from '@/components/Layout/TripPageHeader'
 import type { ImportCandidate } from '@/types'
@@ -138,12 +139,14 @@ export default function GmapsImportPage() {
             {error && (
               <p className="mt-3 text-sm text-critical-fg">{error}</p>
             )}
-            <button
-              onClick={handleReset}
-              className="mt-4 text-sm text-fg-subtle hover:text-fg-muted transition-colors"
-            >
-              다른 URL 입력
-            </button>
+            <StickyActionBar className="justify-start">
+              <button
+                onClick={handleReset}
+                className="text-sm text-fg-subtle hover:text-fg-muted transition-colors"
+              >
+                다른 URL 입력
+              </button>
+            </StickyActionBar>
           </div>
         )}
 

--- a/components/GmapsImport/CandidateList.tsx
+++ b/components/GmapsImport/CandidateList.tsx
@@ -81,8 +81,8 @@ export default function CandidateList({
         </label>
       )}
 
-      {/* 목록 */}
-      <div className="space-y-1 overflow-y-auto max-h-[calc(100vh-280px)]">
+      {/* 목록 — 내부 스크롤 캡 제거: 페이지가 자연 스크롤하고 액션은 sticky 푸터로 고정(#299) */}
+      <div className="space-y-1">
         {candidates.map((candidate, i) => (
           <div
             key={`${candidate.place.name}-${i}`}
@@ -105,7 +105,7 @@ export default function CandidateList({
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 flex-wrap">
                 <span
-                  className={`text-sm font-medium ${
+                  className={`text-sm font-medium break-words ${
                     candidate.status === 'duplicate' ? 'text-fg-subtle' : 'text-fg'
                   }`}
                 >
@@ -122,7 +122,7 @@ export default function CandidateList({
               </div>
 
               {candidate.place.address && (
-                <p className="text-xs text-fg-subtle mt-0.5 truncate">
+                <p className="text-xs text-fg-subtle mt-0.5 break-words">
                   {candidate.place.address}
                 </p>
               )}

--- a/components/UI/StickyActionBar.tsx
+++ b/components/UI/StickyActionBar.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/cn'
+
+/**
+ * 주요 액션을 화면 하단에 고정해 긴 목록에서도 항상 도달 가능하게 한다(모바일 below-the-fold 방지).
+ * 부모 카드의 좌우 패딩(px-6)을 상쇄하도록 기본 -mx-6 px-6 을 둔다.
+ */
+export default function StickyActionBar({
+  children,
+  className,
+}: {
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'sticky bottom-0 z-10 -mx-6 mt-4 flex items-center justify-end gap-2 border-t border-border px-6 py-3',
+        'bg-bg-elevated/95 backdrop-blur supports-[backdrop-filter]:bg-bg-elevated/80',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## 관련 이슈
Closes #299

## 변경 이유
구글맵 연동 후보 검토가 모바일에서 ① 주소가 truncate 되고 장소명이 어색하게 깨졌고 ② "다른 URL 입력"(유일한 재시도 탈출구)이 내부 스크롤 박스 아래에 있어 후보가 많으면 도달 불가했다.

## 변경 범위
- `components/UI/StickyActionBar.tsx` 신설: 주요 액션을 하단 고정(below-the-fold 방지). 재사용 컴포넌트.
- `components/GmapsImport/CandidateList.tsx`: 주소 `truncate`→`break-words`, 장소명 `break-words`. 내부 리스트 `overflow-y-auto max-h-[...]` 캡 제거(페이지 자연 스크롤).
- `app/trip/[tripId]/gmaps-import/page.tsx`: "다른 URL 입력"을 `StickyActionBar` 로 감싸 항상 도달 가능.

## 검증
- `npm run lint` / `npm run build` 통과

## 남은 작업 / 리스크
- "추가"(import) 버튼은 CandidateList 헤더(상단, 진입 시 노출)에 유지. 향후 import 도 sticky 푸터로 통합 검토 가능.
- StickyActionBar 는 #300(모바일 레이아웃 규율)에서 가이드에 문서화 예정.
