### PR TITLE
feat(gmaps): #323 연동 확정 전 프리뷰 요약 + 인라인 이름 수정

### DIFF
--- a/app/api/gmaps/import/route.ts
+++ b/app/api/gmaps/import/route.ts
@@ -6,25 +6,14 @@ import type { GooglePlace, Link, TripItem } from '@/types'
 import { createRouteHandlerSupabase } from '@/lib/supabase-server'
 import { getUserRole } from '@/lib/trip'
 import { reverseGeocode } from '@/lib/geocode'
-
-// "34°39'53.7\"N 135°29'58.3\"E" 또는 "34.123, 135.456" 같이 좌표 자체가 이름인 경우를 감지.
-const DMS_RE = /\d+°\d+['′]/
-const DECIMAL_COORD_RE = /^-?\d{1,3}\.\d+\s*,\s*-?\d{1,3}\.\d+$/
-
-function isCoordinateName(name: string): boolean {
-  const trimmed = name.trim()
-  if (!trimmed) return true
-  if (DMS_RE.test(trimmed)) return true
-  if (DECIMAL_COORD_RE.test(trimmed)) return true
-  return false
-}
+import { isCoordinateLikeName } from '@/services/gmaps/placeName'
 
 async function resolvePinName(
   place: GooglePlace,
   regionLabel: string | null,
   fallbackIndex: number,
 ): Promise<string> {
-  if (!isCoordinateName(place.name)) return place.name
+  if (!isCoordinateLikeName(place.name)) return place.name
 
   // 1차: reverse geocode
   if (typeof place.lat === 'number' && typeof place.lng === 'number') {

--- a/components/GmapsImport/CandidateList.tsx
+++ b/components/GmapsImport/CandidateList.tsx
@@ -1,6 +1,8 @@
 'use client'
 
+import { useState } from 'react'
 import type { ImportCandidate } from '@/types'
+import { isCoordinateLikeName, hasNoCoordinates } from '@/services/gmaps/placeName'
 
 interface CandidateListProps {
   candidates: ImportCandidate[]
@@ -27,7 +29,16 @@ export default function CandidateList({
   onImport,
   importing,
 }: CandidateListProps) {
+  const [editingIndex, setEditingIndex] = useState<number | null>(null)
   const selectedCount = candidates.filter(c => c.selected).length
+
+  // 확정 전 요약(#323): 무엇을 가져오게 되는지 미리 인지하고 수정/제외하도록.
+  const summary = {
+    total: candidates.length,
+    duplicate: candidates.filter(c => c.status === 'duplicate').length,
+    unnamed: candidates.filter(c => isCoordinateLikeName(c.place.name)).length,
+    noCoord: candidates.filter(c => hasNoCoordinates(c.place)).length,
+  }
 
   function toggleAll(checked: boolean) {
     onChange(
@@ -41,6 +52,15 @@ export default function CandidateList({
     if (candidates[index].status === 'duplicate') return
     const updated = [...candidates]
     updated[index] = { ...updated[index], selected: !updated[index].selected }
+    onChange(updated)
+  }
+
+  function renameItem(index: number, name: string) {
+    const updated = [...candidates]
+    updated[index] = {
+      ...updated[index],
+      place: { ...updated[index].place, name },
+    }
     onChange(updated)
   }
 
@@ -68,6 +88,23 @@ export default function CandidateList({
         </button>
       </div>
 
+      {/* 확정 전 요약(#323) — 가져오기 전에 손볼 거리를 한눈에 */}
+      <div className="mb-3 flex flex-wrap gap-x-3 gap-y-1 rounded-lg bg-bg-subtle px-3 py-2 text-xs text-fg-muted">
+        <span>총 <strong className="text-fg">{summary.total}</strong>개</span>
+        {summary.duplicate > 0 && (
+          <span>이미 추가됨 <strong className="text-fg">{summary.duplicate}</strong></span>
+        )}
+        {summary.unnamed > 0 && (
+          <span className="text-warning-fg">이름 미정 <strong>{summary.unnamed}</strong></span>
+        )}
+        {summary.noCoord > 0 && (
+          <span className="text-warning-fg">좌표 없음 <strong>{summary.noCoord}</strong></span>
+        )}
+        {summary.unnamed === 0 && summary.noCoord === 0 && (
+          <span className="text-success-fg">손볼 곳 없음</span>
+        )}
+      </div>
+
       {/* 전체 선택 */}
       {allSelectable.length > 0 && (
         <label className="flex items-center gap-2 mb-2 text-sm text-fg-muted cursor-pointer select-none">
@@ -83,58 +120,97 @@ export default function CandidateList({
 
       {/* 목록 — 내부 스크롤 캡 제거: 페이지가 자연 스크롤하고 액션은 sticky 푸터로 고정(#299) */}
       <div className="space-y-1">
-        {candidates.map((candidate, i) => (
-          <div
-            key={`${candidate.place.name}-${i}`}
-            className={`flex items-start gap-3 p-3 rounded-lg border transition-colors ${
-              candidate.status === 'duplicate'
-                ? 'border-border bg-bg-subtle opacity-60'
-                : candidate.selected
-                ? 'border-border bg-bg-elevated'
-                : 'border-border bg-bg-subtle'
-            }`}
-          >
-            <input
-              type="checkbox"
-              checked={candidate.selected}
-              disabled={candidate.status === 'duplicate'}
-              onChange={() => toggleItem(i)}
-              className="mt-0.5 w-4 h-4 rounded border-border-strong text-fg focus-visible:outline-accent disabled:opacity-40 disabled:cursor-not-allowed"
-            />
+        {candidates.map((candidate, i) => {
+          const unnamed = isCoordinateLikeName(candidate.place.name)
+          const noCoord = hasNoCoordinates(candidate.place)
+          const editing = editingIndex === i
+          return (
+            <div
+              key={`${candidate.place.name}-${i}`}
+              className={`flex items-start gap-3 p-3 rounded-lg border transition-colors ${
+                candidate.status === 'duplicate'
+                  ? 'border-border bg-bg-subtle opacity-60'
+                  : candidate.selected
+                  ? 'border-border bg-bg-elevated'
+                  : 'border-border bg-bg-subtle'
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={candidate.selected}
+                disabled={candidate.status === 'duplicate'}
+                onChange={() => toggleItem(i)}
+                className="mt-0.5 w-4 h-4 rounded border-border-strong text-fg focus-visible:outline-accent disabled:opacity-40 disabled:cursor-not-allowed"
+              />
 
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 flex-wrap">
-                <span
-                  className={`text-sm font-medium break-words ${
-                    candidate.status === 'duplicate' ? 'text-fg-subtle' : 'text-fg'
-                  }`}
-                >
-                  {candidate.place.name}
-                </span>
-                <span
-                  className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium ${STATUS_COLOR[candidate.status]}`}
-                >
-                  {STATUS_LABEL[candidate.status]}
-                </span>
-                <span className="text-xs text-fg-subtle bg-bg-subtle px-1.5 py-0.5 rounded">
-                  {candidate.mappedCategory}
-                </span>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  {editing ? (
+                    <input
+                      autoFocus
+                      type="text"
+                      value={candidate.place.name}
+                      onChange={e => renameItem(i, e.target.value)}
+                      onBlur={() => setEditingIndex(null)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' || e.key === 'Escape') setEditingIndex(null)
+                      }}
+                      placeholder="장소 이름 입력"
+                      className="flex-1 min-w-0 px-2 py-1 text-sm rounded border border-border-strong bg-bg-elevated text-fg focus-visible:outline-accent"
+                    />
+                  ) : (
+                    <>
+                      <span
+                        className={`text-sm font-medium break-words ${
+                          candidate.status === 'duplicate' ? 'text-fg-subtle' : 'text-fg'
+                        }`}
+                      >
+                        {candidate.place.name}
+                      </span>
+                      <span
+                        className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium ${STATUS_COLOR[candidate.status]}`}
+                      >
+                        {STATUS_LABEL[candidate.status]}
+                      </span>
+                      {unnamed && (
+                        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-warning-bg text-warning-fg">
+                          이름 미정
+                        </span>
+                      )}
+                      {noCoord && (
+                        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-warning-bg text-warning-fg">
+                          좌표 없음
+                        </span>
+                      )}
+                      <span className="text-xs text-fg-subtle bg-bg-subtle px-1.5 py-0.5 rounded">
+                        {candidate.mappedCategory}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setEditingIndex(i)}
+                        className="text-xs text-accent hover:underline"
+                      >
+                        이름 수정
+                      </button>
+                    </>
+                  )}
+                </div>
+
+                {candidate.place.address && (
+                  <p className="text-xs text-fg-subtle mt-0.5 break-words">
+                    {candidate.place.address}
+                  </p>
+                )}
+
+                {candidate.status === 'similar' && candidate.similarItem && (
+                  <p className="text-xs text-warning-fg mt-0.5">
+                    유사 장소: {candidate.similarItem.name}
+                  </p>
+                )}
               </div>
-
-              {candidate.place.address && (
-                <p className="text-xs text-fg-subtle mt-0.5 break-words">
-                  {candidate.place.address}
-                </p>
-              )}
-
-              {candidate.status === 'similar' && candidate.similarItem && (
-                <p className="text-xs text-warning-fg mt-0.5">
-                  유사 장소: {candidate.similarItem.name}
-                </p>
-              )}
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/services/gmaps/placeName.ts
+++ b/services/gmaps/placeName.ts
@@ -1,0 +1,23 @@
+import type { GooglePlace } from '@/types'
+
+// "34°39'53.7\"N 135°29'58.3\"E" 또는 "34.123, 135.456" 같이 좌표 자체가 이름인 경우.
+const DMS_RE = /\d+°\d+['′]/
+const DECIMAL_COORD_RE = /^-?\d{1,3}\.\d+\s*,\s*-?\d{1,3}\.\d+$/
+
+/**
+ * 사람이 읽을 이름이 없는 장소(좌표가 이름이거나 비어 있음).
+ * 연동 프리뷰의 "이름 미정" 집계(#323)와 import 의 핀 이름 정규화(resolvePinName)가
+ * 같은 기준을 쓰도록 단일 소스로 둔다.
+ */
+export function isCoordinateLikeName(name: string | null | undefined): boolean {
+  const trimmed = (name ?? '').trim()
+  if (!trimmed) return true
+  if (DMS_RE.test(trimmed)) return true
+  if (DECIMAL_COORD_RE.test(trimmed)) return true
+  return false
+}
+
+/** 좌표(lat/lng)가 없어 지도에 표시할 수 없는 장소(#323). */
+export function hasNoCoordinates(place: Pick<GooglePlace, 'lat' | 'lng'>): boolean {
+  return typeof place.lat !== 'number' || typeof place.lng !== 'number'
+}


### PR DESCRIPTION
## 배경
연동 후에야 "이름 미정 N개 일괄 편집"을 알게 되어, 확정 전에 미리 손볼 수 없었다(#323). 연동이 "확정 후 정리" 모델이라 프리뷰 단계에 검증·요약이 없었다.

## 변경
- **확정 전 요약 배지**: 검토 화면 상단에 `총 N · 이미 추가됨 N · 이름 미정 N · 좌표 없음 N`. 손볼 곳이 없으면 "손볼 곳 없음".
- **후보별 경고 배지**: `이름 미정`(좌표가 이름) / `좌표 없음`(지도 표시 불가)을 각 행에 표시 → 사후가 아닌 **확정 전 인지**.
- **인라인 이름 수정**: 각 후보에 "이름 수정" → 인라인 입력으로 가져오기 전에 보정 (Enter/Esc/blur 저장). 보정한 이름은 import 의 핀 이름 정규화보다 우선(실명이면 그대로 저장).
- **제외**: 기존 체크박스 해제 동선 그대로(중복은 자동 제외).
- 판별 기준은 `services/gmaps/placeName`(isCoordinateLikeName/hasNoCoordinates)로 분리해 import 의 핀 이름 정규화와 **동일 기준** 공유.

## 수용 기준
- [x] 연동 확정 전 화면에서 이름 미정·중복 건수를 보고 수정/제외할 수 있다

## Basics-First 체크
- [ ] 여행 이름 표시: 해당 페이지는 TripPageHeader 로 컨텍스트 유지(기존)
- [x] CRUD 대칭: 프리뷰에서 이름 U(수정)·제외 가능
- [x] 모달·시트 사이징: 변경 없음(페이지 자연 스크롤 + sticky 푸터 유지)
- [x] 카피 정직성: "확정 전 인지·수정" — 요약+경고+인라인 수정으로 실제 구현
- [x] 모바일·데스크탑 동등: 동일 컴포넌트, break-words 유지

Closes #323
