### PR TITLE
fix(layout): align trip work surfaces

### DIFF
--- a/app/trip/[tripId]/list/page.tsx
+++ b/app/trip/[tripId]/list/page.tsx
@@ -23,6 +23,7 @@ import { Input } from '@/components/UI/Input'
 import { useItems } from '@/lib/hooks/useItems'
 import { useToast } from '@/components/UI/Toast'
 import { getTripPulseSummary } from '@/lib/tripPulse'
+import { TRIP_WORKSPACE_CLASS } from '@/lib/tripLayout'
 import type { FilterState } from '@/components/Items/ItemList'
 import { getActiveFilterCount } from '@/components/Items/ItemList'
 import type { Category, ReservationStatus, TripPriority } from '@/types'
@@ -270,64 +271,66 @@ function ResearchPageContent() {
   return (
     <div className="md:pl-44 bg-bg text-fg min-h-screen">
       <header className="px-4 md:px-8 pt-4">
-        <div className="flex items-center justify-between mb-4">
-          <TripPageTitle section="목록" />
-          <div className="flex items-center gap-2">
-            <Link
-              href={`/trip/${tripId}/items/new`}
-              className="hidden md:inline-flex items-center gap-1.5 rounded-md bg-accent text-accent-fg px-3 py-1.5 text-sm font-medium hover:bg-accent-hover"
-            >
-              <Plus className="size-4" aria-hidden />
-              새 항목
-            </Link>
-            <button
-              type="button"
-              onClick={() => setShareDialogOpen(true)}
-              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-bg px-3 py-1.5 text-sm font-medium text-fg-muted hover:bg-bg-subtle"
-              aria-label="공유 링크 관리"
-            >
-              <Share2 className="size-4" aria-hidden />
-              공유
-            </button>
+        <div className={TRIP_WORKSPACE_CLASS}>
+          <div className="flex items-center justify-between mb-4">
+            <TripPageTitle section="목록" />
+            <div className="flex items-center gap-2">
+              <Link
+                href={`/trip/${tripId}/items/new`}
+                className="hidden md:inline-flex items-center gap-1.5 rounded-md bg-accent text-accent-fg px-3 py-1.5 text-sm font-medium hover:bg-accent-hover"
+              >
+                <Plus className="size-4" aria-hidden />
+                새 항목
+              </Link>
+              <button
+                type="button"
+                onClick={() => setShareDialogOpen(true)}
+                className="inline-flex items-center gap-1.5 rounded-md border border-border bg-bg px-3 py-1.5 text-sm font-medium text-fg-muted hover:bg-bg-subtle"
+                aria-label="공유 링크 관리"
+              >
+                <Share2 className="size-4" aria-hidden />
+                공유
+              </button>
+            </div>
           </div>
-        </div>
 
-        <div className="hidden md:block mb-4">
-          <div className="flex items-center gap-2">
-            <div className="flex-1 min-w-0">
-              <Input
-                type="search"
-                hideLabel
-                label="검색"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="이름·주소·메모로 검색"
-                leading={<Search className="size-4" aria-hidden="true" />}
-                data-shortcut="search"
-              />
+          <div className="hidden md:block mb-4">
+            <div className="flex items-center gap-2">
+              <div className="flex-1 min-w-0">
+                <Input
+                  type="search"
+                  hideLabel
+                  label="검색"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="이름·주소·메모로 검색"
+                  leading={<Search className="size-4" aria-hidden="true" />}
+                  data-shortcut="search"
+                />
+              </div>
+              <div className="relative flex items-center gap-1.5 flex-shrink-0">
+                <FilterButton
+                  activeCount={activeCount}
+                  onClick={() => setFilterPanelOpen((v) => !v)}
+                />
+                <FilterPanel
+                  isOpen={filterPanelOpen}
+                  filterState={filterState}
+                  onChange={setFilterState}
+                  onClose={() => setFilterPanelOpen(false)}
+                />
+              </div>
             </div>
-            <div className="relative flex items-center gap-1.5 flex-shrink-0">
-              <FilterButton
-                activeCount={activeCount}
-                onClick={() => setFilterPanelOpen((v) => !v)}
-              />
-              <FilterPanel
-                isOpen={filterPanelOpen}
-                filterState={filterState}
-                onChange={setFilterState}
-                onClose={() => setFilterPanelOpen(false)}
-              />
-            </div>
+            {activeChips.length > 0 && (
+              <div className="mt-2">
+                <ActiveFilterChips chips={activeChips} />
+              </div>
+            )}
+            {!isLoading && <TripPulse summary={tripPulse} className="mt-3" />}
+            <p className="text-xs text-fg-subtle mt-2 tabular" aria-live="polite">
+              {filteredItems.length}개 항목
+            </p>
           </div>
-          {activeChips.length > 0 && (
-            <div className="mt-2">
-              <ActiveFilterChips chips={activeChips} />
-            </div>
-          )}
-          {!isLoading && <TripPulse summary={tripPulse} className="mt-3" />}
-          <p className="text-xs text-fg-subtle mt-2 tabular" aria-live="polite">
-            {filteredItems.length}개 항목
-          </p>
         </div>
       </header>
 
@@ -336,17 +339,19 @@ function ResearchPageContent() {
         if (unnamedCount === 0) return null
         return (
           <div className="px-4 md:px-8 mb-3">
-            <button
-              type="button"
-              onClick={() => setUnnamedDialogOpen(true)}
-              className="w-full flex items-center gap-2 rounded-lg border border-border bg-warning-bg text-warning-fg px-3 py-2 text-sm hover:opacity-90"
-            >
-              <MapPin className="size-4 shrink-0" aria-hidden />
-              <span className="flex-1 text-left">
-                이름 미정 {unnamedCount}개 — 일괄 편집
-              </span>
-              <span className="text-xs opacity-80">열기 →</span>
-            </button>
+            <div className={TRIP_WORKSPACE_CLASS}>
+              <button
+                type="button"
+                onClick={() => setUnnamedDialogOpen(true)}
+                className="w-full flex items-center gap-2 rounded-lg border border-border bg-warning-bg text-warning-fg px-3 py-2 text-sm hover:opacity-90"
+              >
+                <MapPin className="size-4 shrink-0" aria-hidden />
+                <span className="flex-1 text-left">
+                  이름 미정 {unnamedCount}개 — 일괄 편집
+                </span>
+                <span className="text-xs opacity-80">열기 →</span>
+              </button>
+            </div>
           </div>
         )
       })()}
@@ -358,7 +363,7 @@ function ResearchPageContent() {
               <ItemCardSkeleton key={i} />
             ))}
           </div>
-          <div className="hidden md:block px-8">
+          <div className={`hidden md:block px-8 ${TRIP_WORKSPACE_CLASS}`}>
             <ResearchTableSkeleton />
           </div>
         </>
@@ -377,7 +382,7 @@ function ResearchPageContent() {
             />
             <StickyAddBar />
           </div>
-          <div className="hidden md:block px-8 pb-6">
+          <div className={`hidden md:block px-8 pb-6 ${TRIP_WORKSPACE_CLASS}`}>
             <ResearchTable
               items={filteredItems}
               onUpdateItem={updateItem}

--- a/app/trip/[tripId]/schedule/page.tsx
+++ b/app/trip/[tripId]/schedule/page.tsx
@@ -16,6 +16,7 @@ import ExportScheduleDialog from '@/components/Schedule/ExportScheduleDialog'
 import TripPulse from '@/components/Trip/TripPulse'
 import { buildTripPath, useTripId } from '@/lib/hooks/useTripContext'
 import { getTripPulseSummary } from '@/lib/tripPulse'
+import { TRIP_WORKSPACE_CLASS } from '@/lib/tripLayout'
 
 const ItemPanel = dynamic(() => import('@/components/Panel/ItemPanel'), { ssr: false })
 
@@ -78,7 +79,7 @@ function SchedulePageContent() {
 
   return (
     <div className="md:pl-44 bg-bg text-fg min-h-screen">
-      <div className="max-w-3xl mx-auto">
+      <div className={TRIP_WORKSPACE_CLASS}>
         <TripPageHeader
           section="일정"
           actions={
@@ -101,13 +102,13 @@ function SchedulePageContent() {
       </div>
 
       {isLoading ? (
-        <div className="max-w-3xl mx-auto px-4 space-y-2">
+        <div className={`${TRIP_WORKSPACE_CLASS} px-4 space-y-2`}>
           {Array.from({ length: 5 }).map((_, i) => (
             <ItemCardSkeleton key={i} />
           ))}
         </div>
       ) : (
-        <div className="max-w-3xl mx-auto px-4 pb-32 md:pb-6">
+        <div className={`${TRIP_WORKSPACE_CLASS} px-4 pb-32 md:pb-6`}>
           <ScheduleTable
             items={items}
             onUpdateItem={updateItem}

--- a/lib/tripLayout.ts
+++ b/lib/tripLayout.ts
@@ -1,0 +1,1 @@
+export const TRIP_WORKSPACE_CLASS = 'mx-auto w-full max-w-5xl'

--- a/specs/351-container-width/plan.md
+++ b/specs/351-container-width/plan.md
@@ -1,0 +1,57 @@
+# Implementation Plan: Trip Work Surface Width
+
+**Branch**: `tasks/issue-351-container-width` | **Date**: 2026-06-29 | **Spec**: `specs/351-container-width/spec.md`
+**Input**: Feature specification from `specs/351-container-width/spec.md`
+
+## Summary
+
+Introduce a shared trip work-surface width helper and apply it to the list and schedule views so desktop headers and tables align consistently. Leave the map route unchanged because it is a spatial canvas view.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 18, Next.js 14 App Router
+**Primary Dependencies**: `next`, `react`, `tailwindcss`
+**Storage**: Not applicable
+**Testing**: `npm run lint`, `npx tsc --noEmit`, `git diff --check`, `npm run build`
+**Target Platform**: Trip list and schedule pages
+**Project Type**: Next.js web application
+**Performance Goals**: No extra rendering work or data fetching
+**Constraints**: Preserve mobile layouts and avoid changing map canvas behavior
+**Scale/Scope**: Layout wrappers for two trip work-surface routes
+
+## Constitution Check
+
+Repository constitution is scaffold placeholders. Applicable gates from `AGENTS.md`:
+
+- Entry point consistency: list and schedule page controls align consistently.
+- Sizing: shared desktop max-width replaces per-page ad hoc width choices.
+- Design system mechanics: use Tailwind utility composition without new hex values or arbitrary spacing.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/351-container-width/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+app/trip/[tripId]/list/page.tsx
+app/trip/[tripId]/schedule/page.tsx
+lib/tripLayout.ts
+```
+
+**Structure Decision**: Keep the shared width rule in `lib/tripLayout.ts` so related trip pages can reuse one token without introducing a new component wrapper.
+
+## Complexity Tracking
+
+No added architectural complexity.
+
+## Process Note
+
+The repo-local `.codex/prompts/speckit.*.md` files referenced by the Speckit skills are absent. This feature uses the checked-in `.specify/templates` structure directly.

--- a/specs/351-container-width/spec.md
+++ b/specs/351-container-width/spec.md
@@ -1,0 +1,50 @@
+# Feature Specification: Trip Work Surface Width
+
+**Feature Branch**: `tasks/issue-351-container-width`
+**Created**: 2026-06-29
+**Status**: Draft
+**Input**: GitHub issue #351 "PC 목록/일정 화면 컨테이너 폭 규칙 정리"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Desktop Trip Views Share A Reading Width (Priority: P1)
+
+A desktop user moving between the trip list and schedule views sees content aligned to the same centered work surface instead of each screen choosing a separate width.
+
+**Why this priority**: The list and schedule are adjacent planning workflows, so inconsistent desktop widths make the product feel uneven.
+
+**Independent Test**: Open the list and schedule routes on a desktop viewport and confirm their headers and primary table content share the same max width and horizontal alignment.
+
+**Acceptance Scenarios**:
+
+1. **Given** a desktop viewport, **When** the user opens the list route, **Then** the header controls and desktop table are centered inside the same bounded width.
+2. **Given** a desktop viewport, **When** the user opens the schedule route, **Then** the header and schedule table use the same bounded width as the list route.
+
+### User Story 2 - Map Remains A Spatial Canvas (Priority: P2)
+
+A user opening the map view still gets the map-focused spatial layout rather than a reading-width table container.
+
+**Why this priority**: Map interactions need available canvas area and should remain visually distinct from list-like work surfaces.
+
+**Independent Test**: Open the map route and confirm it continues to render through `PlanScreen` without the shared list/schedule width wrapper.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user opens the map route, **When** the screen loads, **Then** map layout behavior is unchanged.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: List and schedule desktop work surfaces MUST use one shared max-width rule.
+- **FR-002**: List page header controls, unnamed-item warning, skeleton, and desktop table MUST align to that shared work surface.
+- **FR-003**: Schedule page header, loading skeleton, and schedule table MUST align to that shared work surface.
+- **FR-004**: Mobile list and schedule layouts MUST retain their existing full-width compact behavior.
+- **FR-005**: Map route MUST NOT receive the shared reading/table width rule.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Desktop list and schedule primary content use the same `max-width` source.
+- **SC-002**: Map page source remains untouched by the shared work-surface helper.

--- a/specs/351-container-width/tasks.md
+++ b/specs/351-container-width/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Trip Work Surface Width
+
+**Input**: `specs/351-container-width/spec.md`, `specs/351-container-width/plan.md`
+**Prerequisites**: Issue #351 acceptance criteria
+
+## Phase 1: Shared Layout Rule
+
+- [x] T001 Add a shared trip work-surface width helper in `lib/tripLayout.ts`.
+- [x] T002 Apply the shared width to schedule header, loading, and table wrappers in `app/trip/[tripId]/schedule/page.tsx`.
+- [x] T003 Apply the shared width to list desktop header, warning, skeleton, and table wrappers in `app/trip/[tripId]/list/page.tsx`.
+- [x] T004 Confirm the map route remains unchanged.
+
+## Phase 2: Verification
+
+- [x] T005 Run `npm run lint`.
+- [x] T006 Run `npx tsc --noEmit`.
+- [x] T007 Run `git diff --check`.
+- [x] T008 Run `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`.
+
+## Dependencies & Execution Order
+
+- T001 before T002-T003.
+- T002-T004 before verification.


### PR DESCRIPTION
## 변경 이유

Closes #351

PC 목록/일정 화면의 본문 폭이 서로 달라 화면 전환 시 정렬 기준이 흔들렸습니다. 목록과 일정은 읽기/표 중심 작업면으로 보고 동일한 최대 폭 규칙을 공유하도록 정리했습니다.

## 변경 범위

- `lib/tripLayout.ts`에 trip work-surface 폭 토큰 추가
- 여행 목록 화면의 헤더, 이름 미정 안내, 데스크톱 스켈레톤, 데스크톱 테이블을 동일 폭으로 정렬
- 여행 일정 화면의 헤더, 로딩 스켈레톤, 일정 테이블을 동일 폭으로 정렬
- 지도 화면은 공간형 캔버스이므로 변경하지 않음
- `specs/351-container-width/` Speckit 산출물 추가

## 검증

- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`

## 남은 리스크

- 실제 브라우저 시각 검증은 로컬 인증 데이터 없이 자동화하지 못했습니다. 변경은 Tailwind wrapper 정렬에 국한되어 있습니다.
