### PR TITLE
feat(items): #326 항목 추가·수정 일시 상대시간 표시

### DIFF
--- a/app/trip/[tripId]/items/[id]/page.tsx
+++ b/app/trip/[tripId]/items/[id]/page.tsx
@@ -7,6 +7,7 @@ import ItemMetadataChips from '@/components/UI/ItemMetadataChips'
 import { buildTripPath } from '@/lib/hooks/useTripContext'
 import TripContextLabel from '@/components/UI/TripContextLabel'
 import { formatBudget, normalizeCurrency } from '@/lib/currency'
+import { formatRelativeTime, formatAbsoluteTime } from '@/lib/formatRelativeTime'
 import type { TripItem } from '@/types'
 
 export default async function ItemDetailPage({
@@ -109,6 +110,8 @@ export default async function ItemDetailPage({
               <p className="text-sm text-fg whitespace-pre-wrap">{item.memo}</p>
             </section>
           )}
+
+          <Timestamps createdAt={item.created_at} updatedAt={item.updated_at} />
         </div>
       </div>
       <Navigation />
@@ -121,6 +124,31 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
     <h2 className="text-xs font-semibold text-fg-subtle uppercase tracking-wider mb-2">
       {children}
     </h2>
+  )
+}
+
+function Timestamps({ createdAt, updatedAt }: { createdAt: string; updatedAt: string }) {
+  const created = formatRelativeTime(createdAt)
+  const updated = formatRelativeTime(updatedAt)
+  if (!created && !updated) return null
+  // 추가·수정 시각이 사실상 같으면(생성 직후 미편집) "추가"만 보여 중복을 피한다.
+  const sameMoment = createdAt === updatedAt
+  return (
+    <p className="text-xs text-fg-subtle pt-1">
+      {created && (
+        <time dateTime={createdAt} title={formatAbsoluteTime(createdAt)}>
+          {created} 추가
+        </time>
+      )}
+      {!sameMoment && updated && (
+        <>
+          {created && <span aria-hidden="true"> · </span>}
+          <time dateTime={updatedAt} title={formatAbsoluteTime(updatedAt)}>
+            {updated} 수정
+          </time>
+        </>
+      )}
+    </p>
   )
 }
 

--- a/components/Items/ItemCard.tsx
+++ b/components/Items/ItemCard.tsx
@@ -10,6 +10,7 @@ import LinkButton from './LinkButton'
 import { cn } from '@/lib/cn'
 import { useOptionalTrip, useTripPath } from '@/lib/hooks/useTripContext'
 import { formatBudget, normalizeCurrency } from '@/lib/currency'
+import { formatRelativeTime, formatAbsoluteTime } from '@/lib/formatRelativeTime'
 
 interface ItemCardProps {
   item: TripItem
@@ -41,6 +42,10 @@ export default function ItemCard({
   const scheduleLabel = formatScheduleLabel(item)
   // 확정했는데 날짜가 없으면 일정 배치로 잇는 다리 — map 패널과 동일 패턴.
   const needsDate = item.trip_priority === '확정' && !item.date
+  // 추가/수정 시점(#326). 생성 직후 미편집이면 "추가", 한 번이라도 바뀌면 "수정"으로 표기.
+  const edited = item.updated_at !== item.created_at
+  const stampIso = edited ? item.updated_at : item.created_at
+  const stampLabel = formatRelativeTime(stampIso)
 
   useEffect(() => {
     if (editingName !== null) inputRef.current?.select()
@@ -166,6 +171,14 @@ export default function ItemCard({
             <CalendarPlus className="size-3" aria-hidden="true" />
             확정됨 · 날짜 배정하기
           </Link>
+        </div>
+      )}
+
+      {stampLabel && (
+        <div className="mt-2.5 pl-[22px] text-[11px] text-fg-subtle tabular">
+          <time dateTime={stampIso} title={formatAbsoluteTime(stampIso)}>
+            {stampLabel} {edited ? '수정' : '추가'}
+          </time>
         </div>
       )}
     </div>

--- a/lib/formatRelativeTime.ts
+++ b/lib/formatRelativeTime.ts
@@ -1,0 +1,48 @@
+/**
+ * ISO 시각 문자열을 한국어 상대시간("3일 전")으로 변환한다.
+ * created_at/updated_at 표시용(#326). 절대시각은 title 속성에 별도로 넣어 호버 시 확인.
+ *
+ * SSR(서버 컴포넌트)에서도 호출되므로 기준 시각을 인자로 받을 수 있게 두되,
+ * 미지정 시 호출 시점 now 를 쓴다. 미래 시각이면 "방금"으로 클램프한다.
+ */
+export function formatRelativeTime(iso: string | null | undefined, now: Date = new Date()): string {
+  if (!iso) return ''
+  const then = new Date(iso)
+  if (Number.isNaN(then.getTime())) return ''
+
+  const diffMs = now.getTime() - then.getTime()
+  const sec = Math.floor(diffMs / 1000)
+  if (sec < 60) return '방금'
+
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}분 전`
+
+  const hour = Math.floor(min / 60)
+  if (hour < 24) return `${hour}시간 전`
+
+  const day = Math.floor(hour / 24)
+  if (day < 7) return `${day}일 전`
+
+  const week = Math.floor(day / 7)
+  if (week < 5) return `${week}주 전`
+
+  const month = Math.floor(day / 30)
+  if (month < 12) return `${month}개월 전`
+
+  const year = Math.floor(day / 365)
+  return `${year}년 전`
+}
+
+/** 절대시각(YYYY. M. D. HH:mm) — title 속성용. */
+export function formatAbsoluteTime(iso: string | null | undefined): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleString('ko-KR', {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}


### PR DESCRIPTION
## 관련 이슈
Closes #326

## 변경 이유
장소 항목에 `created_at`/`updated_at`이 저장돼 있지만 UI 어디에도 노출되지 않아, 사용자가 "이 장소를 언제 담았는지/언제 고쳤는지" 알 길이 없었다(dogfood F-015).

## 변경 범위
- `lib/formatRelativeTime.ts` 신규 — 한국어 상대시간 포맷터(`방금`/`N분 전`/`N시간 전`/`N일 전`/`N주 전`/`N개월 전`/`N년 전`) + 절대시각 포맷터(title 호버용).
- 상세 페이지(`app/trip/[tripId]/items/[id]/page.tsx`) — 메모 아래 `추가 · 수정` 일시 표시. `<time>` 태그 + 절대시각 `title`.
- 목록 카드(`components/Items/ItemCard.tsx`) — 카드 하단에 `N일 전 수정/추가` 한 줄(muted, 11px).
- 생성 직후 미편집이면 `추가`, 한 번이라도 바뀌면 `수정`으로 표기해 중복 회피.

## 검증
- `npm run lint` — No issues found
- `npm run build` — 성공
- 데이터는 이미 존재(types/index.ts의 `created_at`/`updated_at`)하므로 추가 쿼리/마이그레이션 없음.

## 남은 작업 / 리스크
- `ResearchTable`(데스크탑 정렬·편집 그리드)에는 컬럼을 추가하지 않았다 — 헤더·정렬키·셀·열폭이 얽혀 S 범위를 넘기 때문. 필요 시 별도 이슈로 "수정 시각 정렬 컬럼" 추가 가능. 현재 목록(카드)·상세 두 곳에서 시점 확인은 가능.
