### PR TITLE
chore: gitignore .claude 로컬 전용 파일

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@
 .DS_Store
 *.pem
 
+# claude code (local-only)
+.claude/settings.local.json
+.claude/worktrees/
+
 # debug
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## 배경

`.claude/` 안에는 성격이 다른 세 종류가 섞여 있다.

| 항목 | 성격 | 처리 |
|---|---|---|
| `.claude/commands/speckit.*.md` | 프로젝트 공유 슬래시 커맨드 | 추적 유지 (1인 프로젝트라 clone 만으로 따라옴) |
| `.claude/settings.local.json` | 개인 권한 허용 목록 | **gitignore** |
| `.claude/worktrees/` | 로컬 작업 폴더 | **gitignore** |

개인/로컬 전용 파일들이 untracked 상태로만 남아 있어 `git add .` 사고로 커밋될 위험이 있었다. 정식으로 무시 처리한다.

## 변경

- `.gitignore` 에 `.claude/settings.local.json`, `.claude/worktrees/` 추가

## 검증

- `git check-ignore -v` 로 두 경로 모두 무시됨 확인
- `git ls-files .claude/commands/` 로 speckit 커맨드 추적 유지 확인
