### PR TITLE
fix(map): 지도 로딩 셸을 실제 뷰 구조에 맞춤

### DIFF
--- a/app/trip/[tripId]/map/loading.tsx
+++ b/app/trip/[tripId]/map/loading.tsx
@@ -1,0 +1,94 @@
+import Navigation from '@/components/Layout/Navigation'
+import { Skeleton } from '@/components/UI/Skeleton'
+
+function PanelLoading() {
+  return (
+    <aside className="flex h-full flex-col bg-bg-elevated" aria-hidden="true">
+      <div className="flex flex-shrink-0 gap-1 border-b border-border bg-bg-subtle p-1.5">
+        <Skeleton className="h-8 flex-1 rounded-md" />
+        <Skeleton className="h-8 flex-1 rounded-md" />
+      </div>
+      <div className="flex-shrink-0 border-b border-border px-3 py-2">
+        <Skeleton className="h-10 rounded-lg" />
+      </div>
+      <div className="flex-shrink-0 border-b border-border px-3 py-2">
+        <Skeleton className="h-9 rounded-md" />
+      </div>
+      <div className="flex-1 space-y-2 overflow-hidden p-3">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={index}
+            className="flex items-start gap-3 rounded-lg border border-border bg-bg-elevated p-3"
+          >
+            <Skeleton className="size-8 shrink-0 rounded-full" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-4 w-2/3 rounded" />
+              <Skeleton className="h-3 w-1/2 rounded" />
+              <div className="flex gap-1.5">
+                <Skeleton className="h-5 w-12 rounded-full" />
+                <Skeleton className="h-5 w-16 rounded-full" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </aside>
+  )
+}
+
+function MapLoading() {
+  return (
+    <div
+      className="relative h-full w-full overflow-hidden bg-bg-subtle"
+      aria-hidden="true"
+    >
+      <div className="absolute inset-0 opacity-60 [background-image:linear-gradient(rgb(var(--border))_1px,transparent_1px),linear-gradient(90deg,rgb(var(--border))_1px,transparent_1px)] [background-size:72px_72px]" />
+      <div className="absolute left-3 top-3 z-[600] rounded-md bg-bg-elevated/90 px-2.5 py-1.5 shadow-sm backdrop-blur">
+        <Skeleton className="h-4 w-28 rounded" />
+      </div>
+      <div className="absolute right-3 top-3 z-[600] rounded-lg bg-bg-elevated/90 px-3 py-2 shadow-sm backdrop-blur">
+        <Skeleton className="h-5 w-16 rounded" />
+      </div>
+      <div className="absolute bottom-5 right-5 z-[600] space-y-2">
+        <Skeleton className="size-9 rounded-md" />
+        <Skeleton className="size-9 rounded-md" />
+      </div>
+      <div className="absolute left-1/2 top-1/2 size-10 -translate-x-1/2 -translate-y-1/2 rounded-full border border-border bg-bg-elevated shadow-e4" />
+    </div>
+  )
+}
+
+export default function MapRouteLoading() {
+  return (
+    <div className="bg-bg text-fg md:pl-44" aria-busy="true" aria-label="지도 불러오는 중">
+      <div className="hidden h-screen md:flex">
+        <div className="w-[360px] flex-shrink-0 border-r border-border bg-bg-elevated">
+          <PanelLoading />
+        </div>
+        <div className="relative min-w-0 flex-1">
+          <MapLoading />
+        </div>
+      </div>
+
+      <div className="relative flex h-[calc(100vh-56px)] flex-col md:hidden">
+        <div className="relative min-h-0 flex-1">
+          <MapLoading />
+          <Skeleton className="absolute bottom-4 right-4 z-[600] size-12 rounded-full shadow-e4" />
+        </div>
+        <div className="flex h-[40vh] flex-shrink-0 flex-col border-t border-border bg-bg-elevated">
+          <div className="flex w-full flex-shrink-0 items-center justify-center py-2">
+            <span
+              aria-hidden="true"
+              className="block h-1 w-10 rounded-full bg-fg-subtle/40"
+            />
+          </div>
+          <div className="min-h-0 flex-1">
+            <PanelLoading />
+          </div>
+        </div>
+      </div>
+
+      <Navigation />
+    </div>
+  )
+}

--- a/specs/292-map-loading-state/plan.md
+++ b/specs/292-map-loading-state/plan.md
@@ -1,0 +1,39 @@
+# Implementation Plan: Map Loading State Alignment
+
+**Branch**: `codex/292-map-loading-state` | **Date**: 2026-06-30 | **Spec**: `specs/292-map-loading-state/spec.md`
+
+## Summary
+
+Add a dedicated map route loading shell that mirrors the final map work surface: desktop side panel plus map canvas, and mobile map plus bottom drawer. Keep the change route-scoped so list and schedule loading behavior is unaffected.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 18  
+**Primary Dependencies**: Next.js 14 App Router, Tailwind CSS 3.x  
+**Storage**: N/A  
+**Testing**: `npm run lint`, `npm run build`  
+**Target Platform**: Web, responsive mobile and desktop  
+**Project Type**: Next.js App Router frontend  
+**Constraints**: Route-scoped loading state; no fake map data; preserve final map layout dimensions
+
+## Constitution Check
+
+- Basics-first: keeps navigation and map work surface context visible during loading.
+- Design: uses existing `Skeleton`, semantic tokens, and final layout dimensions.
+- Refactoring: no changes to data loading or map behavior.
+
+## Project Structure
+
+```text
+app/trip/[tripId]/map/loading.tsx
+specs/292-map-loading-state/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+**Structure Decision**: The issue targets map view loading, so the fix belongs in the map route segment rather than the shared trip loading fallback.
+
+## Complexity Tracking
+
+No violations.

--- a/specs/292-map-loading-state/spec.md
+++ b/specs/292-map-loading-state/spec.md
@@ -1,0 +1,43 @@
+# Feature Specification: Map Loading State Alignment
+
+**Feature Branch**: `codex/292-map-loading-state`  
+**Created**: 2026-06-30  
+**Status**: Draft  
+**Input**: GitHub issue #292 - 지도 뷰 스켈레톤이 최종 화면의 주요 레이아웃을 보존한다
+
+## User Scenarios & Testing
+
+### User Story 1 - 지도 진입 중 최종 레이아웃을 예측한다 (Priority: P1)
+
+지도 뷰로 이동하는 사용자는 로딩 중에도 최종 화면의 큰 구조가 지도와 사이드 패널이라는 점을 바로 알 수 있어야 한다.
+
+**Why this priority**: 로딩 UI가 실제 지도 화면과 닮지 않으면 전환 후 레이아웃 점프처럼 느껴지고, 스켈레톤이 잘못된 약속을 하게 된다.
+
+**Independent Test**: `/trip/[tripId]/map` route loading state를 확인해 데스크톱은 좌측 패널+우측 지도, 모바일은 지도+하단 패널 구조를 유지하는지 확인한다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 데스크톱 폭에서 지도 뷰가 로딩 중일 때, **When** loading UI가 표시되면, **Then** 좌측 패널 폭과 우측 지도 영역이 최종 지도 뷰와 같은 구조로 보인다.
+2. **Given** 모바일 폭에서 지도 뷰가 로딩 중일 때, **When** loading UI가 표시되면, **Then** 지도 영역과 40vh 하단 패널이 최종 지도 뷰와 같은 구조로 보인다.
+
+### Edge Cases
+
+- 로딩 중에도 네비게이션 영역은 최종 화면과 같은 위치를 유지해야 한다.
+- 스켈레톤은 실제 지도 화면에 없는 배지나 가짜 콘텐츠를 약속하지 않아야 한다.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: 지도 route는 전용 loading shell을 제공해야 한다.
+- **FR-002**: 데스크톱 loading shell은 최종 화면의 360px 사이드 패널과 지도 영역을 보존해야 한다.
+- **FR-003**: 모바일 loading shell은 최종 화면의 지도 영역, 하단 패널 높이, 네비게이션 위치를 보존해야 한다.
+- **FR-004**: 지도 placeholder는 지도 영역임을 암시하되 실제 데이터 마커나 존재하지 않는 항목을 약속하지 않아야 한다.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: `app/trip/[tripId]/map/loading.tsx`가 route-level loading UI를 제공한다.
+- **SC-002**: Loading shell의 주요 layout dimensions가 `PlanScreen` map view와 일치한다.
+- **SC-003**: `npm run lint`와 `npm run build`가 통과한다.

--- a/specs/292-map-loading-state/tasks.md
+++ b/specs/292-map-loading-state/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Map Loading State Alignment
+
+**Input**: `specs/292-map-loading-state/spec.md`, `specs/292-map-loading-state/plan.md`  
+**Prerequisites**: Issue #292 latest map loading comment
+
+## Phase 1: Implementation
+
+- [x] T001 [US1] Add route-level map loading shell in `app/trip/[tripId]/map/loading.tsx`.
+- [x] T002 [US1] Match desktop side panel plus map dimensions from `components/Plan/PlanScreen.tsx`.
+- [x] T003 [US1] Match mobile map plus bottom drawer dimensions from `components/Plan/PlanScreen.tsx`.
+- [x] T004 [US1] Avoid fake data markers or non-final badges in `app/trip/[tripId]/map/loading.tsx`.
+
+## Phase 2: Verification
+
+- [x] T005 Run `npm run lint`.
+- [x] T006 Run `npm run build`.
+
+## Dependencies & Execution Order
+
+T001 is the main route artifact. T002-T004 are implementation checks inside the loading shell. T005 and T006 run after implementation.


### PR DESCRIPTION
Closes #292

## 변경 이유

지도 뷰 로딩 상태가 실제 지도 화면의 주요 구조와 닮지 않으면 스켈레톤이 잘못된 레이아웃을 약속하고 전환이 더 튀어 보입니다.

## 변경 범위

- `/trip/[tripId]/map` route 전용 `loading.tsx`를 추가했습니다.
- 데스크톱 로딩 상태를 최종 지도 뷰와 같은 좌측 360px 패널 + 우측 지도 영역으로 구성했습니다.
- 모바일 로딩 상태를 최종 지도 뷰와 같은 지도 영역 + 40vh 하단 패널 + 하단 네비게이션 구조로 구성했습니다.
- 지도 placeholder는 데이터 마커나 존재하지 않는 배지를 만들지 않고, 지도 캔버스임을 암시하는 중립 셸만 표시합니다.
- `specs/292-map-loading-state`에 spec/plan/tasks를 추가했습니다.

## 검증

- `npm run lint`
- `set -a; source ../trip-planner/.env.local; set +a; npm run build`

## 기본기 5문항 (Basics-First Rule — `docs/basics-first-rule.md` 참조)

- [x] 이 페이지/기능에 "지금 보고 있는 여행 이름" 이 보이는가?
- [x] 이 페이지에서 새 항목을 1 클릭으로 추가할 수 있는가? (해당 시)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가? (`Sheet` 콘텐츠 적응형)
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가?
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가?

## 카피 게이트 (사용자향 카피를 추가·변경한 경우 — `design-guidelines §11`)

N/A — 사용자향 카피 변경 없음.

## 남은 작업 / 리스크

- App Router의 상위 `app/trip/[tripId]/loading.tsx`는 접근 체크 대기 중 계속 공통 trip fallback으로 동작합니다. 이번 PR은 map route segment loading을 실제 지도 구조에 맞추는 범위입니다.