### PR TITLE
feat(gmaps): #324 일괄 추가 진행 중 이탈 방지 가드

### DIFF
--- a/app/trip/[tripId]/gmaps-import/page.tsx
+++ b/app/trip/[tripId]/gmaps-import/page.tsx
@@ -7,6 +7,7 @@ import UrlInput from '@/components/GmapsImport/UrlInput'
 import CandidateList from '@/components/GmapsImport/CandidateList'
 import StickyActionBar from '@/components/UI/StickyActionBar'
 import { useTripId, useTripPath } from '@/lib/hooks/useTripContext'
+import { useBeforeUnload } from '@/lib/hooks/useBeforeUnload'
 import TripPageHeader from '@/components/Layout/TripPageHeader'
 import type { ImportCandidate } from '@/types'
 
@@ -21,6 +22,9 @@ export default function GmapsImportPage() {
   const [error, setError] = useState<string | null>(null)
   const [insertedCount, setInsertedCount] = useState(0)
   const [insertedIds, setInsertedIds] = useState<string[]>([])
+
+  // 일괄 추가 진행 중 탭 닫기·새로고침·외부 이동을 막아 끊김을 방지(#324).
+  useBeforeUnload(state === 'importing')
 
   useEffect(() => {
     if (state !== 'done') return
@@ -152,6 +156,12 @@ export default function GmapsImportPage() {
 
         {state === 'importing' && (
           <div className="bg-bg-elevated rounded-xl border border-border p-6">
+            <p
+              role="status"
+              className="mb-4 rounded-lg bg-info-bg border border-info-border px-3 py-2 text-sm text-info-fg"
+            >
+              장소를 추가하는 중입니다. 완료될 때까지 이 페이지를 닫거나 새로고침하지 마세요.
+            </p>
             <CandidateList
               candidates={candidates}
               onChange={setCandidates}

--- a/lib/hooks/useBeforeUnload.ts
+++ b/lib/hooks/useBeforeUnload.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+
+/**
+ * `active` 동안 탭 닫기·새로고침·외부 URL 이동 시 브라우저 기본 이탈 확인 다이얼로그를 띄운다.
+ * 장기 실행 작업(예: 구글맵 200개 일괄 추가, #324) 도중 실수로 페이지를 벗어나
+ * 진행이 끊기는 것을 막는다.
+ *
+ * 주의: SPA 내부 라우팅(Link 클릭)에는 `beforeunload` 가 발화하지 않는다 — 그 경우
+ * 진행 중이던 fetch 는 백그라운드에서 계속 완료되므로(서버 삽입은 원자적) 데이터 손실이
+ * 없다. 데이터가 깨지는 경우는 문서 언로드(닫기/새로고침/외부 이동)뿐이라 여기서만 막는다.
+ */
+export function useBeforeUnload(active: boolean) {
+  useEffect(() => {
+    if (!active) return
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      // 일부 브라우저는 returnValue 가 설정돼야 다이얼로그를 띄운다(문구는 브라우저가 무시).
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [active])
+}


### PR DESCRIPTION
## 관련 이슈
Closes #324

## 변경 이유
구글맵 공개 리스트 일괄 추가(최대 200개)는 단일 서버 요청으로 진행되는데, 진행 중(`state === 'importing'`)에도 탭 닫기·새로고침·외부 URL 이동이 막히지 않아 작업이 끊길 수 있었다(dogfood F-012).

## 변경 범위
- `lib/hooks/useBeforeUnload.ts` 신규 — `active` 동안 `beforeunload` 리스너로 브라우저 이탈 확인 다이얼로그를 띄우는 재사용 훅.
- `app/trip/[tripId]/gmaps-import/page.tsx`:
  - `useBeforeUnload(state === 'importing')` 로 일괄 추가 중 이탈 가드.
  - 진행 중 인페이지 안내 배너("완료될 때까지 닫거나 새로고침하지 마세요") 추가.

## 동작 근거
- **닫기/새로고침/외부 이동** — 문서 언로드라 진행 중 fetch 가 취소될 수 있는 유일한 위험 경로. `beforeunload` 로 경고한다.
- **SPA 내부 라우팅(Link 클릭)** — `beforeunload` 미발화. 단, 이 경우 진행 중 fetch 는 백그라운드에서 계속 완료되므로(서버 삽입은 원자적) 데이터 손실이 없다 → 수용 기준의 "안전하게 백그라운드로 이어진다"를 자연 충족.

## 검증
- `npm run lint` — No issues found
- `npm run build` — 성공

## 남은 작업 / 리스크
- 진행률 퍼센트 표시는 단일 원자적 요청 구조상 부분 진행 정보가 없어 별도 스트리밍 API 가 필요 → 본 범위 제외(이슈의 "또는 진행률 표시" 선택지 중 가드+안내 경로 채택).
