### PR TITLE
fix(schedule): #356 날짜 변경 컨트롤 정리

### DIFF
--- a/components/Schedule/ScheduleTable.tsx
+++ b/components/Schedule/ScheduleTable.tsx
@@ -29,7 +29,6 @@ import DateGroupHeader from './DateGroupHeader'
 import UndatedGroupHeader from './UndatedGroupHeader'
 import DistanceSeparator from './DistanceSeparator'
 import ItemWarnings from './ItemWarnings'
-import { useDraggable } from '@dnd-kit/core'
 
 interface EditingCell {
   itemId: string
@@ -125,10 +124,12 @@ function formatDate(dateStr: string): string {
 function MobileScheduleItemCard({
   item,
   onOpenPanel,
+  onChangeDate,
   todayKey,
 }: {
   item: TripItem
   onOpenPanel: (id: string) => void
+  onChangeDate: (id: string, date: string | null) => void
   todayKey: string
 }) {
   const trip = useOptionalTrip()
@@ -136,17 +137,13 @@ function MobileScheduleItemCard({
   const budget = formatBudget(item.budget, trip?.currency ?? 'KRW')
   const time = formatTimeRange(item)
   const Icon = CATEGORY_META[item.category]?.Icon
-  const { setNodeRef, listeners, attributes, isDragging } = useDraggable({
-    id: `drag:item:${item.id}`,
-    data: { itemId: item.id, sourceDate: item.date ?? null },
-  })
 
   return (
-    <div ref={setNodeRef} className={`relative ${isDragging ? 'opacity-40' : ''}`}>
+    <div className="rounded-2xl border border-border bg-bg-elevated p-4 text-left shadow-sm transition-all hover:border-border-strong hover:shadow-md">
       <button
         type="button"
         onClick={() => onOpenPanel(item.id)}
-        className="w-full rounded-2xl border border-border bg-bg-elevated p-4 pl-10 text-left shadow-sm transition-all hover:border-border-strong hover:shadow-md active:scale-[0.99]"
+        className="w-full text-left"
       >
         <div className="flex items-start gap-3">
           <span className="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl bg-bg-subtle text-fg-muted">
@@ -163,27 +160,71 @@ function MobileScheduleItemCard({
                 {status.label}
               </span>
             </div>
-
-            <div className="mt-3 flex items-center justify-between gap-3 text-xs text-fg-muted">
-              <span className="tabular-nums">{time}</span>
-              {budget ? <span className="tabular-nums font-medium text-fg">{budget}</span> : <span />}
-            </div>
-            <ItemWarnings item={item} todayKey={todayKey} className="mt-2" />
           </div>
         </div>
       </button>
-      <span
-        {...listeners}
-        {...attributes}
-        role="button"
-        aria-label="길게 눌러 다른 날짜로 이동"
-        className="absolute top-0 left-0 bottom-0 w-8 flex items-center justify-center text-fg-subtle touch-none cursor-grab active:cursor-grabbing rounded-l-2xl"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-          <path d="M7 4a1 1 0 11-2 0 1 1 0 012 0zM7 10a1 1 0 11-2 0 1 1 0 012 0zM7 16a1 1 0 11-2 0 1 1 0 012 0zM15 4a1 1 0 11-2 0 1 1 0 012 0zM15 10a1 1 0 11-2 0 1 1 0 012 0zM15 16a1 1 0 11-2 0 1 1 0 012 0z" />
-        </svg>
-      </span>
+
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-fg-muted">
+        <div className="flex flex-wrap items-center gap-2">
+          <MobileDateChangeControl
+            currentDate={item.date ?? null}
+            onChange={(date) => onChangeDate(item.id, date)}
+          />
+          <span className="tabular-nums">{time}</span>
+        </div>
+        {budget ? <span className="tabular-nums font-medium text-fg">{budget}</span> : <span />}
+      </div>
+      <ItemWarnings item={item} todayKey={todayKey} className="mt-2" />
     </div>
+  )
+}
+
+function MobileDateChangeControl({
+  currentDate,
+  onChange,
+}: {
+  currentDate: string | null
+  onChange: (date: string | null) => void
+}) {
+  const trip = useOptionalTrip()
+  const inputRef = useRef<HTMLInputElement>(null)
+  return (
+    <span className="relative inline-flex">
+      <button
+        type="button"
+        onClick={() => {
+          const el = inputRef.current
+          if (!el) return
+          if (typeof (el as HTMLInputElement & { showPicker?: () => void }).showPicker === 'function') {
+            ;(el as HTMLInputElement & { showPicker: () => void }).showPicker()
+          } else {
+            el.focus()
+            el.click()
+          }
+        }}
+        className="inline-flex min-h-9 items-center gap-1 rounded-lg border border-border bg-bg-subtle px-2.5 text-xs font-medium text-fg-muted"
+        aria-label="날짜 변경"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" className="size-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fillRule="evenodd" d="M6 2a1 1 0 011 1v1h6V3a1 1 0 112 0v1h1a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2h1V3a1 1 0 011-1zM4 8v8h12V8H4z" clipRule="evenodd" />
+        </svg>
+        날짜
+      </button>
+      <input
+        ref={inputRef}
+        type="date"
+        value={currentDate ?? ''}
+        min={trip?.startDate ?? undefined}
+        max={trip?.endDate ?? undefined}
+        onChange={(e) => {
+          const next = e.target.value || null
+          if (next !== currentDate) onChange(next)
+        }}
+        className="absolute inset-0 opacity-0 pointer-events-none"
+        tabIndex={-1}
+        aria-hidden
+      />
+    </span>
   )
 }
 
@@ -553,7 +594,12 @@ export default function ScheduleTable({
           return (
             <Fragment key={item.id}>
               {km != null && <DistanceSeparator km={km} variant="mobile" />}
-              <MobileScheduleItemCard item={item} onOpenPanel={onOpenPanel} todayKey={todayKey} />
+              <MobileScheduleItemCard
+                item={item}
+                onOpenPanel={onOpenPanel}
+                onChangeDate={(id, nextDate) => onUpdateItem(id, { date: nextDate })}
+                todayKey={todayKey}
+              />
             </Fragment>
           )
         })}

--- a/components/Schedule/TableRow.tsx
+++ b/components/Schedule/TableRow.tsx
@@ -199,7 +199,7 @@ export default function TableRow({
       </div>
 
       {/* 날짜 이동 + 상세 버튼 */}
-      <div className="w-16 flex-shrink-0 flex items-center justify-end gap-1 pr-2 py-2.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+      <div className="w-20 flex-shrink-0 flex items-center justify-end gap-1 pr-2 py-2.5">
         <DateChangeButton
           currentDate={item.date ?? null}
           onChange={(next) => onCellSave('date', next)}
@@ -244,13 +244,14 @@ function DateChangeButton({
             el.click()
           }
         }}
-        className="p-1 text-fg-subtle hover:text-fg rounded transition-colors"
+        className="inline-flex items-center gap-1 rounded-md border border-border bg-bg-elevated px-1.5 py-1 text-xs text-fg-muted transition-colors hover:border-border-strong hover:text-fg"
         aria-label="다른 날짜로 이동"
         title="다른 날짜로 이동"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+        <svg xmlns="http://www.w3.org/2000/svg" className="size-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
           <path fillRule="evenodd" d="M6 2a1 1 0 011 1v1h6V3a1 1 0 112 0v1h1a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2h1V3a1 1 0 011-1zM4 8v8h12V8H4z" clipRule="evenodd" />
         </svg>
+        날짜
       </button>
       <input
         ref={inputRef}

--- a/specs/356-date-change-controls/plan.md
+++ b/specs/356-date-change-controls/plan.md
@@ -1,0 +1,56 @@
+# Implementation Plan: Schedule Date Change Controls
+
+**Branch**: `tasks/issue-356-date-change-controls` | **Date**: 2026-06-29 | **Spec**: `specs/356-date-change-controls/spec.md`
+**Input**: Feature specification from `specs/356-date-change-controls/spec.md`
+
+## Summary
+
+Remove mobile item drag handles, add an explicit mobile date-change button per card, and make the desktop row date button visible and labeled while preserving desktop drag-and-drop.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 18, Next.js 14 App Router
+**Primary Dependencies**: `next`, `react`, `@dnd-kit/core`
+**Storage**: Existing item update hook/API
+**Testing**: `npm run lint`, `npx tsc --noEmit`, `npm run build`
+**Target Platform**: Mobile and desktop schedule views
+**Project Type**: Next.js web application
+**Performance Goals**: No additional network calls beyond existing date update
+**Constraints**: Preserve desktop drag-and-drop; avoid a broader schedule table redesign
+**Scale/Scope**: Schedule table row and mobile schedule card
+
+## Constitution Check
+
+Repository constitution is scaffold placeholders. Applicable gates from `AGENTS.md`:
+
+- UI control is visible without hover on mobile and desktop.
+- Mobile scroll interaction takes precedence over drag gestures.
+- No new design tokens or arbitrary colors.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/356-date-change-controls/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+components/Schedule/ScheduleTable.tsx
+components/Schedule/TableRow.tsx
+```
+
+**Structure Decision**: Keep the change inside existing schedule components. A separate shared date button abstraction can wait until another view needs it.
+
+## Complexity Tracking
+
+No added architectural complexity.
+
+## Process Note
+
+The repo-local `.codex/prompts/speckit.*.md` files referenced by the Speckit skills are absent. This feature uses the checked-in `.specify/templates` structure directly.

--- a/specs/356-date-change-controls/spec.md
+++ b/specs/356-date-change-controls/spec.md
@@ -1,0 +1,57 @@
+# Feature Specification: Schedule Date Change Controls
+
+**Feature Branch**: `tasks/issue-356-date-change-controls`
+**Created**: 2026-06-29
+**Status**: Draft
+**Input**: GitHub issue #356 "일정 뷰 날짜 변경 컨트롤의 모바일/PC 조작성 개선"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Mobile Date Change Without Drag Conflict (Priority: P1)
+
+A mobile user can scroll the schedule without accidentally starting item drag, and can still change an item's date through an explicit control.
+
+**Why this priority**: Mobile scroll conflict blocks a daily schedule browsing/editing path.
+
+**Independent Test**: On mobile schedule cards, scroll vertically and confirm no item drag starts; tap the visible date control to open date selection.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mobile schedule card, **When** the user scrolls the list, **Then** the card does not register a drag handle gesture.
+2. **Given** a mobile schedule card, **When** the user taps "날짜", **Then** the native date picker opens.
+
+### User Story 2 - Desktop Date Control Is Discoverable (Priority: P2)
+
+A desktop user can find the date-change control without relying on row hover.
+
+**Why this priority**: The previous icon-only hover affordance was easy to miss.
+
+**Independent Test**: Open the desktop schedule table and confirm each row has a visible labeled date control.
+
+**Acceptance Scenarios**:
+
+1. **Given** a desktop schedule row, **When** the row is not hovered, **Then** the date-change control remains visible.
+2. **Given** a desktop schedule row, **When** the user clicks the date control, **Then** the native date picker opens.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Mobile schedule cards MUST NOT register draggable item handles.
+- **FR-002**: Mobile schedule cards MUST expose an always-visible date-change control.
+- **FR-003**: Desktop rows MUST keep drag-and-drop behavior.
+- **FR-004**: Desktop rows MUST expose an always-visible labeled date-change control.
+- **FR-005**: Date picker min/max MUST keep using trip start/end bounds.
+
+### Key Entities
+
+- **TripItem date**: Existing `date` field updated through `onUpdateItem`.
+- **Date change control**: Native date input trigger for mobile and desktop schedule rows.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Mobile schedule scrolling does not start drag.
+- **SC-002**: Mobile and desktop both show a date-change control without hover.
+- **SC-003**: Changing date still uses the existing item update path.

--- a/specs/356-date-change-controls/tasks.md
+++ b/specs/356-date-change-controls/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Schedule Date Change Controls
+
+**Input**: `specs/356-date-change-controls/spec.md`, `specs/356-date-change-controls/plan.md`
+**Prerequisites**: Issue #356 acceptance criteria
+
+## Phase 1: Mobile Date Control
+
+- [x] T001 Remove mobile schedule card draggable handle registration in `components/Schedule/ScheduleTable.tsx`.
+- [x] T002 Add visible mobile date-change control in `components/Schedule/ScheduleTable.tsx`.
+- [x] T003 Route mobile date changes through existing `onUpdateItem` path.
+
+## Phase 2: Desktop Discoverability
+
+- [x] T004 Make desktop row date-change control visible without hover in `components/Schedule/TableRow.tsx`.
+- [x] T005 Add visible text label to desktop date-change control in `components/Schedule/TableRow.tsx`.
+
+## Phase 3: Verification
+
+- [x] T006 Run `npm run lint`.
+- [x] T007 Run `npx tsc --noEmit`.
+- [x] T008 Run `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`.
+- [ ] T009 Manually verify mobile scroll/date picker if local auth data is available.
+
+## Dependencies & Execution Order
+
+- T001-T003 before mobile verification.
+- T004-T005 before desktop verification.


### PR DESCRIPTION
## 변경 이유
일정 뷰 날짜 변경이 모바일에서는 스크롤과 드래그가 충돌할 수 있고, 데스크톱에서는 날짜 변경 버튼이 hover 뒤에 숨어 발견성이 낮았습니다.

Closes #356

## 변경 범위
- 모바일 일정 카드에서 draggable 핸들을 제거해 스크롤과 drag gesture 충돌을 없앴습니다.
- 모바일 카드에 항상 보이는 `날짜` 버튼을 추가하고 기존 `onUpdateItem` date 업데이트 경로로 연결했습니다.
- 데스크톱 행의 날짜 변경 버튼을 hover 없이 보이게 하고 텍스트 라벨을 추가했습니다.
- PC 드래그앤드롭은 기존 `TableRow` 경로로 유지했습니다.
- #356용 Speckit spec/plan/tasks 문서를 추가했습니다.

## 검증
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`
- [ ] 실제 모바일 브라우저/인증 데이터로 스크롤 및 date picker 수동 검증은 미수행

## 기본기 체크
- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? (기존 화면 유지)
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? (기존 항목 date update 경로 유지)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? (신규 모달/시트 없음)
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가?
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가? (모바일은 명시 버튼, PC는 버튼+드래그)

## 남은 리스크
- 네이티브 date picker 동작은 브라우저별 UI 차이가 있어 실제 모바일 기기에서 한 번 확인하는 것이 좋습니다.
