### PR TITLE
fix(dashboard): #349 검색·정렬 노출 정리

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -70,6 +70,7 @@ export default function DashboardClient({ initialTrips }: Props) {
   const [query, setQuery] = useState('')
   const [sort, setSort] = useState<SortKey>('created_desc')
   const [menuOpen, setMenuOpen] = useState<string | null>(null)
+  const showDiscoveryControls = trips.length > 3
 
   async function handleDeleteTrip(trip: TripSummary) {
     setMenuOpen(null)
@@ -134,34 +135,44 @@ export default function DashboardClient({ initialTrips }: Props) {
 
       <main className="max-w-5xl mx-auto px-4 md:px-8 py-6">
         {trips.length > 0 && (
-          <div className="flex flex-col md:flex-row gap-3 mb-6">
-            <div className="flex-1 min-w-0">
-              <Input
-                type="search"
-                hideLabel
-                label="여행 검색"
-                value={query}
-                onChange={e => setQuery(e.target.value)}
-                placeholder="이름·지역으로 검색"
-                leading={<Search className="size-4" aria-hidden="true" />}
-                data-shortcut="search"
-              />
-            </div>
-            <div className="flex items-center gap-2">
-              <label className="sr-only" htmlFor="sort-select">정렬</label>
-              <select
-                id="sort-select"
-                value={sort}
-                onChange={e => setSort(e.target.value as SortKey)}
-                className="bg-bg-elevated border border-border-strong rounded-lg px-3 py-2 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-border-strong"
-              >
-                {(Object.keys(SORT_LABELS) as SortKey[]).map(k => (
-                  <option key={k} value={k}>
-                    {SORT_LABELS[k]}
-                  </option>
-                ))}
-              </select>
-              <Link href="/dashboard/new">
+          <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            {showDiscoveryControls ? (
+              <div className="flex-1 min-w-0">
+                <Input
+                  type="search"
+                  hideLabel
+                  label="여행 검색"
+                  value={query}
+                  onChange={e => setQuery(e.target.value)}
+                  placeholder="이름·지역으로 검색"
+                  leading={<Search className="size-4" aria-hidden="true" />}
+                  data-shortcut="search"
+                />
+              </div>
+            ) : (
+              <p className="text-sm text-fg-muted">
+                여행 {trips.length}개
+              </p>
+            )}
+            <div className="flex items-center justify-end gap-2">
+              {showDiscoveryControls && (
+                <>
+                  <label className="sr-only" htmlFor="sort-select">정렬</label>
+                  <select
+                    id="sort-select"
+                    value={sort}
+                    onChange={e => setSort(e.target.value as SortKey)}
+                    className="h-10 bg-bg-elevated border border-border-strong rounded-lg px-3 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-border-strong"
+                  >
+                    {(Object.keys(SORT_LABELS) as SortKey[]).map(k => (
+                      <option key={k} value={k}>
+                        {SORT_LABELS[k]}
+                      </option>
+                    ))}
+                  </select>
+                </>
+              )}
+              <Link href="/dashboard/new" className="shrink-0">
                 <Button>
                   <Plus className="size-4 mr-1" aria-hidden="true" />
                   새 여행

--- a/specs/349-dashboard-controls/plan.md
+++ b/specs/349-dashboard-controls/plan.md
@@ -1,0 +1,55 @@
+# Implementation Plan: Dashboard Control Disclosure
+
+**Branch**: `tasks/issue-349-dashboard-controls` | **Date**: 2026-06-29 | **Spec**: `specs/349-dashboard-controls/spec.md`
+**Input**: Feature specification from `specs/349-dashboard-controls/spec.md`
+
+## Summary
+
+Add progressive disclosure to dashboard controls: hide search/sort for 1-3 trips, keep "새 여행" visible, and show search/sort at 4+ trips.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 18, Next.js 14 App Router
+**Primary Dependencies**: `next`, `react`, `swr`
+**Storage**: Existing trips API/SWR cache
+**Testing**: `npm run lint`, `npx tsc --noEmit`, `npm run build`
+**Target Platform**: Dashboard page
+**Project Type**: Next.js web application
+**Performance Goals**: No extra fetches or recomputation
+**Constraints**: Avoid changing trip card behavior or data fetching
+**Scale/Scope**: Dashboard top controls only
+
+## Constitution Check
+
+Repository constitution is scaffold placeholders. Applicable gates from `AGENTS.md`:
+
+- Entry point consistency: "새 여행" remains reachable.
+- Copy honesty: no search/sort affordance shown when intentionally unavailable.
+- Sizing: visible controls align to the same height.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/349-dashboard-controls/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+app/dashboard/DashboardClient.tsx
+```
+
+**Structure Decision**: Keep the threshold local to dashboard rendering.
+
+## Complexity Tracking
+
+No added architectural complexity.
+
+## Process Note
+
+The repo-local `.codex/prompts/speckit.*.md` files referenced by the Speckit skills are absent. This feature uses the checked-in `.specify/templates` structure directly.

--- a/specs/349-dashboard-controls/spec.md
+++ b/specs/349-dashboard-controls/spec.md
@@ -1,0 +1,50 @@
+# Feature Specification: Dashboard Control Disclosure
+
+**Feature Branch**: `tasks/issue-349-dashboard-controls`
+**Created**: 2026-06-29
+**Status**: Draft
+**Input**: GitHub issue #349 "대시보드 검색·정렬·새 여행 컨트롤 노출 정리"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Early Dashboard Focuses New Trip (Priority: P1)
+
+A user with 1-3 trips sees the existing trips and a clear "새 여행" action without prominent search/sort controls.
+
+**Why this priority**: Search and sort are low-value until the trip list has enough items.
+
+**Independent Test**: Render the dashboard with 1-3 trips and confirm only the count and "새 여행" appear above the grid.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has 1 trip, **When** the dashboard loads, **Then** search and sort controls are hidden and "새 여행" remains visible.
+2. **Given** a user has 3 trips, **When** the dashboard loads, **Then** search and sort controls are still hidden.
+
+### User Story 2 - Larger Dashboard Keeps Search And Sort (Priority: P2)
+
+A user with more than 3 trips can search and sort the trip list.
+
+**Why this priority**: Search/sort become useful when the list is large enough.
+
+**Independent Test**: Render the dashboard with 4 trips and confirm search, sort, and "새 여행" align in the top controls.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has 4 trips, **When** the dashboard loads, **Then** search, sort, and "새 여행" are visible.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Dashboard MUST hide search and sort when trip count is 1-3.
+- **FR-002**: Dashboard MUST keep "새 여행" visible when trip count is 1 or more.
+- **FR-003**: Dashboard MUST keep empty-state "첫 여행 만들기" for 0 trips.
+- **FR-004**: Dashboard MUST show search and sort when trip count is greater than 3.
+- **FR-005**: Visible controls MUST use consistent height and alignment.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 0-3 trip states emphasize creating or entering trips instead of search/sort.
+- **SC-002**: 4+ trip states retain search/sort.

--- a/specs/349-dashboard-controls/tasks.md
+++ b/specs/349-dashboard-controls/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Dashboard Control Disclosure
+
+**Input**: `specs/349-dashboard-controls/spec.md`, `specs/349-dashboard-controls/plan.md`
+**Prerequisites**: Issue #349 acceptance criteria
+
+## Phase 1: Dashboard Controls
+
+- [x] T001 Add trip-count threshold for dashboard search/sort controls in `app/dashboard/DashboardClient.tsx`.
+- [x] T002 Keep "새 여행" visible for non-empty dashboards in `app/dashboard/DashboardClient.tsx`.
+- [x] T003 Align visible control heights in `app/dashboard/DashboardClient.tsx`.
+
+## Phase 2: Verification
+
+- [x] T004 Run `npm run lint`.
+- [x] T005 Run `npx tsc --noEmit`.
+- [x] T006 Run `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`.
+- [ ] T007 Manually verify 0-3 and 4+ trip states if local auth data is available.
+
+## Dependencies & Execution Order
+
+- T001-T003 before verification.


### PR DESCRIPTION
## 변경 이유
여행이 적은 초기 대시보드에서 검색/정렬 컨트롤이 과하게 노출되어 “새 여행” 액션의 우선순위가 흐려졌습니다.

Closes #349

## 변경 범위
- 여행이 1-3개일 때 검색/정렬을 숨기고 여행 개수와 “새 여행”만 노출합니다.
- 여행이 4개 이상일 때 기존 검색/정렬/새 여행 컨트롤을 유지합니다.
- 정렬 select와 버튼 높이를 맞췄습니다.
- #349용 Speckit spec/plan/tasks 문서를 추가했습니다.

## 검증
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`
- [ ] 실제 계정 데이터로 0-3개 및 4개 이상 상태 수동 검증은 미수행

## 기본기 체크
- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? (대시보드 목록 화면)
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? (새 여행 및 기존 카드 진입 유지)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? (신규 모달/시트 없음)
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가?
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가?

## 남은 리스크
- 임계값은 이슈 수용 기준에 맞춰 3개 이하 숨김, 4개 이상 노출로 정했습니다. 실제 사용량에 따라 조정 여지는 있습니다.
