### PR TITLE
fix(schedule): #354 시간 입력 정책 정리

### DIFF
--- a/app/api/items/[id]/route.ts
+++ b/app/api/items/[id]/route.ts
@@ -15,6 +15,7 @@ import {
   type TripBounds,
 } from '@/lib/trips'
 import { isValidOpeningHours, isValidClosedDays } from '@/lib/itemValidation'
+import { normalizeTimeField } from '@/lib/timeInput'
 
 function validatePartial(body: Record<string, unknown>, bounds: TripBounds | null): string | null {
   if (body.name !== undefined && (typeof body.name !== 'string' || !body.name.trim())) {
@@ -107,20 +108,10 @@ function validatePartial(body: Record<string, unknown>, bounds: TripBounds | nul
   ) {
     return 'end_date는 시작 날짜보다 빠를 수 없습니다.'
   }
-  if (
-    body.time_start !== undefined &&
-    body.time_start !== null &&
-    !/^\d{2}:\d{2}$/.test(body.time_start as string)
-  ) {
-    return 'time_start는 HH:MM 형식이어야 합니다.'
-  }
-  if (
-    body.time_end !== undefined &&
-    body.time_end !== null &&
-    !/^\d{2}:\d{2}$/.test(body.time_end as string)
-  ) {
-    return 'time_end는 HH:MM 형식이어야 합니다.'
-  }
+  const timeStartError = normalizeTimeField(body, 'time_start')
+  if (timeStartError) return timeStartError
+  const timeEndError = normalizeTimeField(body, 'time_end')
+  if (timeEndError) return timeEndError
   return null
 }
 

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -16,6 +16,7 @@ import {
   type TripBounds,
 } from '@/lib/trips'
 import { isValidOpeningHours, isValidClosedDays } from '@/lib/itemValidation'
+import { normalizeTimeField } from '@/lib/timeInput'
 
 function validateItem(body: Record<string, unknown>, bounds: TripBounds | null): string | null {
   if (!body.name || typeof body.name !== 'string' || !body.name.trim()) {
@@ -104,16 +105,10 @@ function validateItem(body: Record<string, unknown>, bounds: TripBounds | null):
   ) {
     return 'end_date는 시작 날짜보다 빠를 수 없습니다.'
   }
-  if (body.time_start !== undefined && !/^\d{2}:\d{2}$/.test(body.time_start as string)) {
-    return 'time_start는 HH:MM 형식이어야 합니다.'
-  }
-  if (
-    body.time_end !== undefined &&
-    body.time_end !== null &&
-    !/^\d{2}:\d{2}$/.test(body.time_end as string)
-  ) {
-    return 'time_end는 HH:MM 형식이어야 합니다.'
-  }
+  const timeStartError = normalizeTimeField(body, 'time_start')
+  if (timeStartError) return timeStartError
+  const timeEndError = normalizeTimeField(body, 'time_end')
+  if (timeEndError) return timeEndError
   if (body.time_start !== undefined && body.time_start !== null && !body.date) {
     return 'time_start를 입력하려면 시작 날짜가 필요합니다.'
   }

--- a/components/Schedule/TableRow.tsx
+++ b/components/Schedule/TableRow.tsx
@@ -121,8 +121,8 @@ export default function TableRow({
           }}
           onKeyDown={(e, currentValue) =>
             handleTextKeyDown(e, 'time_start', () => {
-              if (currentValue !== (item.time_start ?? '') && currentValue !== '') {
-                onCellSave('time_start', currentValue)
+              if (currentValue !== (item.time_start ?? '')) {
+                onCellSave('time_start', currentValue ? currentValue : null)
               }
             })
           }

--- a/components/Schedule/cells/TimeCell.tsx
+++ b/components/Schedule/cells/TimeCell.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
+import { normalizeTimeInput } from '@/lib/timeInput'
 
 interface TimeCellProps {
   value: string | undefined
@@ -10,17 +11,16 @@ interface TimeCellProps {
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>, currentValue: string) => void
 }
 
-function isValidTime(value: string): boolean {
-  return /^\d{2}:\d{2}$/.test(value)
-}
-
 export default function TimeCell({ value, isEditing, onClick, onBlur, onKeyDown }: TimeCellProps) {
+  const errorId = useId()
   const inputRef = useRef<HTMLInputElement>(null)
   const [draft, setDraft] = useState(value ?? '')
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (isEditing) {
       setDraft(value ?? '')
+      setError(null)
       setTimeout(() => {
         inputRef.current?.focus()
         inputRef.current?.select()
@@ -35,29 +35,58 @@ export default function TimeCell({ value, isEditing, onClick, onBlur, onKeyDown 
   }, [value, isEditing])
 
   function handleBlur() {
-    if (draft === '') {
+    const result = normalizeTimeInput(draft)
+    if (result.status === 'empty') {
       onBlur(undefined)
-    } else if (isValidTime(draft)) {
-      onBlur(draft)
+    } else if (result.status === 'complete') {
+      onBlur(result.value)
     } else {
-      // 잘못된 포맷이면 원래 값으로 복원
-      setDraft(value ?? '')
-      onBlur(value)
+      setError(result.message)
+      setTimeout(() => inputRef.current?.focus(), 0)
     }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Tab' || e.key === 'Enter') {
+      const result = normalizeTimeInput(draft)
+      if (result.status === 'partial' || result.status === 'invalid') {
+        e.preventDefault()
+        setError(result.message)
+        return
+      }
+      onKeyDown(e, result.value ?? '')
+      return
+    }
+    setError(null)
+    onKeyDown(e, draft)
   }
 
   if (isEditing) {
     return (
+      <>
       <input
         ref={inputRef}
         value={draft}
-        onChange={e => setDraft(e.target.value)}
+        onChange={e => {
+          setDraft(e.target.value)
+          setError(null)
+        }}
         onBlur={handleBlur}
-        onKeyDown={e => onKeyDown(e, draft)}
-        placeholder="HH:MM"
-        className="w-16 bg-transparent border-b border-border-strong focus:border-accent outline-none text-sm text-fg py-0.5"
+        onKeyDown={handleKeyDown}
+        placeholder="08:00"
+        className={`w-16 bg-transparent border-b outline-none text-sm py-0.5 ${
+          error ? 'border-critical-fg text-critical-fg' : 'border-border-strong focus:border-accent text-fg'
+        }`}
         style={{ fontSize: 16 }}
+        aria-invalid={!!error}
+        aria-describedby={error ? errorId : undefined}
       />
+      {error && (
+        <p id={errorId} className="mt-1 w-32 text-xs text-critical-fg">
+          {error}
+        </p>
+      )}
+      </>
     )
   }
 

--- a/lib/timeInput.ts
+++ b/lib/timeInput.ts
@@ -1,0 +1,55 @@
+export type TimeInputResult =
+  | { status: 'empty'; value: null }
+  | { status: 'complete'; value: string }
+  | { status: 'partial'; message: string }
+  | { status: 'invalid'; message: string }
+
+const TIME_MESSAGE = '시간은 08:00 또는 0800처럼 입력해주세요.'
+const PARTIAL_MESSAGE = '시간을 끝까지 입력해주세요. 예: 08:00'
+
+function toTime(hourText: string, minuteText: string): TimeInputResult {
+  const hour = Number(hourText)
+  const minute = Number(minuteText)
+  if (!Number.isInteger(hour) || !Number.isInteger(minute) || hour > 23 || minute > 59) {
+    return { status: 'invalid', message: TIME_MESSAGE }
+  }
+  return {
+    status: 'complete',
+    value: `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`,
+  }
+}
+
+export function normalizeTimeInput(input: string): TimeInputResult {
+  const value = input.trim()
+  if (!value) return { status: 'empty', value: null }
+
+  const colon = value.match(/^(\d{1,2}):(\d{2})$/)
+  if (colon) return toTime(colon[1], colon[2])
+
+  const compact = value.match(/^(\d{3,4})$/)
+  if (compact) {
+    const raw = compact[1]
+    return toTime(raw.slice(0, -2), raw.slice(-2))
+  }
+
+  if (/^\d{1,2}:?$/.test(value)) return { status: 'partial', message: PARTIAL_MESSAGE }
+
+  return { status: 'invalid', message: TIME_MESSAGE }
+}
+
+export function normalizeTimeField(body: Record<string, unknown>, field: string): string | null {
+  const raw = body[field]
+  if (raw === undefined || raw === null) return null
+  if (typeof raw !== 'string') return TIME_MESSAGE
+
+  const result = normalizeTimeInput(raw)
+  if (result.status === 'empty') {
+    body[field] = null
+    return null
+  }
+  if (result.status === 'complete') {
+    body[field] = result.value
+    return null
+  }
+  return result.message
+}

--- a/specs/354-time-input-policy/plan.md
+++ b/specs/354-time-input-policy/plan.md
@@ -1,0 +1,59 @@
+# Implementation Plan: Schedule Time Input Policy
+
+**Branch**: `tasks/issue-354-time-input-policy` | **Date**: 2026-06-29 | **Spec**: `specs/354-time-input-policy/spec.md`
+**Input**: Feature specification from `specs/354-time-input-policy/spec.md`
+
+## Summary
+
+Add a shared time parser/normalizer, use it in schedule table time cells before committing edits, and use it in item API validation before persisting time fields.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 18, Next.js 14 App Router
+**Primary Dependencies**: `next`, `react`, `swr`
+**Storage**: Supabase-backed item records through existing item APIs
+**Testing**: `npm run lint`, `npx tsc --noEmit`, `npm run build`, parser probe
+**Target Platform**: Browser schedule table and Next.js API routes
+**Project Type**: Next.js web application
+**Performance Goals**: Synchronous parser only; no async work on keystrokes
+**Constraints**: Keep table editing model intact and avoid broader spreadsheet redesign
+**Scale/Scope**: Time cell, schedule table row save behavior, item POST/PATCH validation
+
+## Constitution Check
+
+Repository constitution is scaffold placeholders. Applicable gates from `AGENTS.md`:
+
+- Behavior change is narrow and tied to #354.
+- UI gives recoverable inline error near the edited cell.
+- Server/client policies stay consistent through a shared helper.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/354-time-input-policy/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+lib/timeInput.ts
+components/Schedule/cells/TimeCell.tsx
+components/Schedule/TableRow.tsx
+app/api/items/route.ts
+app/api/items/[id]/route.ts
+```
+
+**Structure Decision**: A small `lib/timeInput.ts` helper keeps UI and API behavior aligned without introducing a new form framework.
+
+## Complexity Tracking
+
+No added architectural complexity.
+
+## Process Note
+
+The repo-local `.codex/prompts/speckit.*.md` files referenced by the Speckit skills are absent. This feature uses the checked-in `.specify/templates` structure directly.

--- a/specs/354-time-input-policy/spec.md
+++ b/specs/354-time-input-policy/spec.md
@@ -1,0 +1,70 @@
+# Feature Specification: Schedule Time Input Policy
+
+**Feature Branch**: `tasks/issue-354-time-input-policy`
+**Created**: 2026-06-29
+**Status**: Draft
+**Input**: GitHub issue #354 "일정 테이블 시간 입력 포맷·저장·오류 정책 정리"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Natural Time Entry (Priority: P1)
+
+A user can enter common time formats in the schedule table and have them saved as canonical `HH:MM`.
+
+**Why this priority**: Schedule editing is a core flow, and values like `0800` currently fail even though users naturally type them.
+
+**Independent Test**: Edit a schedule row time to `0800`, Tab away, and confirm the item saves as `08:00`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a row has no start time, **When** the user enters `0800`, **Then** the value is saved as `08:00`.
+2. **Given** a row has no start time, **When** the user enters `8:30`, **Then** the value is saved as `08:30`.
+
+### User Story 2 - Partial Input Does Not Save (Priority: P2)
+
+A partial time entry does not send a PATCH request or move focus as if it were valid.
+
+**Why this priority**: The issue reports that `01` followed by Tab can send an invalid save request.
+
+**Independent Test**: Type `01` in a time cell and press Tab; focus stays in the cell and an inline error appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a time cell is editing, **When** the user types `01` and presses Tab, **Then** no save is attempted and the cell explains that the time is incomplete.
+2. **Given** a time cell is editing, **When** the user types an invalid value, **Then** the error is shown next to the cell and can be corrected in place.
+
+### User Story 3 - API Uses Same Policy (Priority: P3)
+
+Direct item API writes accept and normalize the same time formats as the schedule table.
+
+**Why this priority**: Server and client validation must not drift.
+
+**Independent Test**: Send `time_start: "0800"` to item create/update API and confirm it persists as `08:00`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an item PATCH contains `time_start: "0800"`, **When** the API validates it, **Then** the update is accepted and normalized.
+2. **Given** an item PATCH contains `time_start: "01"`, **When** the API validates it, **Then** the update is rejected with a corrective message.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Accepted time formats MUST include `HH:MM`, `H:MM`, and compact `HHMM` or `HMM`.
+- **FR-002**: Saved time values MUST be normalized to `HH:MM`.
+- **FR-003**: Partial values such as `01` MUST NOT trigger schedule-table save/navigation.
+- **FR-004**: Invalid or partial values MUST show an inline cell-level error.
+- **FR-005**: Item POST/PATCH validation MUST use the same normalization policy.
+
+### Key Entities
+
+- **TripItem time fields**: Existing `time_start` and `time_end` string fields stored as canonical `HH:MM`.
+- **Time input policy**: Shared parser/normalizer for schedule table and item API.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `0800` and `8:00` save as `08:00`.
+- **SC-002**: `01` does not issue a schedule-table save on Tab/Enter.
+- **SC-003**: API validation accepts normalized compact time and rejects partial time with a helpful message.

--- a/specs/354-time-input-policy/tasks.md
+++ b/specs/354-time-input-policy/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Schedule Time Input Policy
+
+**Input**: `specs/354-time-input-policy/spec.md`, `specs/354-time-input-policy/plan.md`
+**Prerequisites**: Issue #354 acceptance criteria
+
+## Phase 1: Shared Time Policy
+
+- [x] T001 Add shared time input normalization in `lib/timeInput.ts`.
+- [x] T002 Use shared normalization in `app/api/items/route.ts`.
+- [x] T003 Use shared normalization in `app/api/items/[id]/route.ts`.
+
+## Phase 2: Schedule Table Editing
+
+- [x] T004 Normalize complete time drafts before `TimeCell` blur/Tab/Enter commits.
+- [x] T005 Block partial/invalid drafts from Tab/Enter navigation in `components/Schedule/cells/TimeCell.tsx`.
+- [x] T006 Show inline cell-level time errors in `components/Schedule/cells/TimeCell.tsx`.
+- [x] T007 Allow clearing time via keyboard commit in `components/Schedule/TableRow.tsx`.
+
+## Phase 3: Verification
+
+- [x] T008 Probe parser examples with `npx tsx`.
+- [x] T009 Run `npm run lint`.
+- [x] T010 Run `npx tsc --noEmit`.
+- [x] T011 Run `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`.
+- [ ] T012 Manually verify schedule table time editing if local auth data is available.
+
+## Dependencies & Execution Order
+
+- T001 before T002-T006.
+- T004-T007 before verification.


### PR DESCRIPTION
## 변경 이유
일정 테이블 시간 입력에서 `0800` 같은 자연스러운 입력이 실패하고, `01` 같은 부분 입력이 Tab/Enter 시점에 저장 요청으로 이어질 수 있었습니다. 클라이언트와 API의 시간 정책을 맞춰 저장 전 정규화와 인라인 오류를 제공합니다.

Closes #354

## 변경 범위
- `lib/timeInput.ts` 에 `HH:MM`, `H:MM`, `HHMM`, `HMM` 입력을 `HH:MM`으로 정규화하는 공통 정책을 추가했습니다.
- 일정 테이블 시간 셀이 blur, Tab, Enter 시점에 같은 정책으로 검사합니다.
- 부분/잘못된 입력은 저장·이동하지 않고 셀 주변에 오류를 표시합니다.
- 시간 삭제를 키보드 커밋으로도 저장할 수 있게 했습니다.
- item POST/PATCH API도 같은 정규화 정책을 사용합니다.
- #354용 Speckit spec/plan/tasks 문서를 추가했습니다.

## 검증
- [x] `npx tsx -e` 로 `0800`, `8:00`, `930`, `01`, `24:00`, `12:60`, 빈 값 파서 결과 확인
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`
- [ ] 인증된 로컬 데이터로 일정 테이블 시간 편집 수동 검증은 미수행

## 기본기 체크
- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? (기존 화면 유지)
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? (기존 항목 편집 흐름 유지)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? (신규 모달/시트 없음)
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가?
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? (데스크톱 테이블 시간 셀 경로 수정, API 정책 공유)

## 남은 리스크
- 실제 Supabase 데이터가 연결된 브라우저 수동 검증은 하지 못했습니다. 자동 검증은 파서, lint, 타입, production build까지 통과했습니다.
