### PR TITLE
fix(schedule): 날짜 헤더 여백과 위계 개선

### DIFF
--- a/components/Schedule/DateGroupHeader.tsx
+++ b/components/Schedule/DateGroupHeader.tsx
@@ -54,89 +54,91 @@ export default function DateGroupHeader({
   return (
     <div
       ref={setNodeRef}
-      className={`bg-bg-elevated border-b border-border sticky top-0 z-10 transition-colors ${
+      className={`sticky top-0 z-10 border-y border-border-strong bg-bg-elevated/95 shadow-sm backdrop-blur transition-colors ${
         isDropTarget ? 'bg-accent-subtle ring-2 ring-accent ring-inset' : ''
       }`}
     >
-      <div className="flex items-center gap-2 px-3 py-3">
-      <button
-        type="button"
-        onClick={onToggleCollapse}
-        className="flex items-center gap-2 flex-1 min-w-0 text-left group"
-      >
-        <span className="text-sm font-semibold text-fg whitespace-nowrap">
-          {formatDate(date)}
-        </span>
-        {isToday && (
-          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-info-bg text-info-fg">
-            오늘
-          </span>
-        )}
-        {!isUndated && dayOffset !== null && (
-          <span className="text-xs text-fg-muted font-normal whitespace-nowrap">D+{dayOffset}</span>
-        )}
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          className={`w-3.5 h-3.5 text-fg-subtle transition-transform flex-shrink-0 ${isCollapsed ? '-rotate-90' : ''}`}
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fillRule="evenodd"
-            d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-            clipRule="evenodd"
-          />
-        </svg>
-      </button>
-
-      <div className="flex items-center gap-3 flex-shrink-0 min-w-0">
-        {lodgingName && (
-          <span
-            className="inline-flex items-center gap-1 text-xs text-fg-muted min-w-0 max-w-[10rem] sm:max-w-[14rem]"
-            title={lodgingName}
-          >
-            <span className="flex-shrink-0">🏨</span>
-            <span className="truncate">{lodgingName}</span>
-          </span>
-        )}
-        {totalBudget > 0 && (() => {
-          const tripCurrency = normalizeCurrency(trip?.currency)
-          const homeCurrency = isCurrencyCode(trip?.homeCurrency) ? trip.homeCurrency : null
-          const converted = formatHomeConversion(
-            totalBudget,
-            tripCurrency,
-            homeCurrency,
-            trip?.homeCurrencyRate ?? null,
-          )
-          return (
-            <span className="text-xs text-fg-muted tabular-nums">
-              {formatBudget(totalBudget, tripCurrency)}
-              {converted && (
-                <span className="ml-1 text-fg-subtle">≈ {converted}</span>
-              )}
-            </span>
-          )
-        })()}
+      <div className="flex min-h-14 flex-wrap items-center gap-x-4 gap-y-2 px-4 py-4 sm:flex-nowrap sm:px-5">
         <button
           type="button"
-          onClick={onAddItem}
-          className="flex items-center gap-1 text-xs text-fg-subtle hover:text-fg transition-colors"
+          onClick={onToggleCollapse}
+          className="group flex min-w-0 flex-1 items-center gap-2 text-left"
         >
+          <span className="text-base font-semibold leading-snug text-fg whitespace-nowrap">
+            {formatDate(date)}
+          </span>
+          {isToday && (
+            <span className="inline-flex items-center rounded bg-info-bg px-1.5 py-0.5 text-xs font-medium text-info-fg">
+              오늘
+            </span>
+          )}
+          {!isUndated && dayOffset !== null && (
+            <span className="rounded bg-bg-subtle px-1.5 py-0.5 text-xs font-medium text-fg-muted whitespace-nowrap">
+              D+{dayOffset}
+            </span>
+          )}
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            className="w-3.5 h-3.5"
+            className={`h-4 w-4 flex-shrink-0 text-fg-subtle transition-transform ${isCollapsed ? '-rotate-90' : ''}`}
             viewBox="0 0 20 20"
             fill="currentColor"
           >
             <path
               fillRule="evenodd"
-              d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
+              d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
               clipRule="evenodd"
             />
           </svg>
-          추가
         </button>
-      </div>
+
+        <div className="flex min-w-0 flex-shrink-0 items-center gap-3">
+          {lodgingName && (
+            <span
+              className="inline-flex min-w-0 max-w-[10rem] items-center gap-1 text-xs text-fg-muted sm:max-w-[14rem]"
+              title={lodgingName}
+            >
+              <span className="flex-shrink-0">🏨</span>
+              <span className="truncate">{lodgingName}</span>
+            </span>
+          )}
+          {totalBudget > 0 && (() => {
+            const tripCurrency = normalizeCurrency(trip?.currency)
+            const homeCurrency = isCurrencyCode(trip?.homeCurrency) ? trip.homeCurrency : null
+            const converted = formatHomeConversion(
+              totalBudget,
+              tripCurrency,
+              homeCurrency,
+              trip?.homeCurrencyRate ?? null,
+            )
+            return (
+              <span className="text-xs text-fg-muted tabular-nums">
+                {formatBudget(totalBudget, tripCurrency)}
+                {converted && (
+                  <span className="ml-1 text-fg-subtle">≈ {converted}</span>
+                )}
+              </span>
+            )
+          })()}
+          <button
+            type="button"
+            onClick={onAddItem}
+            className="flex min-h-8 items-center gap-1 text-xs font-medium text-fg-subtle transition-colors hover:text-fg"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="w-3.5 h-3.5"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
+                clipRule="evenodd"
+              />
+            </svg>
+            추가
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/specs/357-date-header/plan.md
+++ b/specs/357-date-header/plan.md
@@ -1,0 +1,39 @@
+# Implementation Plan: Schedule Date Header Hierarchy
+
+**Branch**: `codex/357-date-header` | **Date**: 2026-06-30 | **Spec**: `specs/357-date-header/spec.md`
+
+## Summary
+
+Improve `DateGroupHeader` so date sections read as section headers rather than dense table rows. Keep the change scoped to presentation: spacing, border hierarchy, typography, and responsive wrapping.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 18  
+**Primary Dependencies**: Next.js 14, Tailwind CSS 3.x, `@dnd-kit/core`  
+**Storage**: N/A  
+**Testing**: `npm run lint`, `npm run build`  
+**Target Platform**: Web, responsive mobile and desktop  
+**Project Type**: Next.js App Router frontend  
+**Constraints**: Existing design tokens only; no direct hex; 4px spacing scale
+
+## Constitution Check
+
+- Basics-first: context and CRUD unaffected; visual hierarchy improves schedule readability.
+- Design: uses semantic Tailwind tokens and 4px spacing scale.
+- Refactoring: no structural refactor mixed into this behavior/UI polish.
+
+## Project Structure
+
+```text
+components/Schedule/DateGroupHeader.tsx
+specs/357-date-header/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+**Structure Decision**: This is a single component polish change with feature documentation under `specs/357-date-header`.
+
+## Complexity Tracking
+
+No violations.

--- a/specs/357-date-header/spec.md
+++ b/specs/357-date-header/spec.md
@@ -1,0 +1,43 @@
+# Feature Specification: Schedule Date Header Hierarchy
+
+**Feature Branch**: `codex/357-date-header`  
+**Created**: 2026-06-30  
+**Status**: Draft  
+**Input**: GitHub issue #357 - 일정 테이블 날짜 헤더 여백과 위계 개선
+
+## User Scenarios & Testing
+
+### User Story 1 - 날짜 섹션을 빠르게 구분한다 (Priority: P1)
+
+일정 뷰에서 여러 날짜가 이어질 때 사용자는 날짜 헤더를 일반 일정 행과 즉시 구분할 수 있어야 한다.
+
+**Why this priority**: 날짜 헤더는 일정 테이블의 주요 구조 단위이며, 위계가 약하면 긴 일정에서 탐색 비용이 커진다.
+
+**Independent Test**: 일정 뷰에서 두 개 이상의 날짜 섹션을 표시하고, 날짜 헤더가 일반 항목 행보다 여백과 텍스트 위계로 분리되어 보이는지 확인한다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 일정 항목이 여러 날짜에 나뉘어 있을 때, **When** 사용자가 일정 테이블을 스캔하면, **Then** 각 날짜 헤더가 섹션 시작점으로 명확히 인지된다.
+2. **Given** 날짜 헤더에 예산, 숙소, 오늘 배지가 함께 표시될 때, **When** 화면 폭이 줄어들면, **Then** 날짜 라벨의 위계가 유지되고 보조 정보가 헤더를 압도하지 않는다.
+
+### Edge Cases
+
+- 날짜 미정 그룹도 같은 섹션 헤더 리듬을 사용해야 한다.
+- 드래그 중 drop target 상태에서도 헤더 경계와 위계가 유지되어야 한다.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: 날짜 헤더는 일반 일정 행보다 큰 텍스트 위계와 충분한 상하 여백을 가져야 한다.
+- **FR-002**: 날짜 헤더는 인접 날짜 섹션과 구분되는 경계선을 가져야 한다.
+- **FR-003**: 오늘 배지, D+n, 숙소, 예산, 추가 버튼은 날짜 라벨의 주 위계를 훼손하지 않아야 한다.
+- **FR-004**: 날짜 헤더 스타일은 기존 디자인 토큰과 4px spacing 체계를 사용해야 한다.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: 날짜 헤더의 기본 텍스트 크기가 일반 메타 텍스트보다 한 단계 이상 크다.
+- **SC-002**: 날짜 헤더의 수직 padding은 16px 단위 리듬을 사용한다.
+- **SC-003**: `npm run lint`와 `npm run build`가 통과한다.

--- a/specs/357-date-header/tasks.md
+++ b/specs/357-date-header/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: Schedule Date Header Hierarchy
+
+**Input**: `specs/357-date-header/spec.md`, `specs/357-date-header/plan.md`  
+**Prerequisites**: Issue #357
+
+## Phase 1: Implementation
+
+- [x] T001 [US1] Increase date header typography and vertical rhythm in `components/Schedule/DateGroupHeader.tsx`.
+- [x] T002 [US1] Strengthen section boundaries and drop target state without direct color values in `components/Schedule/DateGroupHeader.tsx`.
+- [x] T003 [US1] Keep secondary metadata responsive so it does not dominate the date label in `components/Schedule/DateGroupHeader.tsx`.
+
+## Phase 2: Verification
+
+- [x] T004 Run `npm run lint`.
+- [x] T005 Run `npm run build`.
+
+## Dependencies & Execution Order
+
+T001, T002, and T003 affect the same component and should be completed together. T004 and T005 run after implementation.


### PR DESCRIPTION
Closes #357

## 변경 이유

일정 테이블에서 `N월 M일` 날짜 헤더가 일반 항목 행과 가까운 밀도로 붙어 보여, 여러 날짜 섹션을 스캔할 때 구분감이 약했습니다.

## 변경 범위

- `DateGroupHeader`의 날짜 라벨을 `text-base` 위계로 올리고 상하 여백을 16px 리듬으로 조정했습니다.
- 날짜 섹션 경계를 `border-y border-border-strong`, 얕은 shadow, elevated surface로 강화했습니다.
- `오늘`, `D+n`, 숙소, 예산, 추가 버튼이 날짜 라벨을 압도하지 않도록 보조 정보 스타일과 래핑을 정리했습니다.
- `specs/357-date-header`에 spec/plan/tasks를 추가했습니다.

## 검증

- `npm run lint`
- `set -a; source ../trip-planner/.env.local; set +a; npm run build`

## 기본기 5문항 (Basics-First Rule — `docs/basics-first-rule.md` 참조)

- [x] 이 페이지/기능에 "지금 보고 있는 여행 이름" 이 보이는가?
- [x] 이 페이지에서 새 항목을 1 클릭으로 추가할 수 있는가? (해당 시)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? (`Sheet` 콘텐츠 적응형)
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가?
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가?

## 카피 게이트 (사용자향 카피를 추가·변경한 경우 — `design-guidelines §11`)

N/A — 사용자향 카피 변경 없음.

## 남은 작업 / 리스크

- 실제 여행 데이터가 있는 브라우저 화면에서 추가 시각 QA를 하면 더 확실합니다.