### PR TITLE
fix(auth): #287 비밀번호 정책 일치

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { signUpWithEmail } from '@/lib/auth'
 import { mapAuthError } from '@/lib/auth-errors'
-import { isCommonPassword } from '@/lib/commonPasswords'
+import { validatePasswordPolicy } from '@/lib/passwordPolicy'
 
 export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => null)
@@ -11,15 +11,8 @@ export async function POST(request: NextRequest) {
   if (!email || !password) {
     return NextResponse.json({ error: '이메일과 비밀번호를 입력해주세요.' }, { status: 400 })
   }
-  if (password.length < 8) {
-    return NextResponse.json({ error: '비밀번호는 8자 이상이어야 합니다.' }, { status: 400 })
-  }
-  if (isCommonPassword(password)) {
-    return NextResponse.json(
-      { error: '너무 흔한 비밀번호예요. 추측하기 어려운 비밀번호로 바꿔주세요.' },
-      { status: 400 },
-    )
-  }
+  const passwordPolicy = await validatePasswordPolicy(password)
+  if (!passwordPolicy.ok) return NextResponse.json({ error: passwordPolicy.message }, { status: 400 })
 
   const origin = new URL(request.url).origin
   const emailRedirectTo = `${origin}/api/auth/callback?next=/login`

--- a/app/api/auth/update-password/route.ts
+++ b/app/api/auth/update-password/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getSession, updatePassword } from '@/lib/auth'
-import { isCommonPassword } from '@/lib/commonPasswords'
+import { validatePasswordPolicy } from '@/lib/passwordPolicy'
 
 export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => null)
@@ -9,15 +9,8 @@ export async function POST(request: NextRequest) {
   if (!password) {
     return NextResponse.json({ error: '새 비밀번호를 입력해주세요.' }, { status: 400 })
   }
-  if (password.length < 8) {
-    return NextResponse.json({ error: '비밀번호는 8자 이상이어야 합니다.' }, { status: 400 })
-  }
-  if (isCommonPassword(password)) {
-    return NextResponse.json(
-      { error: '너무 흔한 비밀번호예요. 추측하기 어려운 비밀번호로 바꿔주세요.' },
-      { status: 400 },
-    )
-  }
+  const passwordPolicy = await validatePasswordPolicy(password)
+  if (!passwordPolicy.ok) return NextResponse.json({ error: passwordPolicy.message }, { status: 400 })
 
   const session = await getSession()
   if (!session) {

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -3,20 +3,36 @@
 import Link from 'next/link'
 import { useState } from 'react'
 import { clearAppCache } from '@/lib/clearAppCache'
+import { validatePasswordPolicy } from '@/lib/passwordPolicy'
 import { ErrorBanner, PasswordInput, PasswordStrengthMeter } from '@/components/UI'
 import { BrandMark, PRODUCT_TAGLINE } from '@/components/Brand/Wordmark'
 
 export default function SignupForm() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [passwordConfirm, setPasswordConfirm] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
   const [submitted, setSubmitted] = useState<null | { needsEmailConfirmation: boolean }>(null)
+  const passwordMismatch = passwordConfirm.length > 0 && password !== passwordConfirm
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setLoading(true)
     setError('')
+
+    if (password !== passwordConfirm) {
+      setError('비밀번호가 일치하지 않습니다.')
+      setLoading(false)
+      return
+    }
+
+    const passwordPolicy = await validatePasswordPolicy(password)
+    if (!passwordPolicy.ok) {
+      setError(passwordPolicy.message ?? '비밀번호를 다시 확인해주세요.')
+      setLoading(false)
+      return
+    }
 
     const res = await fetch('/api/auth/signup', {
       method: 'POST',
@@ -90,6 +106,24 @@ export default function SignupForm() {
                 required
               />
               <PasswordStrengthMeter password={password} />
+            </div>
+
+            <div>
+              <PasswordInput
+                label="비밀번호 확인"
+                value={passwordConfirm}
+                onChange={e => setPasswordConfirm(e.target.value)}
+                autoComplete="new-password"
+                minLength={8}
+                required
+              />
+              <div className="min-h-5 pt-1">
+                {passwordMismatch && (
+                  <p className="text-xs text-critical-fg" role="alert">
+                    비밀번호가 일치하지 않습니다.
+                  </p>
+                )}
+              </div>
             </div>
 
             {error && (

--- a/components/UI/PasswordStrengthMeter.tsx
+++ b/components/UI/PasswordStrengthMeter.tsx
@@ -44,25 +44,29 @@ export default function PasswordStrengthMeter({ password }: Props) {
     }
   }, [password])
 
-  if (!password || !result) return null
+  const score = password && result ? result.score : null
+  const hasResult = score !== null
 
-  const tip = result.score < 3 ? '더 길게 쓰거나 추측하기 어려운 단어 조합을 써보세요.' : ''
+  const tip = score !== null && score < 3 ? '더 길게 쓰거나 추측하기 어려운 단어 조합을 써보세요.' : ''
 
   return (
-    <div className="mt-1.5" aria-live="polite">
+    <div className="mt-1.5 min-h-12" aria-live="polite">
       <div className="flex gap-1" role="presentation">
         {[0, 1, 2, 3].map((i) => (
           <span
             key={i}
             className={cn(
               'h-1 flex-1 rounded-full transition-colors',
-              i <= result.score - 1 ? BAR_COLOR[result.score] : 'bg-border',
+              score !== null && i <= score - 1 ? BAR_COLOR[score] : 'bg-border',
             )}
           />
         ))}
       </div>
-      <p className="mt-1 text-xs text-fg-subtle">
-        비밀번호 강도: <span className="font-medium text-fg-muted">{STRENGTH_LABEL[result.score]}</span>
+      <p className={cn('mt-1 text-xs text-fg-subtle', !hasResult && 'invisible')}>
+        비밀번호 강도:{' '}
+        <span className="font-medium text-fg-muted">
+          {score !== null ? STRENGTH_LABEL[score] : STRENGTH_LABEL[0]}
+        </span>
         {tip ? ` · ${tip}` : ''}
       </p>
     </div>

--- a/lib/passwordPolicy.ts
+++ b/lib/passwordPolicy.ts
@@ -1,0 +1,35 @@
+import { isCommonPassword } from '@/lib/commonPasswords'
+import { estimateStrength, type StrengthResult } from '@/lib/passwordStrength'
+
+export const MIN_PASSWORD_LENGTH = 8
+export const MIN_ACCEPTED_PASSWORD_SCORE: StrengthResult['score'] = 2
+
+export interface PasswordPolicyResult {
+  ok: boolean
+  message?: string
+  score?: StrengthResult['score']
+}
+
+export async function validatePasswordPolicy(password: string): Promise<PasswordPolicyResult> {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return { ok: false, message: '비밀번호는 8자 이상이어야 합니다.' }
+  }
+
+  if (isCommonPassword(password)) {
+    return {
+      ok: false,
+      message: '너무 흔한 비밀번호예요. 추측하기 어려운 비밀번호로 바꿔주세요.',
+    }
+  }
+
+  const { score } = await estimateStrength(password)
+  if (score < MIN_ACCEPTED_PASSWORD_SCORE) {
+    return {
+      ok: false,
+      score,
+      message: '비밀번호가 너무 약합니다. 더 길거나 추측하기 어려운 조합을 사용해주세요.',
+    }
+  }
+
+  return { ok: true, score }
+}

--- a/specs/287-password-policy/plan.md
+++ b/specs/287-password-policy/plan.md
@@ -1,0 +1,59 @@
+# Implementation Plan: Signup Password Policy Alignment
+
+**Branch**: `tasks/issue-287-password-policy` | **Date**: 2026-06-29 | **Spec**: `specs/287-password-policy/spec.md`
+**Input**: Feature specification from `specs/287-password-policy/spec.md`
+
+## Summary
+
+Centralize the password acceptance policy, use it in signup server validation and client submit validation, add password confirmation to signup, and keep the strength meter layout stable.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 18, Next.js 14 App Router
+**Primary Dependencies**: `next`, `react`, `@zxcvbn-ts/core`, `@zxcvbn-ts/language-common`
+**Storage**: Supabase Auth
+**Testing**: `npm run lint`, `npx tsc --noEmit`, `npm run build`
+**Target Platform**: Browser signup page and Next.js auth API routes
+**Project Type**: Next.js web application
+**Performance Goals**: Password score loads only when password validation/meter needs it
+**Constraints**: Avoid complexity-rule password requirements; keep length plus strength/common-password policy
+**Scale/Scope**: Signup form, password meter, password policy helper, auth password-setting routes
+
+## Constitution Check
+
+The repository constitution is scaffold placeholders. Applicable gates from `AGENTS.md`:
+
+- Behavior change is security/user-flow scoped; no unrelated refactor.
+- Copy must honestly match implemented signup behavior.
+- UI must avoid layout shift and preserve accessible labels.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/287-password-policy/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+app/signup/SignupForm.tsx
+app/api/auth/signup/route.ts
+app/api/auth/update-password/route.ts
+components/UI/PasswordStrengthMeter.tsx
+lib/passwordPolicy.ts
+```
+
+**Structure Decision**: Add a small policy helper in `lib/` so client and route handlers share the same acceptance threshold.
+
+## Complexity Tracking
+
+No added architectural complexity beyond a shared policy helper.
+
+## Process Note
+
+The repo-local `.codex/prompts/speckit.*.md` files referenced by the Speckit skills are absent. This feature uses the checked-in `.specify/templates` structure directly.

--- a/specs/287-password-policy/spec.md
+++ b/specs/287-password-policy/spec.md
@@ -1,0 +1,69 @@
+# Feature Specification: Signup Password Policy Alignment
+
+**Feature Branch**: `tasks/issue-287-password-policy`
+**Created**: 2026-06-29
+**Status**: Draft
+**Input**: GitHub issue #287 "비밀번호 강도·유출 비밀번호 차단"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Block Weak Signup Passwords (Priority: P1)
+
+A new user cannot create an account with a password that the product itself labels as too weak.
+
+**Why this priority**: The current signup path can show "매우 약함" while still allowing submission, which breaks trust and weakens account security.
+
+**Independent Test**: Enter `123123123` on the signup form and confirm the form blocks submission before account creation; direct API signup must also reject it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a signup password is very weak, **When** the user submits the form, **Then** signup is blocked with a clear message.
+2. **Given** a direct API request uses the same weak password, **When** `/api/auth/signup` receives it, **Then** the API rejects it.
+
+### User Story 2 - Prevent Password Typos (Priority: P2)
+
+A new user confirms the password before signup so accidental typos do not silently become the account password.
+
+**Why this priority**: The reopened issue specifically identifies the missing confirmation field as part of the same password-area defect.
+
+**Independent Test**: Enter different password and confirmation values and confirm the form shows an inline mismatch message and does not submit.
+
+**Acceptance Scenarios**:
+
+1. **Given** password and confirmation differ, **When** the user attempts signup, **Then** signup is blocked and the mismatch is shown near the confirmation field.
+2. **Given** password and confirmation match, **When** the password also passes policy, **Then** the signup request can proceed.
+
+### User Story 3 - Avoid Strength Meter Layout Shift (Priority: P3)
+
+The signup button does not move when the password strength meter finishes calculating.
+
+**Why this priority**: The issue reports CLS in the same signup password area.
+
+**Independent Test**: Focus the password field, type a password, and confirm the strength meter area keeps stable height before and after the async score resolves.
+
+**Acceptance Scenarios**:
+
+1. **Given** the signup form is visible, **When** the user starts typing a password, **Then** the strength meter does not push the submit button down after async loading.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Signup client validation MUST block passwords below the accepted strength threshold.
+- **FR-002**: Signup API validation MUST enforce the same minimum password policy as the client.
+- **FR-003**: Common password blocking MUST remain enforced server-side.
+- **FR-004**: Signup MUST include password confirmation and block mismatches before calling the API.
+- **FR-005**: Password strength meter layout MUST reserve stable vertical space.
+
+### Key Entities
+
+- **Password policy**: Shared rule set for minimum length, common password blocking, and minimum zxcvbn score.
+- **Signup form**: Client form collecting email, password, and confirmation.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `123123123` is rejected by the signup form and `/api/auth/signup`.
+- **SC-002**: Mismatched password confirmation prevents signup.
+- **SC-003**: The signup button position is stable while password strength is calculated.

--- a/specs/287-password-policy/tasks.md
+++ b/specs/287-password-policy/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Signup Password Policy Alignment
+
+**Input**: `specs/287-password-policy/spec.md`, `specs/287-password-policy/plan.md`
+**Prerequisites**: Issue #287 reopened acceptance criteria
+
+## Phase 1: Shared Policy
+
+- [x] T001 Add shared password policy validation in `lib/passwordPolicy.ts`.
+- [x] T002 Use shared policy in `app/api/auth/signup/route.ts`.
+- [x] T003 Use shared policy in `app/api/auth/update-password/route.ts`.
+
+## Phase 2: Signup UX
+
+- [x] T004 Add password confirmation to `app/signup/SignupForm.tsx`.
+- [x] T005 Block weak/mismatched passwords before signup API call in `app/signup/SignupForm.tsx`.
+- [x] T006 Reserve stable height for `components/UI/PasswordStrengthMeter.tsx`.
+
+## Phase 3: Verification
+
+- [x] T007 Run `npm run lint`.
+- [x] T008 Run `npx tsc --noEmit`.
+- [x] T009 Run `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`.
+- [ ] T010 Manually verify signup form if local auth credentials are available.
+
+## Dependencies & Execution Order
+
+- T001 before T002, T003, and T005.
+- T004 before T005.
+- T006 can run independently.
+- Verification runs after implementation.


### PR DESCRIPTION
## 변경 이유
가입 화면의 비밀번호 강도 표시와 실제 제출 허용 정책이 어긋나 `123123123` 같은 매우 약한 비밀번호가 통과할 수 있었습니다. 비밀번호 확인 필드 부재와 강도 미터 영역의 레이아웃 시프트도 함께 닫습니다.

Closes #287

## 변경 범위
- `lib/passwordPolicy.ts` 에 길이, 흔한 비밀번호, zxcvbn 최소 점수 정책을 공통화했습니다.
- 가입 API와 비밀번호 변경 API가 같은 정책을 사용하도록 정리했습니다.
- 가입 폼에서 API 호출 전에 약한 비밀번호와 비밀번호 확인 불일치를 차단합니다.
- 비밀번호 확인 입력을 추가했습니다.
- 강도 미터 영역에 안정적인 높이를 예약해 버튼 위치가 계산 완료 후 밀리지 않게 했습니다.
- #287용 Speckit spec/plan/tasks 문서를 추가했습니다.

## 검증
- [x] `npx tsx -e` 로 `validatePasswordPolicy('123123123')` 거부 확인
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`
- [ ] 운영/로컬 Supabase 계정 생성 플로우 수동 검증은 미수행

## 기본기 체크
- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? (auth 화면이라 해당 없음)
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? (계정 생성 입력 흐름)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? (신규 모달/시트 없음)
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가?
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가?

## 남은 리스크
- zxcvbn 동적 로드는 기존 강도 미터와 같은 경로를 사용합니다. 서버/API에서도 같은 점수 계산을 사용하므로 콜드 스타트 비용이 약간 늘 수 있습니다.