### PR TITLE
fix(ui): 한국어 빈 상태 줄바꿈 품질 개선

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,14 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  .text-keep-korean {
+    line-break: strict;
+    overflow-wrap: break-word;
+    word-break: keep-all;
+  }
+}
+
 /* ============================================================
  * 시맨틱 디자인 토큰
  * - 색은 RGB triple 로 정의해 Tailwind 의 rgb(var(--x) / <alpha-value>) 와 호환

--- a/components/UI/EmptyState.tsx
+++ b/components/UI/EmptyState.tsx
@@ -41,14 +41,16 @@ export default function EmptyState({
       )}
       <p
         className={cn(
-          'font-semibold text-fg',
+          'text-keep-korean font-semibold text-fg',
           size === 'page' ? 'text-base' : 'text-sm',
         )}
       >
         {title}
       </p>
       {description && (
-        <p className="text-sm text-fg-muted max-w-sm leading-relaxed">{description}</p>
+        <p className="text-keep-korean max-w-md text-sm leading-relaxed text-fg-muted">
+          {description}
+        </p>
       )}
       {action && <div className="mt-2">{action}</div>}
     </div>

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -521,6 +521,7 @@ Key + Ambient 2종 합성, 14% opacity 기본. trip-planner 매핑:
 - `title`: 한 줄. "아직 …이 없어요" 처럼 사용자 시점 (§ 11.2).
 - `description`: 선택. **다음 행동을 안내** (Polaris empty-state 원칙).
 - `action`: 선택. 1차 액션은 `<Button>` 으로 — 추가 / 검색 초기화 등.
+- 한국어 제목·설명은 `text-keep-korean`으로 조사·어미가 한 글자 단독 줄로 떨어지지 않게 한다.
 
 **lucide 매핑 가이드**
 

--- a/specs/348-korean-line-breaks/plan.md
+++ b/specs/348-korean-line-breaks/plan.md
@@ -1,0 +1,41 @@
+# Implementation Plan: Korean Copy Line Break Quality
+
+**Branch**: `codex/348-korean-line-breaks` | **Date**: 2026-06-30 | **Spec**: `specs/348-korean-line-breaks/spec.md`
+
+## Summary
+
+Add a reusable Korean text wrapping utility and apply it to the shared `EmptyState` component so major empty-state and onboarding copy avoids awkward one-character Korean line breaks.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 18  
+**Primary Dependencies**: Next.js 14, Tailwind CSS 3.x  
+**Storage**: N/A  
+**Testing**: `npm run lint`, `npm run build`  
+**Target Platform**: Web, responsive mobile and desktop  
+**Project Type**: Next.js App Router frontend  
+**Constraints**: Use shared component and CSS utility; avoid one-off copy-specific layout hacks
+
+## Constitution Check
+
+- Basics-first: improves empty-state copy readability without changing CRUD or navigation behavior.
+- Design: adds a reusable typography utility and documents the rule in `docs/design-guidelines.md`.
+- Refactoring: no unrelated structural refactor.
+
+## Project Structure
+
+```text
+app/globals.css
+components/UI/EmptyState.tsx
+docs/design-guidelines.md
+specs/348-korean-line-breaks/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+**Structure Decision**: Shared text wrapping belongs in global utilities; EmptyState consumes it so existing screens inherit the behavior.
+
+## Complexity Tracking
+
+No violations.

--- a/specs/348-korean-line-breaks/spec.md
+++ b/specs/348-korean-line-breaks/spec.md
@@ -1,0 +1,43 @@
+# Feature Specification: Korean Copy Line Break Quality
+
+**Feature Branch**: `codex/348-korean-line-breaks`  
+**Created**: 2026-06-30  
+**Status**: Draft  
+**Input**: GitHub issue #348 - 한국어 문장 줄바꿈 품질 점검
+
+## User Scenarios & Testing
+
+### User Story 1 - 빈 상태 설명을 자연스럽게 읽는다 (Priority: P1)
+
+한국어 빈 상태와 온보딩성 설명 문구를 읽는 사용자는 조사나 어미 한 글자만 다음 줄에 떨어지는 어색한 줄바꿈을 보지 않아야 한다.
+
+**Why this priority**: 빈 상태는 사용자가 다음 행동을 결정하는 첫 안내 표면이므로, 문장이 끊기면 제품 신뢰와 가독성이 떨어진다.
+
+**Independent Test**: 대시보드 빈 상태의 “가 보고 싶은 곳을 모으면, 여기서 하루 단위 일정으로 정리할 수 있어요.” 문구와 주요 EmptyState 문구를 모바일/데스크톱 폭에서 확인한다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 대시보드에 여행이 없을 때, **When** 사용자가 빈 상태 설명을 보면, **Then** “있어요” 같은 어미가 한 글자 단독 줄로 쪼개지지 않는다.
+2. **Given** 목록, 지도, 일정, 공유 등 공통 EmptyState가 표시될 때, **When** 화면 폭이 달라지면, **Then** 한국어 제목과 설명은 단어/어절 중심으로 줄바꿈된다.
+
+### Edge Cases
+
+- 긴 URL이나 영문 토큰이 포함되면 컨테이너를 넘치지 않고 필요한 경우에만 단어 내부에서 줄바꿈되어야 한다.
+- inline 크기의 EmptyState도 같은 줄바꿈 정책을 따라야 한다.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: 공통 EmptyState 제목과 설명은 한국어에 적합한 줄바꿈 정책을 사용해야 한다.
+- **FR-002**: EmptyState 설명 영역은 주요 한국어 안내 문구가 과도하게 좁은 폭에서 강제로 쪼개지지 않도록 적정 최대 폭을 가져야 한다.
+- **FR-003**: 줄바꿈 정책은 재사용 가능한 기준으로 남아야 한다.
+- **FR-004**: 긴 비한국어 토큰이 있을 때 레이아웃 overflow를 만들면 안 된다.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: `components/UI/EmptyState.tsx`를 사용하는 주요 빈 상태가 같은 한국어 줄바꿈 정책을 공유한다.
+- **SC-002**: 디자인 가이드의 EmptyState 규칙에 한국어 줄바꿈 기준이 남는다.
+- **SC-003**: `npm run lint`와 `npm run build`가 통과한다.

--- a/specs/348-korean-line-breaks/tasks.md
+++ b/specs/348-korean-line-breaks/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Korean Copy Line Break Quality
+
+**Input**: `specs/348-korean-line-breaks/spec.md`, `specs/348-korean-line-breaks/plan.md`  
+**Prerequisites**: Issue #348
+
+## Phase 1: Implementation
+
+- [x] T001 [US1] Add reusable Korean wrapping utility in `app/globals.css`.
+- [x] T002 [US1] Apply the utility to EmptyState title and description in `components/UI/EmptyState.tsx`.
+- [x] T003 [US1] Adjust EmptyState description measure to reduce awkward narrow wrapping in `components/UI/EmptyState.tsx`.
+- [x] T004 [US1] Document the rule in `docs/design-guidelines.md`.
+
+## Phase 2: Verification
+
+- [x] T005 Run `npm run lint`.
+- [x] T006 Run `npm run build`.
+
+## Dependencies & Execution Order
+
+T001 precedes T002. T003 and T004 can be completed after the shared utility is defined. T005 and T006 run after implementation.


### PR DESCRIPTION
Closes #348

## 변경 이유

빈 상태와 온보딩성 한국어 설명에서 조사·어미 한 글자가 다음 줄에 단독으로 떨어지는 줄바꿈 문제가 있었습니다.

## 변경 범위

- `text-keep-korean` 유틸리티를 추가해 `line-break: strict`, `word-break: keep-all`, overflow fallback을 함께 적용했습니다.
- 공통 `EmptyState`의 제목과 설명에 해당 유틸리티를 적용했습니다.
- EmptyState 설명의 최대 폭을 `max-w-md`로 넓혀 주요 한국어 안내 문구가 과도하게 좁게 접히지 않도록 했습니다.
- 디자인 가이드의 EmptyState 규칙에 한국어 줄바꿈 기준을 추가했습니다.
- `specs/348-korean-line-breaks`에 spec/plan/tasks를 추가했습니다.

## 검증

- `npm run lint`
- `set -a; source ../trip-planner/.env.local; set +a; npm run build`

## 기본기 5문항 (Basics-First Rule — `docs/basics-first-rule.md` 참조)

- [x] 이 페이지/기능에 "지금 보고 있는 여행 이름" 이 보이는가?
- [x] 이 페이지에서 새 항목을 1 클릭으로 추가할 수 있는가? (해당 시)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? (`Sheet` 콘텐츠 적응형)
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가?
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가?

## 카피 게이트 (사용자향 카피를 추가·변경한 경우 — `design-guidelines §11`)

N/A — 사용자향 카피 변경 없음.

## 남은 작업 / 리스크

- 브라우저별 CJK line-break 렌더링 차이가 있을 수 있어 실제 기기 시각 QA를 추가하면 더 확실합니다.