### PR TITLE
feat(auth): #321 회원 탈퇴(계정 즉시 삭제)

### DIFF
--- a/app/api/auth/delete-account/route.ts
+++ b/app/api/auth/delete-account/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server'
+import { getSession, signOut } from '@/lib/auth'
+import { createRouteHandlerSupabase } from '@/lib/supabase-server'
+import { createAdminSupabase } from '@/lib/supabase-admin'
+
+/**
+ * 회원 탈퇴(계정 삭제) — 즉시·영구 삭제(#321).
+ *
+ * 정책(현재): 단독 소유 여행은 계정과 함께 즉시 삭제한다. 복구/유예 기간 없음.
+ * `auth.users` 행을 admin API 로 삭제하면 스키마의 `on delete cascade` 로
+ * 소유 trips → items·trip_members·shares·votes 가 연쇄 삭제된다.
+ * 다른 사람이 소유한 공유 여행은 내 trip_members 행만 삭제되고 여행 자체는 남는다.
+ *
+ * NOTE(후속 #321 정책 확장): 멀티유저 공유가 본격화되면 "소유자 탈퇴 시 공유 여행
+ * 소유권 이전" 정책이 필요하다. 현재는 단일 사용자 전제라 즉시 삭제로 단순화.
+ */
+
+/** 사전 고지용: 탈퇴 시 함께 삭제될 '내가 소유한 여행' 개수. */
+export async function GET() {
+  const session = await getSession()
+  if (!session) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+  }
+  const supabase = createRouteHandlerSupabase()
+  const { count } = await supabase
+    .from('trips')
+    .select('id', { count: 'exact', head: true })
+    .eq('owner_user_id', session.userId)
+  return NextResponse.json({ ownedTripCount: count ?? 0 })
+}
+
+/** 계정 즉시 삭제 실행. */
+export async function DELETE() {
+  const session = await getSession()
+  if (!session) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+  }
+
+  let admin
+  try {
+    admin = createAdminSupabase()
+  } catch {
+    return NextResponse.json(
+      { error: '서버에 탈퇴 처리가 구성되지 않았습니다. 관리자에게 문의해주세요.' },
+      { status: 500 },
+    )
+  }
+
+  const { error } = await admin.auth.admin.deleteUser(session.userId)
+  if (error) {
+    console.error('[delete-account] deleteUser failed:', error)
+    return NextResponse.json({ error: '계정 삭제에 실패했습니다.' }, { status: 500 })
+  }
+
+  // 세션 쿠키 정리(이미 무효지만 명시적으로).
+  try {
+    await signOut()
+  } catch {
+    // 쿠키 정리 실패는 치명적이지 않음 — 클라이언트가 하드 리로드로 정리한다.
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/me/ProfileClient.tsx
+++ b/app/me/ProfileClient.tsx
@@ -2,11 +2,13 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, LogOut } from 'lucide-react'
+import { ArrowLeft, LogOut, Trash2 } from 'lucide-react'
 import Button from '@/components/UI/Button'
 import { Input } from '@/components/UI/Input'
 import { useToast } from '@/components/UI/Toast'
+import { useConfirm } from '@/components/UI/ConfirmDialog'
 import { logout } from '@/lib/auth-client'
+import { clearAppCache } from '@/lib/clearAppCache'
 
 const handleLogout = logout
 
@@ -42,8 +44,74 @@ export default function ProfileClient({ email, initialNickname }: Props) {
             로그아웃
           </Button>
         </section>
+        <DangerSection />
       </main>
     </div>
+  )
+}
+
+function DangerSection() {
+  const confirm = useConfirm()
+  const { showToast } = useToast()
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleDelete() {
+    if (submitting) return
+
+    // 사전 고지: 함께 삭제될 '내가 소유한 여행' 개수를 먼저 조회한다(#321).
+    let ownedTripCount = 0
+    try {
+      const res = await fetch('/api/auth/delete-account')
+      if (res.ok) {
+        const data = await res.json()
+        ownedTripCount = data.ownedTripCount ?? 0
+      }
+    } catch {
+      // 개수 조회 실패 시 일반 문구로 진행
+    }
+
+    const ok = await confirm({
+      title: '회원 탈퇴',
+      description: (
+        <>
+          계정과{' '}
+          {ownedTripCount > 0 ? `내가 소유한 여행 ${ownedTripCount}개를 포함한 ` : ''}
+          모든 데이터가 <strong>즉시·영구 삭제</strong>됩니다. 되돌릴 수 없습니다.
+        </>
+      ),
+      confirmLabel: '영구 삭제',
+      cancelLabel: '취소',
+      tone: 'destructive',
+      typeToConfirm: '탈퇴',
+    })
+    if (!ok) return
+
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/auth/delete-account', { method: 'DELETE' })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data?.error ?? '탈퇴에 실패했습니다.')
+      // 계정이 사라졌으니 로컬 캐시를 비우고 로그인 화면으로 하드 리로드한다.
+      clearAppCache()
+      window.location.href = '/login'
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : '탈퇴에 실패했습니다.'
+      showToast({ type: 'error', message: msg })
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="bg-bg-elevated border border-critical-border rounded-xl p-5">
+      <h2 className="text-sm font-semibold text-critical-fg mb-1">위험 구역</h2>
+      <p className="text-xs text-fg-subtle mb-3">
+        탈퇴 시 계정과 내가 소유한 여행·항목이 즉시 영구 삭제됩니다. 복구할 수 없습니다.
+      </p>
+      <Button variant="destructive" onClick={handleDelete} loading={submitting}>
+        <Trash2 className="size-4 mr-1.5" aria-hidden="true" />
+        회원 탈퇴
+      </Button>
+    </section>
   )
 }
 

--- a/lib/supabase-admin.ts
+++ b/lib/supabase-admin.ts
@@ -1,0 +1,17 @@
+import { createClient } from '@supabase/supabase-js'
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY || ''
+
+/**
+ * service_role 키로 RLS 를 우회하는 관리자 클라이언트(서버 전용).
+ * auth.users 삭제 같은 admin API 에만 사용한다. 절대 클라이언트로 노출 금지.
+ */
+export function createAdminSupabase() {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_KEY 가 설정되지 않았습니다.')
+  }
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+}


### PR DESCRIPTION
## 배경
회원 탈퇴(계정 삭제) 진입점이 없고, 탈퇴 시 소유 여행 처리 정의가 없었다 — Basics-First #2(CRUD 대칭) 위반(계정 객체의 D 부재). 결정: **즉시 삭제**(복구는 필요해질 때 검토).

## 변경
- **진입점**: 프로필/설정(`/me`) 하단 '위험 구역' 섹션에 `회원 탈퇴` 버튼(1클릭권). 공통 `ConfirmDialog` 사용(`tone: destructive`, `typeToConfirm: '탈퇴'`) — 네이티브 confirm 금지 준수.
- **사전 고지**: `GET /api/auth/delete-account` 가 '내가 소유한 여행 N개'를 반환 → 확인 다이얼로그에 "계정과 내가 소유한 여행 N개를 포함한 모든 데이터가 즉시·영구 삭제" 명시.
- **실행**: `DELETE /api/auth/delete-account` — `service_role` admin API(`auth.admin.deleteUser`)로 `auth.users` 행 삭제. 스키마의 `on delete cascade`(owner_user_id 등)로 소유 trips → items·trip_members·shares·votes 가 연쇄 삭제. 다른 사람 소유 공유 여행은 내 멤버십만 빠지고 여행은 잔존.
- 삭제 후 `clearAppCache()` + `/login` 하드 리로드.
- `lib/supabase-admin.ts`: 서버 전용 service_role 클라이언트(클라이언트 노출 금지). 필요한 env(`SUPABASE_SERVICE_KEY`)는 `.env.example`에 기존 문서화됨.

## 정책 주석(후속)
멀티유저 공유가 본격화되면 "소유자 탈퇴 시 공유 여행 소유권 이전" 정책이 필요 — 라우트 상단 주석에 명시. 현재는 단일 사용자 전제로 즉시 삭제로 단순화.

## 검증
- `tsc --noEmit` 통과, lint 통과
- cascade 동작은 `supabase/schema.sql` 의 `references auth.users(id) on delete cascade` 로 보장

## 수용 기준
- [x] 프로필/설정에서 탈퇴 진입점이 1클릭권에 보인다 (공통 ConfirmDialog, 네이티브 confirm 미사용)
- [x] 탈퇴 시 소유 여행 처리 결과(N개 즉시 삭제)가 사전 고지된다

## Basics-First 체크
- [x] 여행 이름 표시: 해당 없음(계정 설정 페이지)
- [x] CRUD 대칭: 계정 객체 D(삭제) UI·API 양쪽 닫음
- [x] 모달·시트 사이징: 공통 ConfirmDialog
- [x] 카피 정직성: "즉시·영구 삭제" 약속을 cascade 로 실제 구현
- [x] 모바일·데스크탑 동등: /me 반응형 레이아웃 공통

Closes #321
