### PR TITLE
[codex] Enable RLS on migration tracking table

### DIFF
--- a/scripts/apply-migrations.ts
+++ b/scripts/apply-migrations.ts
@@ -140,7 +140,10 @@ async function main(): Promise<void> {
   await runSql(
     ref,
     token,
-    `create table if not exists ${TRACKING_TABLE} (name text primary key, applied_at timestamptz not null default now());`,
+    [
+      `create table if not exists ${TRACKING_TABLE} (name text primary key, applied_at timestamptz not null default now());`,
+      `alter table ${TRACKING_TABLE} enable row level security;`,
+    ].join('\n'),
   )
 
   const applied = await fetchAppliedNames(ref, token)

--- a/supabase/migration_279_enable_schema_migrations_rls.sql
+++ b/supabase/migration_279_enable_schema_migrations_rls.sql
@@ -1,0 +1,5 @@
+-- Supabase advisor 0013_rls_disabled_in_public:
+-- public.schema_migrations is an internal migration tracking table used by scripts/apply-migrations.ts.
+-- It should not be readable through PostgREST, so enable RLS without adding client policies.
+
+alter table public.schema_migrations enable row level security;


### PR DESCRIPTION
## Why

Supabase Advisor reported `rls_disabled_in_public` for `public.schema_migrations`. The table is exposed through the public schema but is only used internally by the custom migration runner.

## What changed

- Added a migration that enables RLS on `public.schema_migrations` without adding client policies.
- Updated the migration runner so newly created tracking tables also have RLS enabled immediately.

## Validation

- `npm run db:migrate` applied `migration_279_enable_schema_migrations_rls.sql` to project `onzkrbyokomdpjtuvbcy`.
- `npm run lint`
- `npx tsc --noEmit`

## Remaining risk

Supabase Advisor should be re-run in the dashboard to confirm the cached warning clears after the applied migration is reflected.
