### PR TITLE
대시보드 헤더 유저메뉴 통합 + 모바일 유저메뉴 신설 (#310)

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -4,15 +4,13 @@ import { useMemo, useState } from 'react'
 import useSWR from 'swr'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { LogOut, MapPin, MoreVertical, Plus, Search, SearchX, Trash2, User } from 'lucide-react'
-import ThemeToggle from '@/components/Theme/ThemeToggle'
+import { MapPin, MoreVertical, Plus, Search, SearchX, Trash2 } from 'lucide-react'
 import Wordmark, { BrandMark } from '@/components/Brand/Wordmark'
 import { Input } from '@/components/UI/Input'
 import Button from '@/components/UI/Button'
 import EmptyState from '@/components/UI/EmptyState'
 import { useConfirm } from '@/components/UI/ConfirmDialog'
 import { useToast } from '@/components/UI/Toast'
-import { logout } from '@/lib/auth-client'
 import type { TripSummary } from '@/lib/trips'
 
 type SortKey = 'created_desc' | 'start_date' | 'name'
@@ -46,16 +44,13 @@ function formatRange(start: string | null, end: string | null): string | null {
   return `${formatDateShort(end!)} 까지`
 }
 
-const handleLogout = logout
-
 interface Props {
   initialTrips: TripSummary[]
-  userEmail: string | null
 }
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json())
 
-export default function DashboardClient({ initialTrips, userEmail }: Props) {
+export default function DashboardClient({ initialTrips }: Props) {
   const router = useRouter()
   const confirm = useConfirm()
   const { showToast } = useToast()
@@ -132,28 +127,8 @@ export default function DashboardClient({ initialTrips, userEmail }: Props) {
           <div className="min-w-0">
             <Wordmark size="sm" className="mb-1.5" />
             <h1 className="text-lg md:text-xl font-bold text-fg">내 여행</h1>
-            {userEmail && (
-              <p className="text-xs text-fg-subtle mt-0.5 truncate">{userEmail}</p>
-            )}
           </div>
-          <div className="flex items-center gap-2">
-            <ThemeToggle />
-            <Link
-              href="/me"
-              aria-label="프로필"
-              className="p-2 rounded-lg text-fg-subtle hover:text-fg hover:bg-bg-subtle transition-colors"
-            >
-              <User className="size-4" aria-hidden="true" />
-            </Link>
-            <button
-              type="button"
-              onClick={handleLogout}
-              aria-label="로그아웃"
-              className="p-2 rounded-lg text-fg-subtle hover:text-fg hover:bg-bg-subtle transition-colors"
-            >
-              <LogOut className="size-4" aria-hidden="true" />
-            </button>
-          </div>
+          {/* 프로필·테마·로그아웃은 글로벌 AvatarDropdown(우상단 fixed)으로 통합 (#310) */}
         </div>
       </header>
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -15,5 +15,5 @@ export default async function DashboardPage() {
   }
 
   const trips = await listUserTrips(client)
-  return <DashboardClient initialTrips={trips} userEmail={userData.user.email ?? null} />
+  return <DashboardClient initialTrips={trips} />
 }

--- a/components/Layout/AvatarDropdown.tsx
+++ b/components/Layout/AvatarDropdown.tsx
@@ -16,7 +16,9 @@ import { cn } from '@/lib/cn'
  * 목적: user-scope (프로필·테마·로그아웃) 와 trip-scope (목록·지도·일정) 의 IA 완전 분리.
  * 사이드바는 trip-scope 만 남기고 user-scope 는 여기로.
  *
- * - 데스크탑(md+) 만 렌더. 모바일은 기존 더보기 시트 사용.
+ * - 데스크탑(md+) 은 항상 렌더.
+ * - 모바일은 trip 컨텍스트 밖(대시보드·/me 등)에서만 렌더 — trip 페이지는 하단 네비
+ *   ‟더보기" 시트가 user-scope 를 덮으므로 중복 방지로 숨긴다 (#310).
  * - 글로벌 위치 (fixed top-right) — 페이지 전환과 무관.
  * - 로그인 상태가 아니면 렌더 안 함.
  * - trip 컨텍스트 안에선 ‟내 여행 목록" 도 메뉴에 포함 — 사이드바에서 옮긴 진입점.
@@ -83,7 +85,12 @@ export default function AvatarDropdown() {
   return (
     <div
       ref={rootRef}
-      className="hidden md:block fixed top-3 right-4 z-40"
+      className={cn(
+        'fixed top-3 right-4 z-40',
+        // trip 컨텍스트 안에서는 모바일 하단 네비가 user-scope 를 덮으므로 데스크탑만,
+        // 밖(대시보드 등)에서는 모바일에서도 유저메뉴 진입점이 된다 (#310).
+        inTripContext ? 'hidden md:block' : 'block',
+      )}
     >
       <button
         type="button"


### PR DESCRIPTION
## 관련 이슈
Closes #310

## 변경 이유
대시보드는 bottom-nav 도, `AvatarDropdown`(데스크탑 전용 `hidden md:block`)도 없어서, 헤더의 낱개 버튼(이메일·테마·프로필·로그아웃)에만 의존했다. 그대로 두면 user-scope 진입점이 앱 표준 유저메뉴와 비대칭이고, 헤더를 정리하면 모바일에서 로그아웃·프로필 진입점이 사라지는 회귀가 생긴다. 모바일 유저메뉴를 먼저 지어 진입점 일관성(Basics-First)을 닫는다.

## 변경 범위
- **`components/Layout/AvatarDropdown.tsx`**: 모바일 노출 조건 추가. trip 컨텍스트 안(`/trip/:id/...`)에서는 하단 네비 "더보기" 시트가 user-scope 를 이미 덮으므로 데스크탑 전용 유지, 그 **밖(대시보드·`/me` 등)에서는 모바일에서도 렌더** → 모바일 유저메뉴 구멍 메움. (`hidden md:block` → `inTripContext ? 'hidden md:block' : 'block'`)
- **`app/dashboard/DashboardClient.tsx`**: 헤더의 이메일 텍스트·`ThemeToggle`·프로필 링크·로그아웃 버튼 제거 → 글로벌 AvatarDropdown 으로 흡수. 미사용 import(`ThemeToggle`, `LogOut`, `User`, `logout`)·`userEmail` prop 정리.
- **`app/dashboard/page.tsx`**: 더 이상 쓰지 않는 `userEmail` prop 전달 제거.

진입점 자체는 통합/이동만 했고, 메뉴 항목(프로필·테마·로그아웃)·로그아웃 동작은 기존 AvatarDropdown 구현 그대로다.

## 검증
- `npm run lint` ✅ (No issues found)
- `npm run build` ✅ (전체 라우트 컴파일 성공)
- 회귀 분석: trip 페이지 모바일은 변화 없음(여전히 `hidden`, 하단 네비가 커버) → 아바타+더보기 시트 중복 노출 없음. 대시보드/`/me` 모바일은 신규로 우상단 아바타 노출.

## 남은 작업 / 리스크
- **시각 QA 필요(이슈 명시, 자동 머지 부적합)**: 모바일 대시보드에서 아바타 → 메뉴 열림 → 프로필/테마/로그아웃 1클릭 도달, 로그아웃 동선, 데스크탑 동등성. 사람 확인 후 머지 요망.
- 리스크: 아바타가 `fixed top-3 right-4` 라 대시보드 헤더 우측이 비워졌다. 헤더 콘텐츠는 좌측(워드마크+제목)뿐이라 겹침 없음.

## Basics-First 체크
- [x] "지금 보고 있는 여행 이름": 대시보드는 trip 내부가 아니라 해당 없음(헤더에 "내 여행" 유지)
- [ ] 핵심 객체 C/R/U/D: 본 PR 범위는 nav 통합, 해당 없음
- [x] 모달·시트 사이징: 변경 없음(드롭다운 재사용)
- [x] 카피 정직성: 새 약속 카피 없음
- [x] 모바일·데스크탑 동등: 대시보드 양쪽에서 유저메뉴 1클릭 도달
