### PR TITLE
새 여행 생성의 베이스캠프 역할 정리

### DIFF
--- a/app/dashboard/new/NewTripWizard.tsx
+++ b/app/dashboard/new/NewTripWizard.tsx
@@ -31,7 +31,7 @@ const STEP_TITLES: Record<Step, string> = {
   1: '여행 이름',
   2: '기간',
   3: '지역',
-  4: '베이스캠프',
+  4: '통화',
   5: '확인',
 }
 
@@ -45,7 +45,6 @@ export default function NewTripWizard() {
   const [endDate, setEndDate] = useState('')
   const [region, setRegion] = useState('')
   const [center, setCenter] = useState<CenterValue | null>(null)
-  const [basecamp, setBasecamp] = useState('')
   const [currency, setCurrency] = useState<CurrencyCode>('KRW')
   const [submitting, setSubmitting] = useState(false)
   const [restored, setRestored] = useState(false)
@@ -58,7 +57,6 @@ export default function NewTripWizard() {
     startDate !== '' ||
     endDate !== '' ||
     region.trim() !== '' ||
-    basecamp.trim() !== '' ||
     center !== null
 
   // 마운트 시 1회: 임시 저장된 드래프트가 있으면 복원한다(클라이언트 전용 — SSR 불일치 방지).
@@ -73,11 +71,10 @@ export default function NewTripWizard() {
           endDate: string
           region: string
           center: CenterValue | null
-          basecamp: string
           currency: CurrencyCode
         }>
         const hasInput =
-          d.title || d.startDate || d.endDate || d.region || d.basecamp || d.center
+          d.title || d.startDate || d.endDate || d.region || d.center
         if (hasInput) {
           if (typeof d.step === 'number') setStep(d.step)
           if (typeof d.title === 'string') setTitle(d.title)
@@ -85,7 +82,6 @@ export default function NewTripWizard() {
           if (typeof d.endDate === 'string') setEndDate(d.endDate)
           if (typeof d.region === 'string') setRegion(d.region)
           if (d.center) setCenter(d.center)
-          if (typeof d.basecamp === 'string') setBasecamp(d.basecamp)
           if (typeof d.currency === 'string') setCurrency(d.currency)
           setRestored(true)
         }
@@ -107,14 +103,14 @@ export default function NewTripWizard() {
       try {
         sessionStorage.setItem(
           DRAFT_KEY,
-          JSON.stringify({ step, title, startDate, endDate, region, center, basecamp, currency }),
+          JSON.stringify({ step, title, startDate, endDate, region, center, currency }),
         )
       } catch {
         /* 용량 초과 등은 무시 */
       }
     }, 400)
     return () => clearTimeout(t)
-  }, [step, title, startDate, endDate, region, center, basecamp, currency, isDirty])
+  }, [step, title, startDate, endDate, region, center, currency, isDirty])
 
   // 새로고침·탭 닫기 시 브라우저 기본 경고(입력이 있을 때만).
   useEffect(() => {
@@ -143,7 +139,6 @@ export default function NewTripWizard() {
     setEndDate('')
     setRegion('')
     setCenter(null)
-    setBasecamp('')
     setCurrency('KRW')
     setRestored(false)
   }
@@ -196,7 +191,6 @@ export default function NewTripWizard() {
           start_date: startDate || null,
           end_date: endDate || null,
           region: region.trim() || null,
-          basecamp_address: basecamp.trim() || null,
           currency,
         }),
       })
@@ -317,15 +311,13 @@ export default function NewTripWizard() {
           )}
           {step === 4 && (
             <Step4
-              basecamp={basecamp}
-              setBasecamp={setBasecamp}
               currency={currency}
               setCurrency={setCurrency}
             />
           )}
           {step === 5 && (
             <Step5
-              summary={{ title, startDate, endDate, region, basecamp, currency }}
+              summary={{ title, startDate, endDate, region, currency }}
               centerManual={center?.source === 'manual'}
               onEdit={jumpToStep}
             />
@@ -448,48 +440,29 @@ function Step3({
 }
 
 function Step4({
-  basecamp,
-  setBasecamp,
   currency,
   setCurrency,
 }: {
-  basecamp: string
-  setBasecamp: (v: string) => void
   currency: CurrencyCode
   setCurrency: (c: CurrencyCode) => void
 }) {
-  const isTouch = useIsTouchDevice()
   return (
-    <div className="space-y-4">
-      <div>
-        <LocationAutocompleteInput
-          label="베이스캠프 (선택 · 숙소)"
-          value={basecamp}
-          onChange={setBasecamp}
-          placeholder="예: 난바 인근 호텔"
-          autoFocus={!isTouch}
-        />
-        <p className="text-xs text-fg-subtle mt-1">
-          비워두면 여행을 만든 뒤 설정에서 추가할 수 있어요.
-        </p>
-      </div>
-      <div className="border-t border-border pt-4">
-        <label className="block text-sm font-medium text-fg mb-1.5">통화</label>
-        <select
-          value={currency}
-          onChange={(e) => setCurrency(e.target.value as CurrencyCode)}
-          className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-fg focus-visible:outline-2 focus-visible:outline-accent"
-        >
-          {SUPPORTED_CURRENCIES.map((c) => (
-            <option key={c.code} value={c.code}>
-              {c.symbol} {c.code} — {c.label}
-            </option>
-          ))}
-        </select>
-        <p className="text-xs text-fg-subtle mt-1">
-          예산을 입력·표시할 통화를 정해요. 여행 설정에서 나중에 바꿀 수 있어요.
-        </p>
-      </div>
+    <div>
+      <label className="block text-sm font-medium text-fg mb-1.5">통화</label>
+      <select
+        value={currency}
+        onChange={(e) => setCurrency(e.target.value as CurrencyCode)}
+        className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-fg focus-visible:outline-2 focus-visible:outline-accent"
+      >
+        {SUPPORTED_CURRENCIES.map((c) => (
+          <option key={c.code} value={c.code}>
+            {c.symbol} {c.code} — {c.label}
+          </option>
+        ))}
+      </select>
+      <p className="text-xs text-fg-subtle mt-1">
+        예산을 입력·표시할 통화를 정해요. 여행 설정에서 나중에 바꿀 수 있어요.
+      </p>
     </div>
   )
 }
@@ -515,7 +488,7 @@ function Step5({
   centerManual,
   onEdit,
 }: {
-  summary: { title: string; startDate: string; endDate: string; region: string; basecamp: string; currency: CurrencyCode }
+  summary: { title: string; startDate: string; endDate: string; region: string; currency: CurrencyCode }
   centerManual: boolean
   onEdit: (step: Step) => void
 }) {
@@ -542,11 +515,6 @@ function Step5({
             (summary.region || '미설정') + (centerManual ? ' · 중심 직접 지정' : '')
           }
           onEdit={() => onEdit(3)}
-        />
-        <SummaryEditRow
-          label="베이스캠프"
-          value={summary.basecamp.trim() || '미설정 (나중에 추가 가능)'}
-          onEdit={() => onEdit(4)}
         />
         <SummaryEditRow
           label="통화"

--- a/app/share/[token]/page.tsx
+++ b/app/share/[token]/page.tsx
@@ -132,7 +132,7 @@ export default async function SharePage({ params }: Props) {
         </dl>
         {trip.basecamp_address && (
           <p className="mt-2 text-sm text-fg-subtle">
-            <span className="font-medium text-fg-muted">베이스캠프</span>{' '}
+            <span className="font-medium text-fg-muted">지도 기준점</span>{' '}
             <span className="break-words">{trip.basecamp_address}</span>
           </p>
         )}

--- a/components/Map/TripPlannerMap.tsx
+++ b/components/Map/TripPlannerMap.tsx
@@ -83,7 +83,7 @@ export default function TripPlannerMap({
           setBasecampCoord([data.lat, data.lng])
         }
       } catch {
-        // 베이스캠프 좌표 실패는 silent — lodging item 만으로 동작
+        // 지도 기준점 좌표 실패는 silent — lodging item 만으로 동작
       }
     })()
     return () => {
@@ -211,7 +211,7 @@ export default function TripPlannerMap({
           interactive={false}
         >
           <Tooltip direction="top" offset={[0, -16]} opacity={0.9}>
-            <span className="text-xs font-medium">베이스캠프</span>
+            <span className="text-xs font-medium">지도 기준점</span>
           </Tooltip>
         </Marker>
       )}

--- a/components/Trip/TripSettingsSheet.tsx
+++ b/components/Trip/TripSettingsSheet.tsx
@@ -193,7 +193,7 @@ export default function TripSettingsSheet({ open, onClose }: Props) {
       open={open}
       onClose={onClose}
       title="여행 설정"
-      description="제목·기간·지역·베이스캠프를 수정합니다."
+      description="제목·기간·지역·지도 기준점을 수정합니다."
       footer={
         <>
           <Button type="button" variant="ghost" onClick={onClose} disabled={saving}>
@@ -249,12 +249,18 @@ export default function TripSettingsSheet({ open, onClose }: Props) {
               onPickOther={() => void resolveAndStore(region, { skipPreset: true })}
             />
           </div>
-          <Input
-            label="베이스캠프 주소"
-            placeholder="숙소 등 동선의 기준점"
-            value={basecamp}
-            onChange={(e) => setBasecamp(e.target.value)}
-          />
+          <div>
+            <Input
+              label="지도 기준점 주소 (선택)"
+              placeholder="예: 첫날 자주 출발할 위치"
+              value={basecamp}
+              onChange={(e) => setBasecamp(e.target.value)}
+            />
+            <p className="mt-1 text-xs text-fg-subtle">
+              지도 중심을 잡기 위한 한 곳만 저장합니다. 숙소가 여러 곳이면 일정에 숙박 항목으로
+              추가하세요.
+            </p>
+          </div>
           <div>
             <label className="block text-sm font-medium text-fg mb-1.5">통화</label>
             <select

--- a/specs/350-basecamp-role/plan.md
+++ b/specs/350-basecamp-role/plan.md
@@ -1,0 +1,59 @@
+# Implementation Plan: Basecamp Role Clarification
+
+**Branch**: `tasks/issue-350-basecamp-role` | **Date**: 2026-06-30 | **Spec**: `specs/350-basecamp-role/spec.md`
+**Input**: Feature specification from `specs/350-basecamp-role/spec.md`
+
+## Summary
+
+Remove basecamp from the new-trip wizard so creation only asks for immediate trip setup inputs. Preserve the existing trip-level `basecamp_address` storage as a single optional map reference point in settings, and update user-facing copy so multiple lodgings are modeled as lodging/stay items.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 18, Next.js 14 App Router
+**Primary Dependencies**: `next`, `react`, `tailwindcss`, `lucide-react`
+**Storage**: Existing Supabase `trips.basecamp_address`; no schema change
+**Testing**: `npm run lint`, `npx tsc --noEmit`, `git diff --check`, `npm run build`
+**Target Platform**: New trip wizard, trip settings sheet, shared trip/map labels
+**Project Type**: Next.js web application
+**Performance Goals**: No extra rendering work or data fetching
+**Constraints**: Do not remove existing stored `basecamp_address` data; do not add a new lodging model
+**Scale/Scope**: Copy and state cleanup across the create/edit surfaces
+
+## Constitution Check
+
+Repository constitution is scaffold placeholders. Applicable gates from `AGENTS.md`:
+
+- Copy honesty: creation flow must not imply a lodging model that the product does not support.
+- CRUD symmetry: no new object or field is introduced; existing trip settings still update the retained single reference point.
+- Basics-first: reduce creation friction and keep the setting discoverable after trip creation.
+- Design mechanics: use existing form controls and token classes only.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/350-basecamp-role/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+app/dashboard/new/NewTripWizard.tsx
+app/share/[token]/page.tsx
+components/Map/TripPlannerMap.tsx
+components/Trip/TripSettingsSheet.tsx
+```
+
+**Structure Decision**: Keep this as a narrow UI/copy clarification. The API and database schema remain unchanged because existing trips may already have `basecamp_address`.
+
+## Complexity Tracking
+
+No added architectural complexity.
+
+## Process Note
+
+The repo-local `.codex/prompts/speckit.*.md` files referenced by the Speckit skills are absent. This feature uses the checked-in `.specify/templates` structure directly.

--- a/specs/350-basecamp-role/spec.md
+++ b/specs/350-basecamp-role/spec.md
@@ -1,0 +1,58 @@
+# Feature Specification: Basecamp Role Clarification
+
+**Feature Branch**: `tasks/issue-350-basecamp-role`
+**Created**: 2026-06-30
+**Status**: Draft
+**Input**: GitHub issue #350 "새 여행 생성의 베이스캠프 필드 역할 재검토"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Create A Trip Without Lodging Guesswork (Priority: P1)
+
+A user creating a new trip is not asked for lodging or basecamp information before the trip exists.
+
+**Why this priority**: New-trip creation should only ask for information that is immediately useful and clearly understood. Lodging can be unknown, multiple, or better modeled as schedule items.
+
+**Independent Test**: Open the new trip wizard and confirm no step, summary row, draft state, or create request asks for `basecamp_address`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user opens the new trip wizard, **When** they move through all steps, **Then** the wizard asks for title, dates, region, currency, and confirmation only.
+2. **Given** a user creates a trip, **When** the request is sent, **Then** the create payload does not include a lodging/basecamp field.
+
+### User Story 2 - Keep A Narrow Map Reference Point (Priority: P2)
+
+A user editing an existing trip can still set one optional map reference point, but the UI does not imply that this is the lodging model for the trip.
+
+**Why this priority**: Existing `basecamp_address` behavior supports map fallback and marker display, but it is not enough to represent multiple hotels.
+
+**Independent Test**: Open trip settings and confirm the field is described as a single map reference point, with multi-lodging guidance pointing to lodging schedule items.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user opens trip settings, **When** they read the reference point field, **Then** the copy states that it is optional and single-value.
+2. **Given** a user needs two lodgings, **When** they read the field help, **Then** they are directed to add lodging as trip items instead of overloading the trip setting.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: New trip creation MUST NOT ask for `basecamp_address`.
+- **FR-002**: New trip drafts MUST NOT persist basecamp input.
+- **FR-003**: New trip create requests MUST NOT send `basecamp_address`.
+- **FR-004**: Existing trip settings MAY retain `basecamp_address`, but the UI MUST describe it as one optional map reference point, not as the trip's lodging model.
+- **FR-005**: User-facing labels on map/share/settings surfaces MUST avoid implying that `basecamp_address` supports multiple lodgings.
+- **FR-006**: Multi-lodging trips MUST be represented through lodging/stay schedule items, not by adding more trip-level fields in this change.
+
+### Key Entities
+
+- **Trip**: Existing travel container. `basecamp_address` remains an optional single string used as a map reference/fallback.
+- **Item**: Existing place/schedule entry. Lodging is represented by stay/lodging category items when users need one or more accommodations.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: New trip wizard source contains no basecamp input state, summary row, or create payload field.
+- **SC-002**: Trip settings copy identifies the field as one optional map reference point and mentions lodging items for multiple accommodations.
+- **SC-003**: No schema or API migration is required for this clarification.

--- a/specs/350-basecamp-role/tasks.md
+++ b/specs/350-basecamp-role/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Basecamp Role Clarification
+
+**Input**: `specs/350-basecamp-role/spec.md`, `specs/350-basecamp-role/plan.md`
+**Prerequisites**: Issue #350 acceptance criteria
+
+## Phase 1: New Trip Creation
+
+- [x] T001 Remove basecamp state, draft persistence, reset handling, and create payload usage from `app/dashboard/new/NewTripWizard.tsx`.
+- [x] T002 Rename the new-trip wizard step 4 from basecamp to currency and remove the basecamp summary row from `app/dashboard/new/NewTripWizard.tsx`.
+
+## Phase 2: Existing Trip Copy
+
+- [x] T003 Update trip settings copy in `components/Trip/TripSettingsSheet.tsx` so `basecamp_address` is a single optional map reference point.
+- [x] T004 Update shared trip and map labels in `app/share/[token]/page.tsx` and `components/Map/TripPlannerMap.tsx` to match the map reference wording.
+
+## Phase 3: Verification
+
+- [x] T005 Run `npm run lint`.
+- [x] T006 Run `npx tsc --noEmit`.
+- [x] T007 Run `git diff --check`.
+- [x] T008 Run `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`.
+
+## Dependencies & Execution Order
+
+- T001 before T002.
+- T003-T004 can run after T001-T002.
+- Verification runs after all implementation tasks.


### PR DESCRIPTION
## 변경 이유
새 여행 생성 단계의 베이스캠프 입력은 숙소가 여러 곳일 수 있는 실제 사용 흐름과 맞지 않고, 현재 데이터 모델이 숙소 목록을 trip 속성으로 표현하지 않기 때문에 사용자에게 과한 의미를 줍니다.

Closes #350

## 변경 범위
- 새 여행 마법사에서 베이스캠프 입력, 드래프트 저장, 생성 payload 필드를 제거했습니다.
- 4단계를 `통화`로 정리하고 확인 화면에서 베이스캠프 요약 행을 제거했습니다.
- 기존 `basecamp_address`는 유지하되 설정/공유/지도 표면에서 `지도 기준점`으로 표현을 좁혔습니다.
- 다중 숙소는 일정의 숙박 항목으로 추가하라는 안내를 설정 화면에 넣었습니다.
- `specs/350-basecamp-role/`에 spec/plan/tasks를 남겼습니다.

## 검증
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `git diff --check`
- [x] `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`

## Basics-First 체크
- [x] 이 페이지·기능에 "지금 보고 있는 여행 이름" 이 보이는가? (새 여행 생성 전이라 해당 없음, 설정 시트는 기존 trip context 내부)
- [x] 이 페이지에서 핵심 객체의 C/R/U/D 가 모두 UI 로 가능한가? (새 객체 없음, trip 설정 수정 유지)
- [x] 이 페이지가 여는 모든 모달·시트는 콘텐츠 양에 맞게 표시되는가?
- [x] 마법사·카피에서 약속한 모든 동작이 실제로 가능한가?
- [x] 모바일·데스크탑 양쪽에서 동작이 동등한가?

## 남은 리스크
- 기존 DB 컬럼명과 내부 변수명은 `basecamp`로 유지했습니다. 저장 데이터 호환을 위한 선택이며, 별도 마이그레이션은 하지 않았습니다.
- 숙박 항목을 더 강하게 만드는 별도 UX는 이번 범위에 포함하지 않았습니다.