### PR TITLE
fix(schedule): #355 분류 셀 예외 복구

### DIFF
--- a/components/Schedule/cells/CategoryCell.tsx
+++ b/components/Schedule/cells/CategoryCell.tsx
@@ -5,6 +5,8 @@ import { createPortal } from 'react-dom'
 import type { Category } from '@/types'
 import { CATEGORY_META, CATEGORY_OPTIONS } from '@/lib/itemOptions'
 
+const PORTAL_MARGIN = 8
+
 interface CategoryCellProps {
   value: Category
   isEditing: boolean
@@ -23,14 +25,24 @@ export default function CategoryCell({
   const buttonRef = useRef<HTMLButtonElement>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null)
+  const rawValue = String(value)
+  const safeCategory = CATEGORY_OPTIONS.includes(value) ? value : '기타'
+  const CurrentIcon = CATEGORY_META[safeCategory].Icon
+  const label = safeCategory === value ? value : `${rawValue} (분류 확인 필요)`
 
   useEffect(() => {
-    if (!isEditing) return
+    if (!isEditing || typeof window === 'undefined') {
+      setPosition(null)
+      return
+    }
 
     function updatePosition() {
       const rect = buttonRef.current?.getBoundingClientRect()
       if (!rect) return
-      setPosition({ top: rect.bottom + 4, left: rect.left })
+      setPosition({
+        top: rect.bottom + 4,
+        left: Math.max(PORTAL_MARGIN, rect.left),
+      })
     }
 
     function handleClickOutside(e: MouseEvent) {
@@ -51,16 +63,12 @@ export default function CategoryCell({
   }, [isEditing, onClose])
 
   useLayoutEffect(() => {
-    if (!position || !dropdownRef.current) return
+    if (!position || !dropdownRef.current || typeof window === 'undefined') return
     const dropRect = dropdownRef.current.getBoundingClientRect()
-    if (dropRect.right > window.innerWidth) {
-      setPosition(prev =>
-        prev ? { ...prev, left: Math.max(0, prev.left - (dropRect.right - window.innerWidth)) } : prev
-      )
-    }
+    const maxLeft = Math.max(PORTAL_MARGIN, window.innerWidth - dropRect.width - PORTAL_MARGIN)
+    const nextLeft = Math.min(Math.max(PORTAL_MARGIN, position.left), maxLeft)
+    if (nextLeft !== position.left) setPosition({ ...position, left: nextLeft })
   }, [position])
-
-  const CurrentIcon = CATEGORY_META[value]?.Icon
 
   return (
     <>
@@ -69,14 +77,15 @@ export default function CategoryCell({
         type="button"
         onClick={onClick}
         className="inline-flex items-center justify-center leading-none select-none cursor-pointer text-fg-muted hover:text-fg transition-colors"
-        title={value}
-        aria-label={value}
+        title={label}
+        aria-label={label}
       >
-        {CurrentIcon ? <CurrentIcon size={16} /> : null}
+        <CurrentIcon size={16} />
       </button>
 
       {isEditing &&
         position &&
+        typeof document !== 'undefined' &&
         createPortal(
           <div
             ref={dropdownRef}

--- a/lib/hooks/useItems.ts
+++ b/lib/hooks/useItems.ts
@@ -25,6 +25,15 @@ function withTripId(url: string, tripId: string | null): string {
   return `${url}${sep}tripId=${encodeURIComponent(tripId)}`
 }
 
+async function readErrorMessage(res: Response, fallback: string): Promise<string> {
+  try {
+    const payload = (await res.json()) as { error?: unknown }
+    return typeof payload.error === 'string' && payload.error.trim() ? payload.error : fallback
+  } catch {
+    return fallback
+  }
+}
+
 export function useItems() {
   const [hasMounted, setHasMounted] = useState(false)
   const tripId = useOptionalTripId()
@@ -70,13 +79,14 @@ export function useItems() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(changes),
       })
-      if (!res.ok) throw new Error('Save failed')
+      if (!res.ok) throw new Error(await readErrorMessage(res, '저장에 실패했습니다.'))
       mutate()
-    } catch {
+    } catch (e) {
       mutate(snapshot, { revalidate: false })
+      const message = e instanceof Error ? e.message : '저장에 실패했습니다.'
       showToast({
         type: 'error',
-        message: '저장에 실패했습니다.',
+        message,
         action: { label: '재시도', onClick: () => updateItem(id, changes) },
       })
     }

--- a/specs/355-schedule-category-exception/plan.md
+++ b/specs/355-schedule-category-exception/plan.md
@@ -1,0 +1,56 @@
+# Implementation Plan: Schedule Category Cell Exception Recovery
+
+**Branch**: `tasks/issue-355-category-icon-exception` | **Date**: 2026-06-29 | **Spec**: `specs/355-schedule-category-exception/spec.md`
+**Input**: Feature specification from `specs/355-schedule-category-exception/spec.md`
+
+## Summary
+
+Make schedule category editing resilient by hardening the category cell against invalid category metadata and unstable portal positioning, then improve item update error reporting so failed saves remain recoverable.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 18, Next.js 14 App Router
+**Primary Dependencies**: `next`, `react`, `swr`, `lucide-react`, `@dnd-kit/core`
+**Storage**: Supabase-backed item API through existing `/api/items` routes
+**Testing**: `npm run lint`; manual schedule category click verification when local env permits
+**Target Platform**: Browser web app, mobile and desktop
+**Project Type**: Next.js web application
+**Performance Goals**: No visible delay when opening category picker
+**Constraints**: Keep behavior change narrow; preserve existing table navigation model
+**Scale/Scope**: Schedule table category cell and shared item update hook
+
+## Constitution Check
+
+The repository constitution is still scaffold placeholders, so applicable gates come from `AGENTS.md`:
+
+- Refactoring and behavior changes stay separated in intent; no broad structural cleanup.
+- UI changes must pass basics-first gates for recovery, accessibility labels, and desktop/mobile behavior.
+- Design token system remains unchanged; no new colors or spacing scale.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/355-schedule-category-exception/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+components/Schedule/cells/CategoryCell.tsx
+lib/hooks/useItems.ts
+```
+
+**Structure Decision**: Use existing schedule cell and item hook boundaries. Do not introduce a new editor abstraction for this narrow bug.
+
+## Complexity Tracking
+
+No constitution violations or added architectural complexity.
+
+## Process Note
+
+The repo-local `.codex/prompts/speckit.*.md` files referenced by the Speckit skills are absent in this worktree. This plan uses the checked-in `.specify/templates` directly to keep #355 moving.

--- a/specs/355-schedule-category-exception/spec.md
+++ b/specs/355-schedule-category-exception/spec.md
@@ -1,0 +1,63 @@
+# Feature Specification: Schedule Category Cell Exception Recovery
+
+**Feature Branch**: `tasks/issue-355-category-icon-exception`
+**Created**: 2026-06-29
+**Status**: Draft
+**Input**: GitHub issue #355 "일정 뷰 분류 아이콘 클릭 시 클라이언트 예외"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Open Category Editor Without Crashing (Priority: P1)
+
+A user editing the schedule table can click a row's category icon and see a category picker instead of the page switching to a client-side application error.
+
+**Why this priority**: The current reported failure blocks a core daily schedule editing path and requires a refresh to recover.
+
+**Independent Test**: Open the schedule table, click a category icon in a row, and confirm the category picker opens while the rest of the page remains interactive.
+
+**Acceptance Scenarios**:
+
+1. **Given** a schedule row with a valid category, **When** the user clicks the category icon, **Then** the category picker opens without a client exception.
+2. **Given** a schedule row has an unexpected or legacy category value, **When** the row renders or the category icon is clicked, **Then** the UI falls back to a safe category display instead of throwing.
+
+### User Story 2 - Recover From Category Save Failure (Priority: P2)
+
+A user changing a category gets a recoverable failure message if the save request fails, and the table does not remain in a broken editing state.
+
+**Why this priority**: Issue #355 asks that failures avoid full-screen crashes and remain recoverable in-place.
+
+**Independent Test**: Trigger a failed category save and confirm the previous value is restored with a visible error message and retry path.
+
+**Acceptance Scenarios**:
+
+1. **Given** category saving fails, **When** the user selects a category, **Then** the optimistic value is rolled back and an error toast explains the failure.
+2. **Given** the category picker is open, **When** the user selects a category or clicks outside, **Then** the picker closes cleanly.
+
+### Edge Cases
+
+- The category button is near the viewport edge and the portal dropdown needs to reposition.
+- The source item contains a legacy category label not present in `CATEGORY_META`.
+- The user is offline or the API rejects the update.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Category cell rendering MUST tolerate unexpected category values without throwing.
+- **FR-002**: The category picker portal MUST only render when the browser document is available and a stable button position exists.
+- **FR-003**: Category selection MUST close or advance editing state without leaving a stale open portal.
+- **FR-004**: Failed item updates MUST restore the previous item state and show a user-visible error message.
+- **FR-005**: Server-provided validation messages SHOULD be preserved when available.
+
+### Key Entities
+
+- **TripItem**: Existing schedule item whose `category` can be edited from the table.
+- **Category**: Existing controlled category option set from `lib/itemOptions.ts`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Clicking a schedule row category icon no longer produces a full-screen client exception.
+- **SC-002**: Invalid or legacy category values render with a fallback instead of crashing the schedule table.
+- **SC-003**: Category save failures are recoverable without page refresh.

--- a/specs/355-schedule-category-exception/tasks.md
+++ b/specs/355-schedule-category-exception/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Schedule Category Cell Exception Recovery
+
+**Input**: `specs/355-schedule-category-exception/spec.md`, `specs/355-schedule-category-exception/plan.md`
+**Prerequisites**: Issue #355, existing schedule table implementation
+
+## Phase 1: Category Cell Resilience
+
+- [x] T001 [US1] Add safe category metadata fallback in `components/Schedule/cells/CategoryCell.tsx`.
+- [x] T002 [US1] Guard category picker portal positioning against missing browser/document state and repeated invalid measurements in `components/Schedule/cells/CategoryCell.tsx`.
+- [x] T003 [US1] Preserve accessible label/title text for fallback category display in `components/Schedule/cells/CategoryCell.tsx`.
+
+## Phase 2: Recoverable Save Failure
+
+- [x] T004 [US2] Preserve API error text when item update fails in `lib/hooks/useItems.ts`.
+- [x] T005 [US2] Keep optimistic rollback and retry behavior intact in `lib/hooks/useItems.ts`.
+
+## Phase 3: Verification
+
+- [x] T006 Run `npm run lint`.
+- [ ] T007 Manually verify category picker open/select behavior if local app credentials are available.
+
+## Dependencies & Execution Order
+
+- T001-T003 before T006.
+- T004-T005 before T006.
+- T007 after implementation and lint.


### PR DESCRIPTION
## 변경 이유
일정 테이블에서 분류 아이콘을 클릭하거나 분류 저장이 실패할 때 화면 전체가 클라이언트 예외로 전환되지 않도록 복구 가능한 경로를 닫습니다.

Closes #355

## 변경 범위
- 분류 셀이 런타임의 예기치 않은 category 값에도 안전한 fallback 아이콘/라벨을 사용합니다.
- 포털 드롭다운 위치 계산을 viewport 안쪽으로 제한하고 browser/document 가드로 안정화했습니다.
- 항목 PATCH 실패 시 기존 optimistic rollback/retry 흐름을 유지하면서 서버 오류 메시지를 토스트에 노출합니다.
- #355용 Speckit spec/plan/tasks 문서를 추가했습니다.

## 검증
- [x] npm run lint
- [x] npx tsc --noEmit
- [x] NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build
- [ ] 인증된 로컬 데이터로 일정 분류 클릭/선택 수동 검증은 미수행

## 기본기 체크
- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? (기존 화면 유지)
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? (기존 항목 편집 흐름 유지)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? (신규 모달/시트 없음)
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가?
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? (데스크톱 테이블 셀 경로 수정, 모바일 카드 경로 영향 없음)

## 남은 리스크
- 배포에서 보고된 정확한 브라우저 콘솔 스택은 확보하지 못했습니다. PR은 분류 셀의 런타임 fallback, 포털 안정성, 저장 실패 복구를 좁게 보강합니다.